### PR TITLE
Update spec with API for session reconnection

### DIFF
--- a/Overview.src.html
+++ b/Overview.src.html
@@ -590,12 +590,12 @@ function setSession(theSession) {
       by <code>startSession(url, presentationId)</code> remains unresolved.
     </p>
     <p>
-      While there is a pending call to <code>startSession</code> asking the user
-      to select a screen (that the user has not yet accepted or canceled), the
-      browser may choose to reject subsequent calls to <code>startSession</code>
-      from the same page, by returning a <code>Promise</code> that never
-      resolves.  This will prevent the browser from needing to 'queue up'
-      requests to present to the user.
+      While there is a pending call to <code>startSession</code> asking the
+      user to select a screen (that the user has not yet accepted or canceled),
+      the browser may choose to reject subsequent calls to
+      <code>startSession</code> from the same page, by returning a
+      <code>Promise</code> that never resolves. This will prevent the browser
+      from needing to 'queue up' requests to present to the user.
     </p>
     <h4>
       Automatically reconnecting to existing presentations
@@ -608,37 +608,37 @@ function setSession(theSession) {
       that presentation. To reconnect automatically, the page may call
       <code>joinSession(url, presentationId)</code>, which returns a
       <code>Promise</code> that resolves to an existing
-      <code>PresentationSession</code> if one exists that is presenting the same
-      <code>url</code> with the same <code>presentationId</code> as was passed
-      originally into <code>startSession</code>. The requesting page can then
-      communicate with the presentation as if the user had manually connected to
-      it via <code>startSession</code>.
+      <code>PresentationSession</code> if one exists that is presenting the
+      same <code>url</code> with the same <code>presentationId</code> as was
+      passed originally into <code>startSession</code>. The requesting page can
+      then communicate with the presentation as if the user had manually
+      connected to it via <code>startSession</code>.
     </p>
     <p>
       At the time <code>joinSession(url, presentationId)</code> is called, if
       the browser is not aware of any <code>PresentationSession</code> with a
       matching <code>url</code> and <code>presentationId</code>, the
-      <code>Promise</code> should remain unresolved.  The browser may become
+      <code>Promise</code> should remain unresolved. The browser may become
       aware of such a session at a later time (for example, by switching to a
-      WiFi network that has a screen showing that URL).  In this case, the
+      WiFi network that has a screen showing that URL). In this case, the
       browser may resolve the Promise to allow the page to connect to the
       running session.
     </p>
     <p>
       If the browser knows of multiple matching sessions, it should connect the
-      page to the session that was most recently connected to; if that cannot be
-      determined by the browser (for example, if the matching sessions have
+      page to the session that was most recently connected to; if that cannot
+      be determined by the browser (for example, if the matching sessions have
       never been connected), then the <code>Promise</code> should remain
       unresolved.
     </p>
     <p>
-      If the page calls <code>startSession(url, presentationId)</code> and there
-      is a pending <code>Promise</code> from a call to <code>joinSession(url,
-      presentationId)</code> (with the same <code>url</code> and
-      <code>presentationId</code>, and the user selects a screen in response to
-      <code>startSession</code>, then the <code>Promise</code> from
-      <code>startSession</code> will be resolved and the <code>Promise</code>
-      from <code>joinSession</code> will not.
+      If the page calls <code>startSession(url, presentationId)</code> and
+      there is a pending <code>Promise</code> from a call to
+      <code>joinSession(url, presentationId)</code> (with the same
+      <code>url</code> and <code>presentationId</code>, and the user selects a
+      screen in response to <code>startSession</code>, then the
+      <code>Promise</code> from <code>startSession</code> will be resolved and
+      the <code>Promise</code> from <code>joinSession</code> will not.
     </p>
     <h4>
       Open Questions

--- a/index.html
+++ b/index.html
@@ -73,8 +73,8 @@
       <h1>
         Presentation API
       </h1>
-      <h2 class="no-num no-toc" id="draft-report-12-september-2014">
-        Draft Report - 12 September 2014
+      <h2 class="no-num no-toc" id="draft-report-15-september-2014">
+        Draft Report - 15 September 2014
       </h2>
       <dl>
         <dt>
@@ -557,7 +557,7 @@ function updateButtons() {
 };
  
 function startPresent() {
-  presentation.requestSession(presentationUrl, presentationId).then(
+  presentation.startSession(presentationUrl, presentationId).then(
       function(newSession) {
         setSession(newSession);
         updateButtons();
@@ -667,7 +667,15 @@ function setSession(theSession) {
     </p>
     <p>
       If the user cancels screen selection, the <code>Promise</code> returned
-      by <code>startSession(url, presentationId)</code> is rejected.
+      by <code>startSession(url, presentationId)</code> remains unresolved.
+    </p>
+    <p>
+      While there is a pending call to <code>startSession</code> asking the
+      user to select a screen (that the user has not yet accepted or canceled),
+      the browser may choose to reject subsequent calls to
+      <code>startSession</code> from the same page, by returning a
+      <code>Promise</code> that never resolves. This will prevent the browser
+      from needing to 'queue up' requests to present to the user.
     </p>
     <h4 id="automatically-reconnecting-to-existing-presentations"><span class="secno">5.2 </span>
       Automatically reconnecting to existing presentations
@@ -684,9 +692,33 @@ function setSession(theSession) {
       same <code>url</code> with the same <code>presentationId</code> as was
       passed originally into <code>startSession</code>. The requesting page can
       then communicate with the presentation as if the user had manually
-      connected to it via <code>startSession</code>. If no such
-      <code>PresentationSession</code> exists, the <code>Promise</code> is
-      immediately rejected.
+      connected to it via <code>startSession</code>.
+    </p>
+    <p>
+      At the time <code>joinSession(url, presentationId)</code> is called, if
+      the browser is not aware of any <code>PresentationSession</code> with a
+      matching <code>url</code> and <code>presentationId</code>, the
+      <code>Promise</code> should remain unresolved. The browser may become
+      aware of such a session at a later time (for example, by switching to a
+      WiFi network that has a screen showing that URL). In this case, the
+      browser may resolve the Promise to allow the page to connect to the
+      running session.
+    </p>
+    <p>
+      If the browser knows of multiple matching sessions, it should connect the
+      page to the session that was most recently connected to; if that cannot
+      be determined by the browser (for example, if the matching sessions have
+      never been connected), then the <code>Promise</code> should remain
+      unresolved.
+    </p>
+    <p>
+      If the page calls <code>startSession(url, presentationId)</code> and
+      there is a pending <code>Promise</code> from a call to
+      <code>joinSession(url, presentationId)</code> (with the same
+      <code>url</code> and <code>presentationId</code>, and the user selects a
+      screen in response to <code>startSession</code>, then the
+      <code>Promise</code> from <code>startSession</code> will be resolved and
+      the <code>Promise</code> from <code>joinSession</code> will not.
     </p>
     <h4 id="open-questions"><span class="secno">5.3 </span>
       Open Questions
@@ -711,23 +743,6 @@ function setSession(theSession) {
       session? It seems that this could be handled on the page level. The
       opener page could ask the presentation page whether it is
       <code>"new"</code> or <code>"resumed"</code>.
-    </p>
-    <p class="open-issue">
-      If more than one presentation session exists with the same
-      <code>url</code> and <code>presentationId</code> (on different screens)
-      then what is the behavior of <code>joinSession(url,
-      presentationId)</code>?
-    </p>
-    <p class="open-issue">
-      If the user agent becomes aware of a presentation session after the page
-      has already called <code>joinSession</code>, there is no way to notify
-      the page of its existence. Should we use an event handler instead?
-    </p>
-    <p class="open-issue">
-      If the page calls <code>startSession(url, presentationId)</code> with the
-      same <code>url</code> and <code>presenationId</code> as
-      <code>joinSession(url, presentationId)</code>, and the latter call has
-      not resolved, behavior is not defined.
     </p>
     <h3 id="usage-on-remote-screen"><span class="secno">5.4 </span>
       Usage on Remote Screen
@@ -755,7 +770,7 @@ function setSession(theSession) {
 </pre>
     <p>
       When the content denoted by the <code>url</code> argument in the
-      <code>requestSession()</code> example above is loaded, the page on the
+      <code>startSession()</code> example above is loaded, the page on the
       presentation screen will have its
       <code>navigator.presentation.session</code> property set to the session.
       This session is a similar object as in the first example. Here, its


### PR DESCRIPTION
- Updated spec with API for session reconnection, in part:

partial interface NavigatorPresentation {
  Promise<PresentationSession> startSession(DOMString url, DOMString presentationId);
  Promise<PresentationSession> joinSession(DOMString url, DOMString presentationId);
}
- Describe behavior of startSession() and joinSession().
- Update code example to handle both starting and joining presentations.
- Outline a set of algorithms to implement the functions of the Presentation API.
- Other minor fixes/cleanups.
