### PR TITLE
Updated Mark's PR

### DIFF
--- a/Overview.src.html
+++ b/Overview.src.html
@@ -443,7 +443,8 @@
     <p>
       The term <dfn title="presentation display">presentation display</dfn>
       refers to an external screen available to the opening user agent via an
-      imlementation specific connection technology.
+      imlementation specific connection technology and compatible with
+      Presentation API for display content on it.
     </p>
     <p>
       The terms <span data-anolis-spec="w3c-html">browsing context</span>,
@@ -853,23 +854,28 @@ interface PresentationSession : EventTarget {
       Screen Availability Listener Added
     </h3>
     <p>
+      Let <a id="availablescreens"><em>availableScreens</em></a> be the list of
+      available screens that are compatible with the Presentation API and that
+      are currently known to the user agent.
+    </p>
+    <p>
       When a new <span data-anolis-spec="w3c-html" title="event handlers">event
       handler</span> <em>E</em> is added to
       <code>NavigatorPresentation.onavailablechange</code>, the user agent must
       run the following steps:
     </p>
     <ol>
-      <li>If the user agent is not already searching for screens compatible
-      with the Presentation API, then:
+      <li>If the user agent is not already discovering for <a href=
+      "#presentation-display">presention displays</a>, then:
         <ol>
           <li>
-            <span data-anolis-spec="w3c-html">Queue a task</span> to search for
-            screens that are compatible with the Presentation API.
+            <span data-anolis-spec="w3c-html">Queue a task</span> to discover
+            <a href="#presentation-display">presentation displays</a>.
           </li>
         </ol>
       </li>
-      <li>If the search for screens discovers at least one compatible screen,
-      then:
+      <li>If the <a href="#availablescreens">availableScreens</a> list is not
+      empty, then run the following steps:
         <ol>
           <li>
             <span data-anolis-spec="w3c-html">Queue a task</span> to
@@ -882,9 +888,9 @@ interface PresentationSession : EventTarget {
       </li>
     </ol>
     <p class="note">
-      The mechanism used to search for compatible screens is left to the user
-      agent. The user agent may choose search for screens at any time, not just
-      when event handlers are added to
+      The mechanism used to discover <a href="#presentation-display">presention
+      displays</a> is left to the user agent. The user agent may choose search
+      for screens at any time, not just when event handlers are added to
       <code>NavigatorPresentation.onavailablechange</code>.
     </p>
     <p class="open-issue">

--- a/Overview.src.html
+++ b/Overview.src.html
@@ -442,27 +442,21 @@
     </h2>
     <p>
       The term <dfn title="presentation display">presentation display</dfn>
-      refers to an external screen connected to the device that the user agent
-      runs on.
-    </p><!--    <p>
-      The terms <span title="opener-browsing-context" data-anolis-spec=
-      "w3c-html">opener browsing context</span> and <span title=
-      "auxiliary browsing context" data-anolis-spec="w3c-html">auxiliary
-      browsing context</span> are defined in <span data-anolis-ref=
-      "">HTML5</span>.
+      refers to an external screen available to the opening user agent via an
+      imlementation specific connection technology.
     </p>
--->
     <p>
-      The terms <span data-anolis-spec="w3c-html">event handlers</span>,
-      <span title="event handler event type" data-anolis-spec="w3c-html">event
-      handler event types</span>, <span data-anolis-spec="w3c-html" title=
-      "queue a task">queing a task</span> are defined in <span data-anolis-ref=
-      "">HTML5</span>.
+      The terms <span data-anolis-spec="w3c-html">browsing context</span>,
+      <span data-anolis-spec="w3c-html">event handlers</span>, <span title=
+      "event handler event type" data-anolis-spec="w3c-html">event handler
+      event types</span>, <span data-anolis-spec="w3c-html">navigate</span>,
+      <span data-anolis-spec="w3c-html" title="queue a task">queing a
+      task</span> are defined in <span data-anolis-ref="">HTML5</span>.
     </p>
     <p>
       The term <span data-anolis-spec="es6" title=
       "promise-objects">Promise</span> is defined in <span data-anolis-ref=
-      "es6">ES6</span>.
+      "">ES6</span>.
     </p>
     <p>
       The term <span data-anolis-spec="url">URL</span> is defined in the WHATWG
@@ -879,9 +873,9 @@ interface PresentationSession : EventTarget {
       </li>
     </ol>
     <p class="note">
-      The mechanism used to search for compatible screens is up to the user
-      agent. The user agent may choose search for screens at any time, not just
-      when event handlers are added to
+      The mechanism used to search for compatible screens is to the user agent.
+      The user agent may choose search for screens at any time, not just when
+      event handlers are added to
       <code>NavigatorPresentation.onavailablechange</code>.
     </p>
     <p class="open-issue">
@@ -964,7 +958,8 @@ interface PresentationSession : EventTarget {
         </ol>
       </li>
       <li>Queue a task <em>T</em> to request user permission for the use of a
-      presentation screen.
+      <span data-anolis-ref="presentation">presentation display</span> and
+      selection of one presentation display.
         <ol>
           <li>If <em>T</em> completes with the user <em>granting
           permission</em> to use a screen, run the following steps:
@@ -982,12 +977,33 @@ interface PresentationSession : EventTarget {
               <code>S.id</code> to <em>I</em>, and set <code>S.state</code> to
               <code>disconnected</code>.
               </li>
-              <li>Add <em>(S.url, S.id, S)</em> to <em>D</em>.
-              </li>
-              <li>Resolve <em>P</em> with <em>S</em>.
-              </li>
-              <li>Initiate the <em>Presentation Connection</em> algorithm for
-              <em>S</em>.
+              <li>
+                <span data-anolis-spec="w3c-html">Queue a task</span>
+                <em>C</em> to create a new <span data-anolis-spec=
+                "w3c-html">browsing context</span> on the user-selected
+                <a href="presentation-display">presentation display</a> and
+                <span data-anolis-spec="w3c-html">navigate</span> to
+                <code>presentationUrl</code> in it.
+                <ol>
+                  <li>If <em>C</em> completes succesfully, run the following
+                  steps:
+                    <ol>
+                      <li>Add <em>(S.url, S.id, S)</em> to <em>D</em>.
+                      </li>
+                      <li>Resolve <em>P</em> with <em>S</em>.
+                      </li>
+                      <li>Initiate the <em>Presentation Connection</em>
+                      algorithm for <em>S</em>.
+                      </li>
+                    </ol>
+                  </li>
+                  <li>If <em>C</em> fails, run the following steps:
+                    <ol>
+                      <li>Reject P with a "failed" exception.
+                      </li>
+                    </ol>
+                  </li>
+                </ol>
               </li>
             </ol>
           </li>
@@ -1002,10 +1018,10 @@ interface PresentationSession : EventTarget {
       </li>
     </ol>
     <p class="note">
-      The implementation of the permission request is up to the user agent; for
-      example it may show the user a dialog and allow the user to select an
-      available screen (granting permission), or cancel the selection (denying
-      permission).
+      The details of implementing the permission request and display selection
+      are left to the user agent; for example it may show the user a dialog and
+      allow the user to select an available screen (granting permission), or
+      cancel the selection (denying permission).
     </p>
     <p class="open-issue">
       Do we want to distinguish the permission-denied outcome from the
@@ -1164,16 +1180,16 @@ interface PresentationSession : EventTarget {
       </li>
     </ol>
     <p class="note">
-      If <em>T</em> does not complete successfully, the user agent may choose
-      to re-execute the Presentation Connection algorithm at a later time.
+      The mechanism that is used to present on the remote display and connect
+      the opening document with the presented document is an implementation
+      choice of the user agent. The connection must provide a two-way messaging
+      abstraction capable of carrying <code>DOMString</code> payloads in a
+      reliable and in-order fashion as described in the <em>Send Message</em>
+      and <em>Receive Message</em> steps below.
     </p>
     <p class="note">
-      The mechanism that is used to connect the opening document with the
-      presented document is an implementation choice of the user agent. The
-      connection must provide a two-way messaging abstraction capable of
-      carrying <code>DOMString</code> payloads in a reliable and in-order
-      fashion as described in the <em>Send Message</em> and <em>Receive
-      Message</em> steps below.
+      If <em>T</em> does not complete successfully, the user agent may choose
+      to re-execute the Presentation Connection algorithm at a later time.
     </p>
     <p class="open-issue">
       Do we want to notify the caller of a failure to connect, i.e. with an

--- a/Overview.src.html
+++ b/Overview.src.html
@@ -857,7 +857,7 @@ interface PresentationSession : EventTarget {
       <li>If the user agent is not already searching for screens compatible
       with the Presentation API, then:
         <ol>
-          <li>Queue a task to search for screens that are compatible with the
+            <li><span data-anolis-spec="w3c-html">Queue a task</span> to search for screens that are compatible with the
           Presentation API.
           </li>
         </ol>
@@ -865,7 +865,7 @@ interface PresentationSession : EventTarget {
       <li>If the search for screens discovers at least one compatible screen,
       then:
         <ol>
-          <li>Queue a task to fire an event named <code>availablechange</code>
+            <li><span data-anolis-spec="w3c-html">Queue a task</span> to <span data-anolis-spec="w3c-html">fire an event</span> named <code>availablechange</code>
           at <em>E</em> (and only <em>E</em>) with the event's
           <code>available</code> property set to <code>true</code>.
           </li>
@@ -873,7 +873,7 @@ interface PresentationSession : EventTarget {
       </li>
     </ol>
     <p class="note">
-      The mechanism used to search for compatible screens is to the user agent.
+      The mechanism used to search for compatible screens is left to the user agent.
       The user agent may choose search for screens at any time, not just when
       event handlers are added to
       <code>NavigatorPresentation.onavailablechange</code>.

--- a/Overview.src.html
+++ b/Overview.src.html
@@ -971,8 +971,18 @@ interface PresentationSession : EventTarget {
       </li>
       <li>Return <em>P</em>.
       </li>
-      <li>If no screens are available that are compatible with the Presentation
-      API, run these steps:
+      <li>If the user agent is currently not running the <a href=
+      "#monitor-availability-algorithm">presentation display availability
+      monitoring algorithm</a>:
+        <ol>
+          <li>Start the algorithm.
+          </li>
+          <li>Wait until the algorithm completes.
+          </li>
+        </ol>
+      </li>
+      <li>If the <a href="#availabledisplays">availableDisplays</a> list is
+      empty, then:
         <ol>
           <li>
             <span data-anolis-spec="promguide" title=

--- a/Overview.src.html
+++ b/Overview.src.html
@@ -453,10 +453,20 @@
     </p>
 -->
     <p>
-      The terms <span data-anolis-spec="w3c-html">event handlers</span> and
+      The terms <span data-anolis-spec="w3c-html">event handlers</span>,
       <span title="event handler event type" data-anolis-spec="w3c-html">event
-      handler event types</span> are defined in <span data-anolis-ref=
+      handler event types</span>, <span data-anolis-spec="w3c-html" title=
+      "queue a task">queing a task</span> are defined in <span data-anolis-ref=
       "">HTML5</span>.
+    </p>
+    <p>
+      The term <span data-anolis-spec="es6" title=
+      "promise-objects">Promise</span> is defined in <span data-anolis-ref=
+      "es6">ES6</span>.
+    </p>
+    <p>
+      The term <span data-anolis-spec="url">URL</span> is defined in the WHATWG
+      URL standard: <span data-anolis-ref="url">URL</span>.
     </p>
     <p>
       This document provides interface definitions using the
@@ -840,9 +850,6 @@ interface PresentationSession : EventTarget {
       <code>PresentationSession</code> for the presentation. <em>U</em> and
       <em>I</em> together uniquely identify the
       <code>PresentationSession</code> of the corresponding presentation.
-    </p>
-    <p class="open-issue">
-      Need to add xrefs to term definitions: promise, task, assert, URL, etc.
     </p>
     <h3>
       Screen Availability Listener Added

--- a/Overview.src.html
+++ b/Overview.src.html
@@ -851,31 +851,68 @@ interface PresentationSession : EventTarget {
       <code>PresentationSession</code> of the corresponding presentation.
     </p>
     <h3>
-      Screen Availability Listener Added
+      Presentation Display Availability
     </h3>
     <p>
-      Let <a id="availablescreens"><em>availableScreens</em></a> be the list of
-      available screens that are compatible with the Presentation API and that
-      are currently known to the user agent.
+      Let <a id="availabledisplays"><em>availableDisplays</em></a> be the list
+      of available <a href="presentation-display">presentation displays</a>
+      that are currently known to the user agent.
     </p>
+    <h4>
+      Availability Listener Added
+    </h4>
     <p>
       When a new <span data-anolis-spec="w3c-html" title="event handlers">event
       handler</span> <em>E</em> is added to
       <code>NavigatorPresentation.onavailablechange</code>, the user agent must
+      run the <a href="monitor-availability-algorithm">algorithm to monitor
+      availability</a>.
+    </p>
+    <p class="note">
+      The mechanism used to monitor <a href="#presentation-display">presention
+      displays</a> availability is left to the user agent. The user agent may
+      choose search for screens at any time, not just when event handlers are
+      added to <code>NavigatorPresentation.onavailablechange</code>.
+    </p>
+    <p class="open-issue">
+      Do we want to fire the event at all handlers, or only the newly added
+      one?
+    </p>
+    <h4>
+      Availability Listener Removed
+    </h4>
+    <p>
+      When the last <span data-anolis-spec="w3c-html" title=
+      "event handlers">event handler</span> is removed from
+      <code>NavigatorPresentation.onavailablechange</code>, the user agent may
       run the following steps:
     </p>
     <ol>
-      <li>If the user agent is not already discovering for <a href=
-      "#presentation-display">presention displays</a>, then:
-        <ol>
-          <li>
-            <span data-anolis-spec="w3c-html">Queue a task</span> to discover
-            <a href="#presentation-display">presentation displays</a>.
-          </li>
-        </ol>
+      <li>Cancel the <a href="monitor-availability-algorithm">algorithm to
+      monitor availability change.</a>
       </li>
-      <li>If the <a href="#availablescreens">availableScreens</a> list is not
-      empty, then run the following steps:
+    </ol>
+    <h4 id="monitor-availability-algorithm">
+      Algorithm to Monitor Availability Change
+    </h4>
+    <p>
+      While there are <span data-anolis-spec="w3c-html">event handlers</span>
+      added to NavigatorPresentation.onavailablechange, the user agent must
+      continuously keep track of the available <a href=
+      "#presentation-display">presentation displays</a> and repeat the
+      following steps:
+    </p>
+    <ol>
+      <li>
+        <span data-anolis-spec="w3c-html">Queue a task</span> to retrieve the
+        the list of curently available <a href=
+        "#presentation-display">presentation displays</a> and let <a id=
+        "newdisplays"><em>newDisplays</em></a> be this list.
+      </li>
+      <li>Wait for the completion of that task.
+      </li>
+      <li>If <a href="#availabledisplays">availableDisplays</a> is empty and
+      <a href="#newdisplays">newDisplays</a> is not empty, then
         <ol>
           <li>
             <span data-anolis-spec="w3c-html">Queue a task</span> to
@@ -886,55 +923,18 @@ interface PresentationSession : EventTarget {
           </li>
         </ol>
       </li>
-    </ol>
-    <p class="note">
-      The mechanism used to discover <a href="#presentation-display">presention
-      displays</a> is left to the user agent. The user agent may choose search
-      for screens at any time, not just when event handlers are added to
-      <code>NavigatorPresentation.onavailablechange</code>.
-    </p>
-    <p class="open-issue">
-      Do we want to fire the event at all handlers, or only the newly added
-      one?
-    </p>
-    <h3>
-      Screen Availability Listener Removed
-    </h3>
-    <p>
-      When the last <span data-anolis-spec="w3c-html" title=
-      "event handlers">event handler</span> is removed from
-      <code>NavigatorPresentation.onavailablechange</code>, the user agent may
-      run the following steps:
-    </p>
-    <ol>
-      <li>Cancel any pending tasks to search for screens that are compatible
-      with the Presentation API.
+      <li>If <a href="#availabledisplays">availableDisplays</a> is not empty
+      and <a href="#newdisplays">newDisplays</a> is empty, then:
+        <div style="margin-left: 2em">
+          <span data-anolis-spec="w3c-html">Queue a task</span> to
+          <span data-anolis-spec="w3c-html" title="concept-event-fire">fire an
+          event</span> named <code>availablechange</code> at <em>E</em> (and
+          only <em>E</em>) with the event's <code>available</code> property set
+          to <code>false</code>.
+        </div>
       </li>
-    </ol>
-    <h3>
-      No Screens Available
-    </h3>
-    <p>
-      When the set of available screens becomes empty (e.g., because the user
-      agent has lost its network connection), the user agent must run the
-      following steps:
-    </p>
-    <ol>
-      <li>If there are no <span data-anolis-spec="w3c-html">event
-      handlers</span> added to
-      <code>NavigatorPresentation.onavailablechange</code>, then:
-        <ol>
-          <li>Abort these steps.
-          </li>
-        </ol>
-      </li>
-      <li>
-        <span data-anolis-spec="w3c-html">Queue a task</span> to
-        <span data-anolis-spec="w3c-html" title="concept-event-fire">fire an
-        event</span> named <code>availablechange</code> at all the event
-        handlers added to <code>NavigatorPresentation.onavailablechange</code>
-        with the event's <code>available</code> property set to
-        <code>false</code>.
+      <li>Set <a href="#availableDisplays">availableDisplays</a> to the value
+      of <a href="#newDisplays">newDisplays</a>.
       </li>
     </ol>
     <h3>

--- a/Overview.src.html
+++ b/Overview.src.html
@@ -965,36 +965,38 @@ interface PresentationSession : EventTarget {
       </li>
       <li>Queue a task <em>T</em> to request user permission for the use of a
       presentation screen.
-      </li>
-      <li>If <em>T</em> completes with the user <em>granting permission</em> to
-      use a screen, run the following steps:
         <ol>
-          <li>If <code>presentationId</code> is not <em>undefined</em>, assign
-          <em>I</em> to that that <code>presentationId</code>.
+          <li>If <em>T</em> completes with the user <em>granting
+          permission</em> to use a screen, run the following steps:
+            <ol>
+              <li>If <code>presentationId</code> is not <em>undefined</em>,
+              assign <em>I</em> to that that <code>presentationId</code>.
+              </li>
+              <li>If <code>presentationId</code> is <code>undefined</code>, let
+              <em>I</em> be a random alphanumeric value of at least 16
+              characters drawn from the characters <code>[A-Za-z0-9]</code>.
+              </li>
+              <li>Create a new <code>PresentationSession</code> <em>S</em>.
+              </li>
+              <li>Set <code>S.url</code> to <code>presentationUrl</code>, set
+              <code>S.id</code> to <em>I</em>, and set <code>S.state</code> to
+              <code>disconnected</code>.
+              </li>
+              <li>Add <em>(S.url, S.id, S)</em> to <em>D</em>.
+              </li>
+              <li>Resolve <em>P</em> with <em>S</em>.
+              </li>
+              <li>Initiate the <em>Presentation Connection</em> algorithm for
+              <em>S</em>.
+              </li>
+            </ol>
           </li>
-          <li>If <code>presentationId</code> is <code>undefined</code>, let
-          <em>I</em> be a random alphanumeric value of at least 16 characters
-          drawn from the characters <code>[A-Za-z0-9]</code>.
-          </li>
-          <li>Create a new <code>PresentationSession</code> <em>S</em>.
-          </li>
-          <li>Set <code>S.url</code> to <code>presentationUrl</code>, set
-          <code>S.id</code> to <em>I</em>, and set <code>S.state</code> to
-          <code>disconnected</code>.
-          </li>
-          <li>Add <em>(S.url, S.id, S)</em> to <em>D</em>.
-          </li>
-          <li>Resolve <em>P</em> with <em>S</em>.
-          </li>
-          <li>Initiate the <em>Presentation Connection</em> algorithm for <em>
-            S</em>.
-          </li>
-        </ol>
-      </li>
-      <li>If <em>T</em> completes with the user <em>denying permission</em>,
-      run the following steps:
-        <ol>
-          <li>Reject <em>P</em> with a "PermissionDenied" exception.
+          <li>If <em>T</em> completes with the user <em>denying
+          permission</em>, run the following steps:
+            <ol>
+              <li>Reject <em>P</em> with a "PermissionDenied" exception.
+              </li>
+            </ol>
           </li>
         </ol>
       </li>

--- a/Overview.src.html
+++ b/Overview.src.html
@@ -443,8 +443,8 @@
     <p>
       The term <dfn title="presentation display">presentation display</dfn>
       refers to an external screen available to the opening user agent via an
-      imlementation specific connection technology and compatible with
-      Presentation API for display content on it.
+      implementation specific connection technology and compatible with the
+      Presentation API for the display content on it.
     </p>
     <p>
       The terms <span data-anolis-spec="w3c-html">browsing context</span>,
@@ -850,14 +850,14 @@ interface PresentationSession : EventTarget {
       <em>I</em> together uniquely identify the
       <code>PresentationSession</code> of the corresponding presentation.
     </p>
-    <h3>
-      Presentation Display Availability
-    </h3>
     <p>
       Let <a id="availabledisplays"><em>availableDisplays</em></a> be the list
       of available <a href="presentation-display">presentation displays</a>
       that are currently known to the user agent.
     </p>
+    <h3>
+      Presentation Display Availability
+    </h3>
     <h4>
       Availability Listener Added
     </h4>
@@ -893,7 +893,7 @@ interface PresentationSession : EventTarget {
       </li>
     </ol>
     <h4 id="monitor-availability-algorithm">
-      Algorithm to Monitor Availability Change
+      Algorithm to Monitor Presentation Display Availability Change
     </h4>
     <p>
       While there are <span data-anolis-spec="w3c-html">event handlers</span>
@@ -1021,7 +1021,7 @@ interface PresentationSession : EventTarget {
                 <span data-anolis-spec="w3c-html">navigate</span> to
                 <code>presentationUrl</code> in it.
                 <ol>
-                  <li>If <em>C</em> completes succesfully, run the following
+                  <li>If <em>C</em> completes successfully, run the following
                   steps:
                     <ol>
                       <li>Add <em>(S.url, S.id, S)</em> to <em>D</em>.

--- a/Overview.src.html
+++ b/Overview.src.html
@@ -827,40 +827,373 @@ interface PresentationSession : EventTarget {
       Algorithms
     </h2>
     <p>
-      These algorithms are intended to define the behavior of the
+      These algorithms define the behavior of the
       <code>NavigatorPresentation</code> and <code>PresentationSession</code>
       interfaces declared in the <a href="#interfaces">Interfaces</a> section.
     </p>
-    <h3>
-      The Screen Availability algorithm
-    </h3>
     <p>
-      Run when an event handler is added to <code>onavailablechange</code>.
+      Let <em>D</em> be the set of presentations that are currently known to
+      the user agent (regardles of their state). <em>D</em> is represented as a
+      set of tuples <em>(U, I, S)</em> where <em>U</em> is the URL that is
+      being presented; <em>I</em> is an alphanumeric identifier for the
+      presentation; and <em>S</em> is the user agent's
+      <code>PresentationSession</code> for the presentation. <em>U</em> and
+      <em>I</em> together uniquely identify the
+      <code>PresentationSession</code> of the corresponding presentation.
+    </p>
+    <p class="open-issue">
+      Need to add xrefs to term definitions: promise, task, assert, URL, etc.
     </p>
     <h3>
-      The Start Session algorithm
+      Screen Availability Listener Added
     </h3>
     <p>
-      Run when <code>startSession(url, presentationId)</code> is called.
+      When a new event handler <em>E</em> is added to
+      <code>NavigatorPresentation.onavailablechange</code>, the user agent must
+      run the following steps:
+    </p>
+    <ol>
+      <li>If the user agent is not already searching for screens compatible
+      with the Presentation API, then:
+        <ol>
+          <li>Queue a task to search for screens that are compatible with the
+          Presentation API.
+          </li>
+        </ol>
+      </li>
+      <li>If the search for screens discovers at least one compatible screen,
+      then:
+        <ol>
+          <li>Queue a task to fire an event named <code>availablechange</code>
+          at <em>E</em> (and only <em>E</em>) with the event's
+          <code>available</code> property set to <code>true</code>.
+          </li>
+        </ol>
+      </li>
+    </ol>
+    <p class="note">
+      The mechanism used to search for compatible screens is up to the user
+      agent. The user agent may choose search for screens at any time, not just
+      when event handlers are added to
+      <code>NavigatorPresentation.onavailablechange</code>.
+    </p>
+    <p class="open-issue">
+      Do we want to fire the event at all handlers, or only the newly added
+      one?
     </p>
     <h3>
-      The Join Session algorithm
+      Screen Availability Listener Removed
     </h3>
     <p>
-      Run when <code>joinSession(url, presentationId)</code> is called.
+      When the last event handler is removed from
+      <code>NavigatorPresentation.onavailablechange</code>, the user agent may
+      run the following steps:
+    </p>
+    <ol>
+      <li>Cancel any pending tasks to search for screens that are compatible
+      with the Presentation API.
+      </li>
+    </ol>
+    <h3>
+      No Screens Available
+    </h3>
+    <p>
+      When the set of available screens becomes empty (e.g., because the user
+      agent has lost its network connection), the user agent must run the
+      following steps:
+    </p>
+    <ol>
+      <li>If there are no event handlers added to
+      <code>NavigatorPresentation.onavailablechange</code>, then:
+        <ol>
+          <li>Abort these steps.
+          </li>
+        </ol>
+      </li>
+      <li>Queue a task to fire an event named <code>availablechange</code> at
+      all the event handlers added to
+      <code>NavigatorPresentation.onavailablechange</code> with the event's
+      <code>available</code> property set to <code>false</code>.
+      </li>
+    </ol>
+    <h3>
+      Start Session
+    </h3>
+    <p>
+      When <code>NaviagatorPresentaton.startSession(presentationUrl,
+      presentationId)</code> is called, the user agent must run the following
+      steps.
+    </p>
+    <dl>
+      <dt>
+        Input
+      </dt>
+      <dd>
+        <code>presentationUrl</code>, the URL of the document to be presented
+      </dd>
+      <dd>
+        <code>presentationId</code>, an optional identifier for the
+        presentation
+      </dd>
+      <dt>
+        Output
+      </dt>
+      <dd>
+        <em>P</em>, a Promise
+      </dd>
+    </dl>
+    <ol>
+      <li>Let <em>P</em> be a new Promise.
+      </li>
+      <li>Return <em>P</em>.
+      </li>
+      <li>If no screens are available that are compatible with the Presentation
+      API, run these steps:
+        <ol>
+          <li>Reject <em>P</em> with a "NoScreensAvailable" exception.
+          </li>
+          <li>Abort all remaining steps.
+          </li>
+        </ol>
+      </li>
+      <li>Queue a task <em>T</em> to request user permission for the use of a
+      presentation screen.
+      </li>
+      <li>If <em>T</em> completes with the user <em>granting permission</em> to
+      use a screen, run the following steps:
+        <ol>
+          <li>If <code>presentationId</code> is not <em>undefined</em>, assign
+          <em>I</em> to that that <code>presentationId</code>.
+          </li>
+          <li>If <code>presentationId</code> is <code>undefined</code>, let
+          <em>I</em> be a random alphanumeric value of at least 16 characters
+          drawn from the characters <code>[A-Za-z0-9]</code>.
+          </li>
+          <li>Create a new <code>PresentationSession</code> <em>S</em>.
+          </li>
+          <li>Set <code>S.url</code> to <code>presentationUrl</code>, set
+          <code>S.id</code> to <em>I</em>, and set <code>S.state</code> to
+          <code>disconnected</code>.
+          </li>
+          <li>Add <em>(S.url, S.id, S)</em> to <em>D</em>.
+          </li>
+          <li>Resolve <em>P</em> with <em>S</em>.
+          </li>
+          <li>Initiate the <em>Presentation Connection</em> algorithm for <em>
+            S</em>.
+          </li>
+        </ol>
+      </li>
+      <li>If <em>T</em> completes with the user <em>denying permission</em>,
+      run the following steps:
+        <ol>
+          <li>Reject <em>P</em> with a "PermissionDenied" exception.
+          </li>
+        </ol>
+      </li>
+    </ol>
+    <p class="note">
+      The implementation of the permission request is up to the user agent; for
+      example it may show the user a dialog and allow the user to select an
+      available screen (granting permission), or cancel the selection (denying
+      permission).
+    </p>
+    <p class="open-issue">
+      Do we want to distinguish the permission-denied outcome from the
+      no-screens-available outcome? Developers would be able to infer it anyway
+      from <code>onavailablechange</code>.
     </p>
     <h3>
-      The Close Session algorithm
+      Join Session
     </h3>
     <p>
-      Run when <code>close()</code> is called on a
-      <code>PresentationSession.</code>
+      When <code>NavigatorPresentation.joinSession(presentationUrl,
+      presentationId)</code> is called, the user agent must run the following
+      steps.
+    </p>
+    <dl>
+      <dt>
+        Input
+      </dt>
+      <dd>
+        <code>presentationUrl</code>, the URL of the document being presented
+      </dd>
+      <dd>
+        <code>presentationId</code>, the identifier for the presentation
+      </dd>
+      <dt>
+        Output
+      </dt>
+      <dd>
+        <em>P</em>, a Promise
+      </dd>
+    </dl>
+    <ol>
+      <li>Let <em>P</em> be a new Promise.
+      </li>
+      <li>Return <em>P</em>.
+      </li>
+      <li>Let <em>D</em> be the set of presentations known by the user agent.
+      </li>
+      <li>Queue a task <em>T</em> to run the following steps in order:
+        <ol>
+          <li>For each presentation <em>(U, I, S)</em> in <em>D</em>,
+            <ol>
+              <li>Let <em>u</em> equal <em>U</em>, <em>i</em> equal <em>I</em>,
+              and <em>s</em> equal <em>S</em>.
+              </li>
+              <li>If <em>u</em> is equal to <code>presentationUrl</code> and
+              <em>i</em> is equal to <code>presentationId</code>, run the
+              following steps:
+                <ol>
+                  <li>Resolve <em>P</em> with <em>S</em>.
+                  </li>
+                  <li>Initiate the <em>Presentation Connection</em> algorithm
+                  for <em>S</em>.
+                  </li>
+                  <li>Abort the remaining steps of <em>T</em>.
+                  </li>
+                </ol>
+              </li>
+            </ol>
+          </li>
+          <li>Reject <em>P</em> with a "NoPresentationFound" exception.
+          </li>
+        </ol>
+      </li>
+    </ol>
+    <p class="open-issue">
+      If no matching presentation is found, we could leave the Promise pending
+      in case a matching presentation is started in the future.
     </p>
     <h3>
-      The Presentation Initialization algorithm
+      Session Close
     </h3>
     <p>
-      Run when a document opened by <code>startSession()</code> is loaded.
+      When <code>PresentationSession.close()</code> is called on a
+      <code>PresentationSession</code> <em>S</em>, the user agent must run the
+      following steps:
+    </p>
+    <ol>
+      <li>If <em>S.state</em> is not <code>connected</code>, then:
+        <ol>
+          <li>Abort these steps.
+          </li>
+        </ol>
+      </li>
+      <li>Set <em>S.state</em> to <code>disconnected.</code>
+      </li>
+      <li>Let <em>D</em> be the set of presentations known by the user agent.
+      </li>
+      <li>Queue a task <em>T</em> to run the following steps in order:
+        <ol>
+          <li>For each presentation <em>(U, I, S')</em> in <em>D</em>,
+            <ol>
+              <li>Let <em>u</em> equal <em>U</em>, <em>i</em> equal <em>I</em>,
+              and <em>s</em> equal <em>S'</em>.
+              </li>
+              <li>If <em>u</em> is equal to <em>S.url</em> and <em>i</em> is
+              equal to <em>S.id</em>, run the following steps:
+                <ol>
+                  <li>Queue a task to fire an event named
+                  <code>statechange</code> at <em>s.onstatechange</em>.
+                  </li>
+                </ol>
+              </li>
+            </ol>
+          </li>
+        </ol>
+      </li>
+    </ol>
+    <h3>
+      Presentation Connection
+    </h3>
+    <p>
+      When the user agent has created a <code>PresentationSession</code>
+      <em>S</em> to resolve a promise returned from
+      <code>NavigatorPresentation.startSession</code>, or resolved a promise
+      returned from to <code>NavigatorPresentation.joinSession</code> with
+      <em>S</em>, it must run the following steps:
+    </p>
+    <ol>
+      <li>If <em>S.state</em> is <code>connected</code>, then:
+        <ol>
+          <li>Abort all remaining steps.
+          </li>
+        </ol>
+      </li>
+      <li>Queue a task <em>T</em> to connect <em>S</em> to the document that is
+      presenting <em>S.url</em>.
+      </li>
+      <li>If <em>T</em> completes successfully, run the following steps:
+        <ol>
+          <li>Set <em>S.state</em> to <code>connected.</code>
+          </li>
+          <li>Let <em>D</em> be the set of presentations known by the user
+          agent.
+          </li>
+          <li>Queue a task <em>T</em> to run the following steps in order:
+            <ol>
+              <li>For each presentation <em>(U, I, S')</em> in <em>D</em>,
+                <ol>
+                  <li>Let <em>u</em> equal <em>U</em>, <em>i</em> equal
+                  <em>I</em>, and <em>s</em> equal <em>S'</em>.
+                  </li>
+                  <li>If <em>u</em> is equal to <em>S.url</em> and <em>i</em>
+                  is equal to <em>S.id</em>, run the following steps:
+                    <ol>
+                      <li>Queue a task to fire an event named
+                      <code>statechange</code> at <em>s.onstatechange</em>.
+                      </li>
+                    </ol>
+                  </li>
+                </ol>
+              </li>
+            </ol>
+          </li>
+        </ol>
+      </li>
+    </ol>
+    <p class="note">
+      If <em>T</em> does not complete successfully, the user agent may choose
+      to re-execute the Presentation Connection algorithm at a later time.
+    </p>
+    <p class="note">
+      The mechanism that is used to connect the opening document with the
+      presented document is an implementation choice of the user agent. The
+      connection must provide a two-way messaging abstraction capable of
+      carrying <code>DOMString</code> payloads in a reliable and in-order
+      fashion as described in the <em>Send Message</em> and <em>Receive
+      Message</em> steps below.
+    </p>
+    <p class="open-issue">
+      Do we want to notify the caller of a failure to connect, i.e. with an
+      "error" onstatechange?
+    </p>
+    <p class="open-issue">
+      Do we want to pass the new state as a property of the statechange event?
+    </p>
+    <p class="open-issue">
+      Need to further specify the semantics of the messaging channel (using
+      WebSockets or MessagePort as a reference).
+    </p>
+    <h3>
+      TODO
+    </h3>
+    <p class="open-issue">
+      Need algorithm for send message
+    </p>
+    <p class="open-issue">
+      Need algorithm for receive message
+    </p>
+    <p class="open-issue">
+      Need algorithm for initialization of the presented document
+    </p>
+    <p class="open-issue">
+      We could write this spec in a way that distinguished the state of the
+      presentation (owned by the user agent) from the state of the
+      PresentationSession (owned by a specific document); however these should
+      always be sync and it would likely result in more confusion than clarity.
     </p>
     <h2 class="no-num">
       References

--- a/Overview.src.html
+++ b/Overview.src.html
@@ -449,14 +449,18 @@
       The terms <span data-anolis-spec="w3c-html">browsing context</span>,
       <span data-anolis-spec="w3c-html">event handlers</span>, <span title=
       "event handler event type" data-anolis-spec="w3c-html">event handler
-      event types</span>, <span data-anolis-spec="w3c-html">navigate</span>,
-      <span data-anolis-spec="w3c-html" title="queue a task">queing a
-      task</span> are defined in <span data-anolis-ref="">HTML5</span>.
+      event types</span>, <span data-anolis-spec="w3c-html" title=
+      "concept-event-fire">firing an event</span>, <span data-anolis-spec=
+      "w3c-html">navigate</span>, <span data-anolis-spec="w3c-html" title=
+      "queue a task">queing a task</span> are defined in <span data-anolis-ref=
+      "">HTML5</span>.
     </p>
     <p>
       The term <span data-anolis-spec="es6" title=
       "promise-objects">Promise</span> is defined in <span data-anolis-ref=
-      "">ES6</span>.
+      "">ES6</span>. The terms <span data-anolis-spec="promguide" title=
+      "resolve-reject">resolving a Promise, and rejecting a Promise</span> are
+      used as explained in <span data-anolis-ref="">PROMGUIDE</span>.
     </p>
     <p>
       The term <span data-anolis-spec="url">URL</span> is defined in the WHATWG
@@ -849,7 +853,8 @@ interface PresentationSession : EventTarget {
       Screen Availability Listener Added
     </h3>
     <p>
-      When a new event handler <em>E</em> is added to
+      When a new <span data-anolis-spec="w3c-html" title="event handlers">event
+      handler</span> <em>E</em> is added to
       <code>NavigatorPresentation.onavailablechange</code>, the user agent must
       run the following steps:
     </p>
@@ -857,25 +862,29 @@ interface PresentationSession : EventTarget {
       <li>If the user agent is not already searching for screens compatible
       with the Presentation API, then:
         <ol>
-            <li><span data-anolis-spec="w3c-html">Queue a task</span> to search for screens that are compatible with the
-          Presentation API.
+          <li>
+            <span data-anolis-spec="w3c-html">Queue a task</span> to search for
+            screens that are compatible with the Presentation API.
           </li>
         </ol>
       </li>
       <li>If the search for screens discovers at least one compatible screen,
       then:
         <ol>
-            <li><span data-anolis-spec="w3c-html">Queue a task</span> to <span data-anolis-spec="w3c-html">fire an event</span> named <code>availablechange</code>
-          at <em>E</em> (and only <em>E</em>) with the event's
-          <code>available</code> property set to <code>true</code>.
+          <li>
+            <span data-anolis-spec="w3c-html">Queue a task</span> to
+            <span data-anolis-spec="w3c-html" title="concept-event-fire">fire
+            an event</span> named <code>availablechange</code> at <em>E</em>
+            (and only <em>E</em>) with the event's <code>available</code>
+            property set to <code>true</code>.
           </li>
         </ol>
       </li>
     </ol>
     <p class="note">
-      The mechanism used to search for compatible screens is left to the user agent.
-      The user agent may choose search for screens at any time, not just when
-      event handlers are added to
+      The mechanism used to search for compatible screens is left to the user
+      agent. The user agent may choose search for screens at any time, not just
+      when event handlers are added to
       <code>NavigatorPresentation.onavailablechange</code>.
     </p>
     <p class="open-issue">
@@ -886,7 +895,8 @@ interface PresentationSession : EventTarget {
       Screen Availability Listener Removed
     </h3>
     <p>
-      When the last event handler is removed from
+      When the last <span data-anolis-spec="w3c-html" title=
+      "event handlers">event handler</span> is removed from
       <code>NavigatorPresentation.onavailablechange</code>, the user agent may
       run the following steps:
     </p>
@@ -904,24 +914,28 @@ interface PresentationSession : EventTarget {
       following steps:
     </p>
     <ol>
-      <li>If there are no event handlers added to
+      <li>If there are no <span data-anolis-spec="w3c-html">event
+      handlers</span> added to
       <code>NavigatorPresentation.onavailablechange</code>, then:
         <ol>
           <li>Abort these steps.
           </li>
         </ol>
       </li>
-      <li>Queue a task to fire an event named <code>availablechange</code> at
-      all the event handlers added to
-      <code>NavigatorPresentation.onavailablechange</code> with the event's
-      <code>available</code> property set to <code>false</code>.
+      <li>
+        <span data-anolis-spec="w3c-html">Queue a task</span> to
+        <span data-anolis-spec="w3c-html" title="concept-event-fire">fire an
+        event</span> named <code>availablechange</code> at all the event
+        handlers added to <code>NavigatorPresentation.onavailablechange</code>
+        with the event's <code>available</code> property set to
+        <code>false</code>.
       </li>
     </ol>
     <h3>
       Start Session
     </h3>
     <p>
-      When <code>NaviagatorPresentaton.startSession(presentationUrl,
+      When <code>NavigatorPresentaton.startSession(presentationUrl,
       presentationId)</code> is called, the user agent must run the following
       steps.
     </p>
@@ -930,7 +944,8 @@ interface PresentationSession : EventTarget {
         Input
       </dt>
       <dd>
-        <code>presentationUrl</code>, the URL of the document to be presented
+        <code>presentationUrl</code>, the <span data-anolis-spec=
+        "url">URL</span> of the document to be presented
       </dd>
       <dd>
         <code>presentationId</code>, an optional identifier for the
@@ -940,18 +955,23 @@ interface PresentationSession : EventTarget {
         Output
       </dt>
       <dd>
-        <em>P</em>, a Promise
+        <em>P</em>, a <span data-anolis-spec="es6" title=
+        "promise-objects">Promise</span>
       </dd>
     </dl>
     <ol>
-      <li>Let <em>P</em> be a new Promise.
+      <li>Let <em>P</em> be a new <span data-anolis-spec="es6" title=
+      "promise-objects">Promise</span>.
       </li>
       <li>Return <em>P</em>.
       </li>
       <li>If no screens are available that are compatible with the Presentation
       API, run these steps:
         <ol>
-          <li>Reject <em>P</em> with a "NoScreensAvailable" exception.
+          <li>
+            <span data-anolis-spec="promguide" title=
+            "resolve-reject">Reject</span> <em>P</em> with a
+            "NoScreensAvailable" exception.
           </li>
           <li>Abort all remaining steps.
           </li>
@@ -990,16 +1010,23 @@ interface PresentationSession : EventTarget {
                     <ol>
                       <li>Add <em>(S.url, S.id, S)</em> to <em>D</em>.
                       </li>
-                      <li>Resolve <em>P</em> with <em>S</em>.
+                      <li>
+                        <span data-anolis-spec="promguide" title=
+                        "resolve-reject">Resolve</span> <em>P</em> with
+                        <em>S</em>.
                       </li>
-                      <li>Initiate the <em>Presentation Connection</em>
+                      <li>Initiate the <a href=
+                      "#presentation-connection">Presentation Connection</a>
                       algorithm for <em>S</em>.
                       </li>
                     </ol>
                   </li>
                   <li>If <em>C</em> fails, run the following steps:
                     <ol>
-                      <li>Reject P with a "failed" exception.
+                      <li>
+                        <span data-anolis-spec="promguide" title=
+                        "resolve-reject">Reject</span> P with a "failed"
+                        exception.
                       </li>
                     </ol>
                   </li>
@@ -1010,7 +1037,10 @@ interface PresentationSession : EventTarget {
           <li>If <em>T</em> completes with the user <em>denying
           permission</em>, run the following steps:
             <ol>
-              <li>Reject <em>P</em> with a "PermissionDenied" exception.
+              <li>
+                <span data-anolis-spec="promguide" title=
+                "resolve-reject">Reject</span> <em>P</em> with a
+                "PermissionDenied" exception.
               </li>
             </ol>
           </li>
@@ -1034,14 +1064,15 @@ interface PresentationSession : EventTarget {
     <p>
       When <code>NavigatorPresentation.joinSession(presentationUrl,
       presentationId)</code> is called, the user agent must run the following
-      steps.
+      steps:
     </p>
     <dl>
       <dt>
         Input
       </dt>
       <dd>
-        <code>presentationUrl</code>, the URL of the document being presented
+        <code>presentationUrl</code>, the <span data-anolis-spec=
+        "url">URL</span> of the document being presented
       </dd>
       <dd>
         <code>presentationId</code>, the identifier for the presentation
@@ -1050,17 +1081,21 @@ interface PresentationSession : EventTarget {
         Output
       </dt>
       <dd>
-        <em>P</em>, a Promise
+        <em>P</em>, a <span data-anolis-spec="es6" title=
+        "promise-objects">Promise</span>
       </dd>
     </dl>
     <ol>
-      <li>Let <em>P</em> be a new Promise.
+      <li>Let <em>P</em> be a new <span data-anolis-spec="es6" title=
+      "promise-objects">Promise</span>.
       </li>
       <li>Return <em>P</em>.
       </li>
       <li>Let <em>D</em> be the set of presentations known by the user agent.
       </li>
-      <li>Queue a task <em>T</em> to run the following steps in order:
+      <li>
+        <span data-anolis-spec="w3c-html">Queue a task</span> <em>T</em> to run
+        the following steps in order:
         <ol>
           <li>For each presentation <em>(U, I, S)</em> in <em>D</em>,
             <ol>
@@ -1071,10 +1106,13 @@ interface PresentationSession : EventTarget {
               <em>i</em> is equal to <code>presentationId</code>, run the
               following steps:
                 <ol>
-                  <li>Resolve <em>P</em> with <em>S</em>.
+                  <li>
+                    <span data-anolis-spec="promguide" title=
+                    "resolve-reject">Resolve</span> <em>P</em> with <em>S</em>.
                   </li>
-                  <li>Initiate the <em>Presentation Connection</em> algorithm
-                  for <em>S</em>.
+                  <li>Initiate the <a href=
+                  "#presentation-connection">Presentation Connection</a>
+                  algorithm for <em>S</em>.
                   </li>
                   <li>Abort the remaining steps of <em>T</em>.
                   </li>
@@ -1082,7 +1120,10 @@ interface PresentationSession : EventTarget {
               </li>
             </ol>
           </li>
-          <li>Reject <em>P</em> with a "NoPresentationFound" exception.
+          <li>
+            <span data-anolis-spec="promguide" title=
+            "resolve-reject">Reject</span> <em>P</em> with a
+            "NoPresentationFound" exception.
           </li>
         </ol>
       </li>
@@ -1106,11 +1147,13 @@ interface PresentationSession : EventTarget {
           </li>
         </ol>
       </li>
-      <li>Set <em>S.state</em> to <code>disconnected.</code>
+      <li>Set <em>S.state</em> to <code>disconnected</code>.
       </li>
       <li>Let <em>D</em> be the set of presentations known by the user agent.
       </li>
-      <li>Queue a task <em>T</em> to run the following steps in order:
+      <li>
+        <span data-anolis-spec="w3c-html">Queue a task</span> <em>T</em> to run
+        the following steps in order:
         <ol>
           <li>For each presentation <em>(U, I, S')</em> in <em>D</em>,
             <ol>
@@ -1120,8 +1163,11 @@ interface PresentationSession : EventTarget {
               <li>If <em>u</em> is equal to <em>S.url</em> and <em>i</em> is
               equal to <em>S.id</em>, run the following steps:
                 <ol>
-                  <li>Queue a task to fire an event named
-                  <code>statechange</code> at <em>s.onstatechange</em>.
+                  <li>
+                    <span data-anolis-spec="w3c-html">Queue a task</span> to
+                    <span data-anolis-spec="w3c-html" title=
+                    "concept-event-fire">fire an event</span> named
+                    <code>statechange</code> at <em>s.onstatechange</em>.
                   </li>
                 </ol>
               </li>
@@ -1147,8 +1193,9 @@ interface PresentationSession : EventTarget {
           </li>
         </ol>
       </li>
-      <li>Queue a task <em>T</em> to connect <em>S</em> to the document that is
-      presenting <em>S.url</em>.
+      <li>
+        <span data-anolis-spec="w3c-html">Queue a task</span> <em>T</em> to
+        connect <em>S</em> to the document that is presenting <em>S.url</em>.
       </li>
       <li>If <em>T</em> completes successfully, run the following steps:
         <ol>
@@ -1167,8 +1214,11 @@ interface PresentationSession : EventTarget {
                   <li>If <em>u</em> is equal to <em>S.url</em> and <em>i</em>
                   is equal to <em>S.id</em>, run the following steps:
                     <ol>
-                      <li>Queue a task to fire an event named
-                      <code>statechange</code> at <em>s.onstatechange</em>.
+                      <li>
+                        <span data-anolis-spec="w3c-html">Queue a task</span>
+                        to <span data-anolis-spec="w3c-html" title=
+                        "concept-event-fire">fire an event</span> named
+                        <code>statechange</code> at <em>s.onstatechange</em>.
                       </li>
                     </ol>
                   </li>

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
      [data-anolis-spec]::after { content:"[" attr(data-anolis-spec) "]"; font-size:.6em; vertical-align:super; text-transform:uppercase }
     }
     </style>
-    <link href="http://www.w3.org/StyleSheets/TR/W3C-ED" rel="stylesheet" type="text/css">
+    <link href="http://www.w3.org/StyleSheets/TR/W3C-ED.css" type="text/css" rel="stylesheet">
     <style type="text/css">
 /* Note formatting taken from HTML5 spec */
     .note { border-left-style: solid; border-left-width: 0.25em; background: none repeat scroll 0 0 #E9FBE9; border-color: #52E052; }
@@ -68,13 +68,13 @@
     <div class="head">
       
 <!--begin-logo-->
-<p><a href="http://www.w3.org/"><img alt="W3C" height="48" src="https://www.w3.org/Icons/w3c_home" width="72"></a></p>
+<p><a href="http://www.w3.org/"><img width="72" alt="W3C" height="48" src="https://www.w3.org/Icons/w3c_home"></a></p>
 <!--end-logo-->
       <h1>
         Presentation API
       </h1>
-      <h2 class="no-num no-toc" id="w3c-editor's-draft-19-november-2014">
-        W3C Editor's Draft 19 November 2014
+      <h2 class="no-num no-toc" id="editor's-draft-8-january-2015">
+        Editor's Draft - 8 January 2015
       </h2>
       <dl>
         <dt>
@@ -283,10 +283,10 @@
    <li><a href="#todo"><span class="secno">7.8 </span>
       TODO
     </a></ol></li>
- <li><a class="no-num" href="#references">
+ <li><a href="#references" class="no-num">
       References
     </a></li>
- <li><a class="no-num" href="#acknowledgments">
+ <li><a href="#acknowledgments" class="no-num">
       Acknowledgments
     </a></ol>
 <!--end-toc-->
@@ -430,7 +430,7 @@
     </ul>
     <p class="note">
       Multi-Screen enumeration and named identification removed, after
-      discussion on the mailing list, cmp. <a class="external free" href="http://lists.w3.org/Archives/Public/public-webscreens/2014Feb/0021.html" rel="nofollow">
+      discussion on the mailing list, cmp. <a href="http://lists.w3.org/Archives/Public/public-webscreens/2014Feb/0021.html" class="external free" rel="nofollow">
       http://lists.w3.org/Archives/Public/public-webscreens/2014Feb/0021.html</a> :
     </p>
     <ul>
@@ -523,7 +523,7 @@
       Terminology
     </h2>
     <p>
-      The term <dfn id="presentation-display" title="presentation display">presentation display</dfn>
+      The term <dfn title="presentation display" id="presentation-display">presentation display</dfn>
       refers to an external screen connected to the device that the user agent
       runs on.
     </p><!--    <p>
@@ -535,9 +535,16 @@
     </p>
 -->
     <p>
-      The terms <a class="external" data-anolis-spec="w3c-html" href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#event-handlers">event handlers</a> and
-      <a class="external" data-anolis-spec="w3c-html" href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#event-handler-event-type" title="event handler event type">event
-      handler event types</a> are defined in <a href="#refsHTML5">[HTML5]</a>.
+      The terms <a href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#event-handlers" data-anolis-spec="w3c-html" class="external">event handlers</a>,
+      <a href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#event-handler-event-type" data-anolis-spec="w3c-html" title="event handler event type" class="external">event
+      handler event types</a>, <a href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#queue-a-task" title="queue a task" data-anolis-spec="w3c-html" class="external">queing a task</a> are defined in <a href="#refsHTML5">[HTML5]</a>.
+    </p>
+    <p>
+      The term <a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-promise-objects" title="promise-objects" data-anolis-spec="es6" class="external">Promise</a> is defined in <a href="#refsES6">[ES6]</a>.
+    </p>
+    <p>
+      The term <a href="https://url.spec.whatwg.org/#url" data-anolis-spec="url" class="external">URL</a> is defined in the WHATWG
+      URL standard: <a href="#refsURL">[URL]</a>.
     </p>
     <p>
       This document provides interface definitions using the
@@ -914,9 +921,6 @@ interface PresentationSession : EventTarget {
       <em>I</em> together uniquely identify the
       <code>PresentationSession</code> of the corresponding presentation.
     </p>
-    <p class="open-issue">
-      Need to add xrefs to term definitions: promise, task, assert, URL, etc.
-    </p>
     <h3 id="screen-availability-listener-added"><span class="secno">7.1 </span>
       Screen Availability Listener Added
     </h3>
@@ -1271,11 +1275,17 @@ interface PresentationSession : EventTarget {
     <h2 class="no-num" id="references">
       References
     </h2>
-    <div id="anolis-references"><dl><dt id="refsHTML5">[HTML5]
+    <div id="anolis-references"><dl><dt id="refsES6">[ES6]
+<dd><cite><a href="http://people.mozilla.org/~jorendorff/es6-draft.html">ECMA-262 6th Edition / Draft</a></cite>. ECMA / Jason Orendorff.
+
+<dt id="refsHTML5">[HTML5]
 <dd><cite><a href="http://www.w3.org/html/wg/drafts/html/CR/">HTML5</a></cite>, Robin Berjon, Steve Faulkner, Travis Leithead et al.. W3C.
 
 <dt id="refsRFC2119">[RFC2119]
 <dd><cite><a href="http://tools.ietf.org/html/rfc2119">Key words for use in RFCs to Indicate Requirement Levels</a></cite>, Scott Bradner. IETF.
+
+<dt id="refsURL">[URL]
+<dd><cite><a href="https://url.spec.whatwg.org/">URL</a></cite>, Anne van Kesteren. WHATWG.
 
 <dt id="refsWEBIDL">[WEBIDL]
 <dd><cite><a href="http://heycam.github.io/webidl/">Web IDL</a></cite>, Cameron McCormack. W3C.

--- a/index.html
+++ b/index.html
@@ -259,28 +259,32 @@
       Algorithms
     </a>
   <ol>
-   <li><a href="#screen-availability-listener-added"><span class="secno">7.1 </span>
-      Screen Availability Listener Added
+   <li><a href="#presentation-display-availability"><span class="secno">7.1 </span>
+      Presentation Display Availability
+    </a>
+    <ol>
+     <li><a href="#availability-listener-added"><span class="secno">7.1.1 </span>
+      Availability Listener Added
     </a></li>
-   <li><a href="#screen-availability-listener-removed"><span class="secno">7.2 </span>
-      Screen Availability Listener Removed
+     <li><a href="#availability-listener-removed"><span class="secno">7.1.2 </span>
+      Availability Listener Removed
     </a></li>
-   <li><a href="#no-screens-available"><span class="secno">7.3 </span>
-      No Screens Available
-    </a></li>
-   <li><a href="#start-session"><span class="secno">7.4 </span>
+     <li><a href="#monitor-availability-algorithm"><span class="secno">7.1.3 </span>
+      Algorithm to Monitor Availability Change
+    </a></ol></li>
+   <li><a href="#start-session"><span class="secno">7.2 </span>
       Start Session
     </a></li>
-   <li><a href="#join-session"><span class="secno">7.5 </span>
+   <li><a href="#join-session"><span class="secno">7.3 </span>
       Join Session
     </a></li>
-   <li><a href="#session-close"><span class="secno">7.6 </span>
+   <li><a href="#session-close"><span class="secno">7.4 </span>
       Session Close
     </a></li>
-   <li><a href="#presentation-connection"><span class="secno">7.7 </span>
+   <li><a href="#presentation-connection"><span class="secno">7.5 </span>
       Presentation Connection
     </a></li>
-   <li><a href="#todo"><span class="secno">7.8 </span>
+   <li><a href="#todo"><span class="secno">7.6 </span>
       TODO
     </a></ol></li>
  <li><a href="#references" class="no-num">
@@ -916,31 +920,65 @@ interface PresentationSession : EventTarget {
       <em>I</em> together uniquely identify the
       <code>PresentationSession</code> of the corresponding presentation.
     </p>
-    <h3 id="screen-availability-listener-added"><span class="secno">7.1 </span>
-      Screen Availability Listener Added
+    <h3 id="presentation-display-availability"><span class="secno">7.1 </span>
+      Presentation Display Availability
     </h3>
     <p>
-      Let <a id="availablescreens"><em>availableScreens</em></a> be the list of
-      available screens that are compatible with the Presentation API and that
-      are currently known to the user agent.
+      Let <a id="availabledisplays"><em>availableDisplays</em></a> be the list
+      of available <a href="presentation-display">presentation displays</a>
+      that are currently known to the user agent.
     </p>
+    <h4 id="availability-listener-added"><span class="secno">7.1.1 </span>
+      Availability Listener Added
+    </h4>
     <p>
       When a new <a href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#event-handlers" title="event handlers" data-anolis-spec="w3c-html" class="external">event
       handler</a> <em>E</em> is added to
       <code>NavigatorPresentation.onavailablechange</code>, the user agent must
+      run the <a href="monitor-availability-algorithm">algorithm to monitor
+      availability</a>.
+    </p>
+    <p class="note">
+      The mechanism used to monitor <a href="#presentation-display">presention
+      displays</a> availability is left to the user agent. The user agent may
+      choose search for screens at any time, not just when event handlers are
+      added to <code>NavigatorPresentation.onavailablechange</code>.
+    </p>
+    <p class="open-issue">
+      Do we want to fire the event at all handlers, or only the newly added
+      one?
+    </p>
+    <h4 id="availability-listener-removed"><span class="secno">7.1.2 </span>
+      Availability Listener Removed
+    </h4>
+    <p>
+      When the last <a href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#event-handlers" title="event handlers" data-anolis-spec="w3c-html" class="external">event handler</a> is removed from
+      <code>NavigatorPresentation.onavailablechange</code>, the user agent may
       run the following steps:
     </p>
     <ol>
-      <li>If the user agent is not already discovering for <a href="#presentation-display">presention displays</a>, then:
-        <ol>
-          <li>
-            <a href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#queue-a-task" data-anolis-spec="w3c-html" class="external">Queue a task</a> to discover
-            <a href="#presentation-display">presentation displays</a>.
-          </li>
-        </ol>
+      <li>Cancel the <a href="monitor-availability-algorithm">algorithm to
+      monitor availability change.</a>
       </li>
-      <li>If the <a href="#availablescreens">availableScreens</a> list is not
-      empty, then run the following steps:
+    </ol>
+    <h4 id="monitor-availability-algorithm"><span class="secno">7.1.3 </span>
+      Algorithm to Monitor Availability Change
+    </h4>
+    <p>
+      While there are <a href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#event-handlers" data-anolis-spec="w3c-html" class="external">event handlers</a>
+      added to NavigatorPresentation.onavailablechange, the user agent must
+      continuously keep track of the available <a href="#presentation-display">presentation displays</a> and repeat the
+      following steps:
+    </p>
+    <ol>
+      <li>
+        <a href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#queue-a-task" data-anolis-spec="w3c-html" class="external">Queue a task</a> to retrieve the
+        the list of curently available <a href="#presentation-display">presentation displays</a> and let <a id="newdisplays"><em>newDisplays</em></a> be this list.
+      </li>
+      <li>Wait for the completion of that task.
+      </li>
+      <li>If <a href="#availabledisplays">availableDisplays</a> is empty and
+      <a href="#newdisplays">newDisplays</a> is not empty, then
         <ol>
           <li>
             <a href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#queue-a-task" data-anolis-spec="w3c-html" class="external">Queue a task</a> to
@@ -951,57 +989,21 @@ interface PresentationSession : EventTarget {
           </li>
         </ol>
       </li>
-    </ol>
-    <p class="note">
-      The mechanism used to discover <a href="#presentation-display">presention
-      displays</a> is left to the user agent. The user agent may choose search
-      for screens at any time, not just when event handlers are added to
-      <code>NavigatorPresentation.onavailablechange</code>.
-    </p>
-    <p class="open-issue">
-      Do we want to fire the event at all handlers, or only the newly added
-      one?
-    </p>
-    <h3 id="screen-availability-listener-removed"><span class="secno">7.2 </span>
-      Screen Availability Listener Removed
-    </h3>
-    <p>
-      When the last <a href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#event-handlers" title="event handlers" data-anolis-spec="w3c-html" class="external">event handler</a> is removed from
-      <code>NavigatorPresentation.onavailablechange</code>, the user agent may
-      run the following steps:
-    </p>
-    <ol>
-      <li>Cancel any pending tasks to search for screens that are compatible
-      with the Presentation API.
+      <li>If <a href="#availabledisplays">availableDisplays</a> is not empty
+      and <a href="#newdisplays">newDisplays</a> is empty, then:
+        <div style="margin-left: 2em">
+          <a href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#queue-a-task" data-anolis-spec="w3c-html" class="external">Queue a task</a> to
+          <a href="http://www.w3.org/html/wg/drafts/html/master/infrastructure.html#concept-event-fire" title="concept-event-fire" data-anolis-spec="w3c-html" class="external">fire an
+          event</a> named <code>availablechange</code> at <em>E</em> (and
+          only <em>E</em>) with the event's <code>available</code> property set
+          to <code>false</code>.
+        </div>
+      </li>
+      <li>Set <a href="#availableDisplays">availableDisplays</a> to the value
+      of <a href="#newDisplays">newDisplays</a>.
       </li>
     </ol>
-    <h3 id="no-screens-available"><span class="secno">7.3 </span>
-      No Screens Available
-    </h3>
-    <p>
-      When the set of available screens becomes empty (e.g., because the user
-      agent has lost its network connection), the user agent must run the
-      following steps:
-    </p>
-    <ol>
-      <li>If there are no <a href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#event-handlers" data-anolis-spec="w3c-html" class="external">event
-      handlers</a> added to
-      <code>NavigatorPresentation.onavailablechange</code>, then:
-        <ol>
-          <li>Abort these steps.
-          </li>
-        </ol>
-      </li>
-      <li>
-        <a href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#queue-a-task" data-anolis-spec="w3c-html" class="external">Queue a task</a> to
-        <a href="http://www.w3.org/html/wg/drafts/html/master/infrastructure.html#concept-event-fire" title="concept-event-fire" data-anolis-spec="w3c-html" class="external">fire an
-        event</a> named <code>availablechange</code> at all the event
-        handlers added to <code>NavigatorPresentation.onavailablechange</code>
-        with the event's <code>available</code> property set to
-        <code>false</code>.
-      </li>
-    </ol>
-    <h3 id="start-session"><span class="secno">7.4 </span>
+    <h3 id="start-session"><span class="secno">7.2 </span>
       Start Session
     </h3>
     <p>
@@ -1119,7 +1121,7 @@ interface PresentationSession : EventTarget {
       no-screens-available outcome? Developers would be able to infer it anyway
       from <code>onavailablechange</code>.
     </p>
-    <h3 id="join-session"><span class="secno">7.5 </span>
+    <h3 id="join-session"><span class="secno">7.3 </span>
       Join Session
     </h3>
     <p>
@@ -1187,7 +1189,7 @@ interface PresentationSession : EventTarget {
       If no matching presentation is found, we could leave the Promise pending
       in case a matching presentation is started in the future.
     </p>
-    <h3 id="session-close"><span class="secno">7.6 </span>
+    <h3 id="session-close"><span class="secno">7.4 </span>
       Session Close
     </h3>
     <p>
@@ -1230,7 +1232,7 @@ interface PresentationSession : EventTarget {
         </ol>
       </li>
     </ol>
-    <h3 id="presentation-connection"><span class="secno">7.7 </span>
+    <h3 id="presentation-connection"><span class="secno">7.5 </span>
       Presentation Connection
     </h3>
     <p>
@@ -1305,7 +1307,7 @@ interface PresentationSession : EventTarget {
       Need to further specify the semantics of the messaging channel (using
       WebSockets or MessagePort as a reference).
     </p>
-    <h3 id="todo"><span class="secno">7.8 </span>
+    <h3 id="todo"><span class="secno">7.6 </span>
       TODO
     </h3>
     <p class="open-issue">

--- a/index.html
+++ b/index.html
@@ -259,20 +259,29 @@
       Algorithms
     </a>
   <ol>
-   <li><a href="#the-screen-availability-algorithm"><span class="secno">7.1 </span>
-      The Screen Availability algorithm
+   <li><a href="#screen-availability-listener-added"><span class="secno">7.1 </span>
+      Screen Availability Listener Added
     </a></li>
-   <li><a href="#the-start-session-algorithm"><span class="secno">7.2 </span>
-      The Start Session algorithm
+   <li><a href="#screen-availability-listener-removed"><span class="secno">7.2 </span>
+      Screen Availability Listener Removed
     </a></li>
-   <li><a href="#the-join-session-algorithm"><span class="secno">7.3 </span>
-      The Join Session algorithm
+   <li><a href="#no-screens-available"><span class="secno">7.3 </span>
+      No Screens Available
     </a></li>
-   <li><a href="#the-close-session-algorithm"><span class="secno">7.4 </span>
-      The Close Session algorithm
+   <li><a href="#start-session"><span class="secno">7.4 </span>
+      Start Session
     </a></li>
-   <li><a href="#the-presentation-initialization-algorithm"><span class="secno">7.5 </span>
-      The Presentation Initialization algorithm
+   <li><a href="#join-session"><span class="secno">7.5 </span>
+      Join Session
+    </a></li>
+   <li><a href="#session-close"><span class="secno">7.6 </span>
+      Session Close
+    </a></li>
+   <li><a href="#presentation-connection"><span class="secno">7.7 </span>
+      Presentation Connection
+    </a></li>
+   <li><a href="#todo"><span class="secno">7.8 </span>
+      TODO
     </a></ol></li>
  <li><a class="no-num" href="#references">
       References
@@ -891,40 +900,373 @@ interface PresentationSession : EventTarget {
       Algorithms
     </h2>
     <p>
-      These algorithms are intended to define the behavior of the
+      These algorithms define the behavior of the
       <code>NavigatorPresentation</code> and <code>PresentationSession</code>
       interfaces declared in the <a href="#interfaces">Interfaces</a> section.
     </p>
-    <h3 id="the-screen-availability-algorithm"><span class="secno">7.1 </span>
-      The Screen Availability algorithm
-    </h3>
     <p>
-      Run when an event handler is added to <code>onavailablechange</code>.
+      Let <em>D</em> be the set of presentations that are currently known to
+      the user agent (regardles of their state). <em>D</em> is represented as a
+      set of tuples <em>(U, I, S)</em> where <em>U</em> is the URL that is
+      being presented; <em>I</em> is an alphanumeric identifier for the
+      presentation; and <em>S</em> is the user agent's
+      <code>PresentationSession</code> for the presentation. <em>U</em> and
+      <em>I</em> together uniquely identify the
+      <code>PresentationSession</code> of the corresponding presentation.
     </p>
-    <h3 id="the-start-session-algorithm"><span class="secno">7.2 </span>
-      The Start Session algorithm
-    </h3>
-    <p>
-      Run when <code>startSession(url, presentationId)</code> is called.
+    <p class="open-issue">
+      Need to add xrefs to term definitions: promise, task, assert, URL, etc.
     </p>
-    <h3 id="the-join-session-algorithm"><span class="secno">7.3 </span>
-      The Join Session algorithm
+    <h3 id="screen-availability-listener-added"><span class="secno">7.1 </span>
+      Screen Availability Listener Added
     </h3>
     <p>
-      Run when <code>joinSession(url, presentationId)</code> is called.
+      When a new event handler <em>E</em> is added to
+      <code>NavigatorPresentation.onavailablechange</code>, the user agent must
+      run the following steps:
     </p>
-    <h3 id="the-close-session-algorithm"><span class="secno">7.4 </span>
-      The Close Session algorithm
-    </h3>
-    <p>
-      Run when <code>close()</code> is called on a
-      <code>PresentationSession.</code>
+    <ol>
+      <li>If the user agent is not already searching for screens compatible
+      with the Presentation API, then:
+        <ol>
+          <li>Queue a task to search for screens that are compatible with the
+          Presentation API.
+          </li>
+        </ol>
+      </li>
+      <li>If the search for screens discovers at least one compatible screen,
+      then:
+        <ol>
+          <li>Queue a task to fire an event named <code>availablechange</code>
+          at <em>E</em> (and only <em>E</em>) with the event's
+          <code>available</code> property set to <code>true</code>.
+          </li>
+        </ol>
+      </li>
+    </ol>
+    <p class="note">
+      The mechanism used to search for compatible screens is up to the user
+      agent. The user agent may choose search for screens at any time, not just
+      when event handlers are added to
+      <code>NavigatorPresentation.onavailablechange</code>.
     </p>
-    <h3 id="the-presentation-initialization-algorithm"><span class="secno">7.5 </span>
-      The Presentation Initialization algorithm
+    <p class="open-issue">
+      Do we want to fire the event at all handlers, or only the newly added
+      one?
+    </p>
+    <h3 id="screen-availability-listener-removed"><span class="secno">7.2 </span>
+      Screen Availability Listener Removed
     </h3>
     <p>
-      Run when a document opened by <code>startSession()</code> is loaded.
+      When the last event handler is removed from
+      <code>NavigatorPresentation.onavailablechange</code>, the user agent may
+      run the following steps:
+    </p>
+    <ol>
+      <li>Cancel any pending tasks to search for screens that are compatible
+      with the Presentation API.
+      </li>
+    </ol>
+    <h3 id="no-screens-available"><span class="secno">7.3 </span>
+      No Screens Available
+    </h3>
+    <p>
+      When the set of available screens becomes empty (e.g., because the user
+      agent has lost its network connection), the user agent must run the
+      following steps:
+    </p>
+    <ol>
+      <li>If there are no event handlers added to
+      <code>NavigatorPresentation.onavailablechange</code>, then:
+        <ol>
+          <li>Abort these steps.
+          </li>
+        </ol>
+      </li>
+      <li>Queue a task to fire an event named <code>availablechange</code> at
+      all the event handlers added to
+      <code>NavigatorPresentation.onavailablechange</code> with the event's
+      <code>available</code> property set to <code>false</code>.
+      </li>
+    </ol>
+    <h3 id="start-session"><span class="secno">7.4 </span>
+      Start Session
+    </h3>
+    <p>
+      When <code>NaviagatorPresentaton.startSession(presentationUrl,
+      presentationId)</code> is called, the user agent must run the following
+      steps.
+    </p>
+    <dl>
+      <dt>
+        Input
+      </dt>
+      <dd>
+        <code>presentationUrl</code>, the URL of the document to be presented
+      </dd>
+      <dd>
+        <code>presentationId</code>, an optional identifier for the
+        presentation
+      </dd>
+      <dt>
+        Output
+      </dt>
+      <dd>
+        <em>P</em>, a Promise
+      </dd>
+    </dl>
+    <ol>
+      <li>Let <em>P</em> be a new Promise.
+      </li>
+      <li>Return <em>P</em>.
+      </li>
+      <li>If no screens are available that are compatible with the Presentation
+      API, run these steps:
+        <ol>
+          <li>Reject <em>P</em> with a "NoScreensAvailable" exception.
+          </li>
+          <li>Abort all remaining steps.
+          </li>
+        </ol>
+      </li>
+      <li>Queue a task <em>T</em> to request user permission for the use of a
+      presentation screen.
+      </li>
+      <li>If <em>T</em> completes with the user <em>granting permission</em> to
+      use a screen, run the following steps:
+        <ol>
+          <li>If <code>presentationId</code> is not <em>undefined</em>, assign
+          <em>I</em> to that that <code>presentationId</code>.
+          </li>
+          <li>If <code>presentationId</code> is <code>undefined</code>, let
+          <em>I</em> be a random alphanumeric value of at least 16 characters
+          drawn from the characters <code>[A-Za-z0-9]</code>.
+          </li>
+          <li>Create a new <code>PresentationSession</code> <em>S</em>.
+          </li>
+          <li>Set <code>S.url</code> to <code>presentationUrl</code>, set
+          <code>S.id</code> to <em>I</em>, and set <code>S.state</code> to
+          <code>disconnected</code>.
+          </li>
+          <li>Add <em>(S.url, S.id, S)</em> to <em>D</em>.
+          </li>
+          <li>Resolve <em>P</em> with <em>S</em>.
+          </li>
+          <li>Initiate the <em>Presentation Connection</em> algorithm for <em>
+            S</em>.
+          </li>
+        </ol>
+      </li>
+      <li>If <em>T</em> completes with the user <em>denying permission</em>,
+      run the following steps:
+        <ol>
+          <li>Reject <em>P</em> with a "PermissionDenied" exception.
+          </li>
+        </ol>
+      </li>
+    </ol>
+    <p class="note">
+      The implementation of the permission request is up to the user agent; for
+      example it may show the user a dialog and allow the user to select an
+      available screen (granting permission), or cancel the selection (denying
+      permission).
+    </p>
+    <p class="open-issue">
+      Do we want to distinguish the permission-denied outcome from the
+      no-screens-available outcome? Developers would be able to infer it anyway
+      from <code>onavailablechange</code>.
+    </p>
+    <h3 id="join-session"><span class="secno">7.5 </span>
+      Join Session
+    </h3>
+    <p>
+      When <code>NavigatorPresentation.joinSession(presentationUrl,
+      presentationId)</code> is called, the user agent must run the following
+      steps.
+    </p>
+    <dl>
+      <dt>
+        Input
+      </dt>
+      <dd>
+        <code>presentationUrl</code>, the URL of the document being presented
+      </dd>
+      <dd>
+        <code>presentationId</code>, the identifier for the presentation
+      </dd>
+      <dt>
+        Output
+      </dt>
+      <dd>
+        <em>P</em>, a Promise
+      </dd>
+    </dl>
+    <ol>
+      <li>Let <em>P</em> be a new Promise.
+      </li>
+      <li>Return <em>P</em>.
+      </li>
+      <li>Let <em>D</em> be the set of presentations known by the user agent.
+      </li>
+      <li>Queue a task <em>T</em> to run the following steps in order:
+        <ol>
+          <li>For each presentation <em>(U, I, S)</em> in <em>D</em>,
+            <ol>
+              <li>Let <em>u</em> equal <em>U</em>, <em>i</em> equal <em>I</em>,
+              and <em>s</em> equal <em>S</em>.
+              </li>
+              <li>If <em>u</em> is equal to <code>presentationUrl</code> and
+              <em>i</em> is equal to <code>presentationId</code>, run the
+              following steps:
+                <ol>
+                  <li>Resolve <em>P</em> with <em>S</em>.
+                  </li>
+                  <li>Initiate the <em>Presentation Connection</em> algorithm
+                  for <em>S</em>.
+                  </li>
+                  <li>Abort the remaining steps of <em>T</em>.
+                  </li>
+                </ol>
+              </li>
+            </ol>
+          </li>
+          <li>Reject <em>P</em> with a "NoPresentationFound" exception.
+          </li>
+        </ol>
+      </li>
+    </ol>
+    <p class="open-issue">
+      If no matching presentation is found, we could leave the Promise pending
+      in case a matching presentation is started in the future.
+    </p>
+    <h3 id="session-close"><span class="secno">7.6 </span>
+      Session Close
+    </h3>
+    <p>
+      When <code>PresentationSession.close()</code> is called on a
+      <code>PresentationSession</code> <em>S</em>, the user agent must run the
+      following steps:
+    </p>
+    <ol>
+      <li>If <em>S.state</em> is not <code>connected</code>, then:
+        <ol>
+          <li>Abort these steps.
+          </li>
+        </ol>
+      </li>
+      <li>Set <em>S.state</em> to <code>disconnected.</code>
+      </li>
+      <li>Let <em>D</em> be the set of presentations known by the user agent.
+      </li>
+      <li>Queue a task <em>T</em> to run the following steps in order:
+        <ol>
+          <li>For each presentation <em>(U, I, S')</em> in <em>D</em>,
+            <ol>
+              <li>Let <em>u</em> equal <em>U</em>, <em>i</em> equal <em>I</em>,
+              and <em>s</em> equal <em>S'</em>.
+              </li>
+              <li>If <em>u</em> is equal to <em>S.url</em> and <em>i</em> is
+              equal to <em>S.id</em>, run the following steps:
+                <ol>
+                  <li>Queue a task to fire an event named
+                  <code>statechange</code> at <em>s.onstatechange</em>.
+                  </li>
+                </ol>
+              </li>
+            </ol>
+          </li>
+        </ol>
+      </li>
+    </ol>
+    <h3 id="presentation-connection"><span class="secno">7.7 </span>
+      Presentation Connection
+    </h3>
+    <p>
+      When the user agent has created a <code>PresentationSession</code>
+      <em>S</em> to resolve a promise returned from
+      <code>NavigatorPresentation.startSession</code>, or resolved a promise
+      returned from to <code>NavigatorPresentation.joinSession</code> with
+      <em>S</em>, it must run the following steps:
+    </p>
+    <ol>
+      <li>If <em>S.state</em> is <code>connected</code>, then:
+        <ol>
+          <li>Abort all remaining steps.
+          </li>
+        </ol>
+      </li>
+      <li>Queue a task <em>T</em> to connect <em>S</em> to the document that is
+      presenting <em>S.url</em>.
+      </li>
+      <li>If <em>T</em> completes successfully, run the following steps:
+        <ol>
+          <li>Set <em>S.state</em> to <code>connected.</code>
+          </li>
+          <li>Let <em>D</em> be the set of presentations known by the user
+          agent.
+          </li>
+          <li>Queue a task <em>T</em> to run the following steps in order:
+            <ol>
+              <li>For each presentation <em>(U, I, S')</em> in <em>D</em>,
+                <ol>
+                  <li>Let <em>u</em> equal <em>U</em>, <em>i</em> equal
+                  <em>I</em>, and <em>s</em> equal <em>S'</em>.
+                  </li>
+                  <li>If <em>u</em> is equal to <em>S.url</em> and <em>i</em>
+                  is equal to <em>S.id</em>, run the following steps:
+                    <ol>
+                      <li>Queue a task to fire an event named
+                      <code>statechange</code> at <em>s.onstatechange</em>.
+                      </li>
+                    </ol>
+                  </li>
+                </ol>
+              </li>
+            </ol>
+          </li>
+        </ol>
+      </li>
+    </ol>
+    <p class="note">
+      If <em>T</em> does not complete successfully, the user agent may choose
+      to re-execute the Presentation Connection algorithm at a later time.
+    </p>
+    <p class="note">
+      The mechanism that is used to connect the opening document with the
+      presented document is an implementation choice of the user agent. The
+      connection must provide a two-way messaging abstraction capable of
+      carrying <code>DOMString</code> payloads in a reliable and in-order
+      fashion as described in the <em>Send Message</em> and <em>Receive
+      Message</em> steps below.
+    </p>
+    <p class="open-issue">
+      Do we want to notify the caller of a failure to connect, i.e. with an
+      "error" onstatechange?
+    </p>
+    <p class="open-issue">
+      Do we want to pass the new state as a property of the statechange event?
+    </p>
+    <p class="open-issue">
+      Need to further specify the semantics of the messaging channel (using
+      WebSockets or MessagePort as a reference).
+    </p>
+    <h3 id="todo"><span class="secno">7.8 </span>
+      TODO
+    </h3>
+    <p class="open-issue">
+      Need algorithm for send message
+    </p>
+    <p class="open-issue">
+      Need algorithm for receive message
+    </p>
+    <p class="open-issue">
+      Need algorithm for initialization of the presented document
+    </p>
+    <p class="open-issue">
+      We could write this spec in a way that distinguished the state of the
+      presentation (owned by the user agent) from the state of the
+      PresentationSession (owned by a specific document); however these should
+      always be sync and it would likely result in more confusion than clarity.
     </p>
     <h2 class="no-num" id="references">
       References

--- a/index.html
+++ b/index.html
@@ -1034,8 +1034,17 @@ interface PresentationSession : EventTarget {
       </li>
       <li>Return <em>P</em>.
       </li>
-      <li>If no screens are available that are compatible with the Presentation
-      API, run these steps:
+      <li>If the user agent is currently not running the <a href="#monitor-availability-algorithm">presentation display availability
+      monitoring algorithm</a>:
+        <ol>
+          <li>Start the algorithm.
+          </li>
+          <li>Wait until the algorithm completes.
+          </li>
+        </ol>
+      </li>
+      <li>If the <a href="#availabledisplays">availableDisplays</a> list is
+      empty, then:
         <ol>
           <li>
             <a href="http://www.w3.org/2001/tag/doc/promises-guide#shorthand-manipulating" title="resolve-reject" data-anolis-spec="promguide" class="external">Reject</a> <em>P</em> with a

--- a/index.html
+++ b/index.html
@@ -525,7 +525,8 @@
     <p>
       The term <dfn title="presentation display" id="presentation-display">presentation display</dfn>
       refers to an external screen available to the opening user agent via an
-      imlementation specific connection technology.
+      imlementation specific connection technology and compatible with
+      Presentation API for display content on it.
     </p>
     <p>
       The terms <a href="http://www.w3.org/html/wg/drafts/html/master/browsers.html#browsing-context" data-anolis-spec="w3c-html" class="external">browsing context</a>,
@@ -919,23 +920,27 @@ interface PresentationSession : EventTarget {
       Screen Availability Listener Added
     </h3>
     <p>
+      Let <a id="availablescreens"><em>availableScreens</em></a> be the list of
+      available screens that are compatible with the Presentation API and that
+      are currently known to the user agent.
+    </p>
+    <p>
       When a new <a href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#event-handlers" title="event handlers" data-anolis-spec="w3c-html" class="external">event
       handler</a> <em>E</em> is added to
       <code>NavigatorPresentation.onavailablechange</code>, the user agent must
       run the following steps:
     </p>
     <ol>
-      <li>If the user agent is not already searching for screens compatible
-      with the Presentation API, then:
+      <li>If the user agent is not already discovering for <a href="#presentation-display">presention displays</a>, then:
         <ol>
           <li>
-            <a href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#queue-a-task" data-anolis-spec="w3c-html" class="external">Queue a task</a> to search for
-            screens that are compatible with the Presentation API.
+            <a href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#queue-a-task" data-anolis-spec="w3c-html" class="external">Queue a task</a> to discover
+            <a href="#presentation-display">presentation displays</a>.
           </li>
         </ol>
       </li>
-      <li>If the search for screens discovers at least one compatible screen,
-      then:
+      <li>If the <a href="#availablescreens">availableScreens</a> list is not
+      empty, then run the following steps:
         <ol>
           <li>
             <a href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#queue-a-task" data-anolis-spec="w3c-html" class="external">Queue a task</a> to
@@ -948,9 +953,9 @@ interface PresentationSession : EventTarget {
       </li>
     </ol>
     <p class="note">
-      The mechanism used to search for compatible screens is left to the user
-      agent. The user agent may choose search for screens at any time, not just
-      when event handlers are added to
+      The mechanism used to discover <a href="#presentation-display">presention
+      displays</a> is left to the user agent. The user agent may choose search
+      for screens at any time, not just when event handlers are added to
       <code>NavigatorPresentation.onavailablechange</code>.
     </p>
     <p class="open-issue">

--- a/index.html
+++ b/index.html
@@ -1035,36 +1035,38 @@ interface PresentationSession : EventTarget {
       </li>
       <li>Queue a task <em>T</em> to request user permission for the use of a
       presentation screen.
-      </li>
-      <li>If <em>T</em> completes with the user <em>granting permission</em> to
-      use a screen, run the following steps:
         <ol>
-          <li>If <code>presentationId</code> is not <em>undefined</em>, assign
-          <em>I</em> to that that <code>presentationId</code>.
+          <li>If <em>T</em> completes with the user <em>granting
+          permission</em> to use a screen, run the following steps:
+            <ol>
+              <li>If <code>presentationId</code> is not <em>undefined</em>,
+              assign <em>I</em> to that that <code>presentationId</code>.
+              </li>
+              <li>If <code>presentationId</code> is <code>undefined</code>, let
+              <em>I</em> be a random alphanumeric value of at least 16
+              characters drawn from the characters <code>[A-Za-z0-9]</code>.
+              </li>
+              <li>Create a new <code>PresentationSession</code> <em>S</em>.
+              </li>
+              <li>Set <code>S.url</code> to <code>presentationUrl</code>, set
+              <code>S.id</code> to <em>I</em>, and set <code>S.state</code> to
+              <code>disconnected</code>.
+              </li>
+              <li>Add <em>(S.url, S.id, S)</em> to <em>D</em>.
+              </li>
+              <li>Resolve <em>P</em> with <em>S</em>.
+              </li>
+              <li>Initiate the <em>Presentation Connection</em> algorithm for
+              <em>S</em>.
+              </li>
+            </ol>
           </li>
-          <li>If <code>presentationId</code> is <code>undefined</code>, let
-          <em>I</em> be a random alphanumeric value of at least 16 characters
-          drawn from the characters <code>[A-Za-z0-9]</code>.
-          </li>
-          <li>Create a new <code>PresentationSession</code> <em>S</em>.
-          </li>
-          <li>Set <code>S.url</code> to <code>presentationUrl</code>, set
-          <code>S.id</code> to <em>I</em>, and set <code>S.state</code> to
-          <code>disconnected</code>.
-          </li>
-          <li>Add <em>(S.url, S.id, S)</em> to <em>D</em>.
-          </li>
-          <li>Resolve <em>P</em> with <em>S</em>.
-          </li>
-          <li>Initiate the <em>Presentation Connection</em> algorithm for <em>
-            S</em>.
-          </li>
-        </ol>
-      </li>
-      <li>If <em>T</em> completes with the user <em>denying permission</em>,
-      run the following steps:
-        <ol>
-          <li>Reject <em>P</em> with a "PermissionDenied" exception.
+          <li>If <em>T</em> completes with the user <em>denying
+          permission</em>, run the following steps:
+            <ol>
+              <li>Reject <em>P</em> with a "PermissionDenied" exception.
+              </li>
+            </ol>
           </li>
         </ol>
       </li>

--- a/index.html
+++ b/index.html
@@ -73,8 +73,8 @@
       <h1>
         Presentation API
       </h1>
-      <h2 class="no-num no-toc" id="editor's-draft-8-january-2015">
-        Editor's Draft - 8 January 2015
+      <h2 class="no-num no-toc" id="editor's-draft-9-january-2015">
+        Editor's Draft - 9 January 2015
       </h2>
       <dl>
         <dt>
@@ -530,12 +530,11 @@
     <p>
       The terms <a href="http://www.w3.org/html/wg/drafts/html/master/browsers.html#browsing-context" data-anolis-spec="w3c-html" class="external">browsing context</a>,
       <a href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#event-handlers" data-anolis-spec="w3c-html" class="external">event handlers</a>, <a href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#event-handler-event-type" data-anolis-spec="w3c-html" title="event handler event type" class="external">event handler
-      event types</a>, <a href="http://www.w3.org/html/wg/drafts/html/master/browsers.html#navigate" data-anolis-spec="w3c-html" class="external">navigate</a>,
-      <a href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#queue-a-task" title="queue a task" data-anolis-spec="w3c-html" class="external">queing a
-      task</a> are defined in <a href="#refsHTML5">[HTML5]</a>.
+      event types</a>, <a href="http://www.w3.org/html/wg/drafts/html/master/infrastructure.html#concept-event-fire" title="concept-event-fire" data-anolis-spec="w3c-html" class="external">firing an event</a>, <a href="http://www.w3.org/html/wg/drafts/html/master/browsers.html#navigate" data-anolis-spec="w3c-html" class="external">navigate</a>, <a href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#queue-a-task" title="queue a task" data-anolis-spec="w3c-html" class="external">queing a task</a> are defined in <a href="#refsHTML5">[HTML5]</a>.
     </p>
     <p>
-      The term <a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-promise-objects" title="promise-objects" data-anolis-spec="es6" class="external">Promise</a> is defined in <a href="#refsES6">[ES6]</a>.
+      The term <a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-promise-objects" title="promise-objects" data-anolis-spec="es6" class="external">Promise</a> is defined in <a href="#refsES6">[ES6]</a>. The terms <a href="http://www.w3.org/2001/tag/doc/promises-guide#shorthand-manipulating" title="resolve-reject" data-anolis-spec="promguide" class="external">resolving a Promise, and rejecting a Promise</a> are
+      used as explained in <a href="#refsPROMGUIDE">[PROMGUIDE]</a>.
     </p>
     <p>
       The term <a href="https://url.spec.whatwg.org/#url" data-anolis-spec="url" class="external">URL</a> is defined in the WHATWG
@@ -920,7 +919,8 @@ interface PresentationSession : EventTarget {
       Screen Availability Listener Added
     </h3>
     <p>
-      When a new event handler <em>E</em> is added to
+      When a new <a href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#event-handlers" title="event handlers" data-anolis-spec="w3c-html" class="external">event
+      handler</a> <em>E</em> is added to
       <code>NavigatorPresentation.onavailablechange</code>, the user agent must
       run the following steps:
     </p>
@@ -928,25 +928,29 @@ interface PresentationSession : EventTarget {
       <li>If the user agent is not already searching for screens compatible
       with the Presentation API, then:
         <ol>
-          <li>Queue a task to search for screens that are compatible with the
-          Presentation API.
+          <li>
+            <a href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#queue-a-task" data-anolis-spec="w3c-html" class="external">Queue a task</a> to search for
+            screens that are compatible with the Presentation API.
           </li>
         </ol>
       </li>
       <li>If the search for screens discovers at least one compatible screen,
       then:
         <ol>
-          <li>Queue a task to fire an event named <code>availablechange</code>
-          at <em>E</em> (and only <em>E</em>) with the event's
-          <code>available</code> property set to <code>true</code>.
+          <li>
+            <a href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#queue-a-task" data-anolis-spec="w3c-html" class="external">Queue a task</a> to
+            <a href="http://www.w3.org/html/wg/drafts/html/master/infrastructure.html#concept-event-fire" title="concept-event-fire" data-anolis-spec="w3c-html" class="external">fire
+            an event</a> named <code>availablechange</code> at <em>E</em>
+            (and only <em>E</em>) with the event's <code>available</code>
+            property set to <code>true</code>.
           </li>
         </ol>
       </li>
     </ol>
     <p class="note">
-      The mechanism used to search for compatible screens is to the user agent.
-      The user agent may choose search for screens at any time, not just when
-      event handlers are added to
+      The mechanism used to search for compatible screens is left to the user
+      agent. The user agent may choose search for screens at any time, not just
+      when event handlers are added to
       <code>NavigatorPresentation.onavailablechange</code>.
     </p>
     <p class="open-issue">
@@ -957,7 +961,7 @@ interface PresentationSession : EventTarget {
       Screen Availability Listener Removed
     </h3>
     <p>
-      When the last event handler is removed from
+      When the last <a href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#event-handlers" title="event handlers" data-anolis-spec="w3c-html" class="external">event handler</a> is removed from
       <code>NavigatorPresentation.onavailablechange</code>, the user agent may
       run the following steps:
     </p>
@@ -975,24 +979,28 @@ interface PresentationSession : EventTarget {
       following steps:
     </p>
     <ol>
-      <li>If there are no event handlers added to
+      <li>If there are no <a href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#event-handlers" data-anolis-spec="w3c-html" class="external">event
+      handlers</a> added to
       <code>NavigatorPresentation.onavailablechange</code>, then:
         <ol>
           <li>Abort these steps.
           </li>
         </ol>
       </li>
-      <li>Queue a task to fire an event named <code>availablechange</code> at
-      all the event handlers added to
-      <code>NavigatorPresentation.onavailablechange</code> with the event's
-      <code>available</code> property set to <code>false</code>.
+      <li>
+        <a href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#queue-a-task" data-anolis-spec="w3c-html" class="external">Queue a task</a> to
+        <a href="http://www.w3.org/html/wg/drafts/html/master/infrastructure.html#concept-event-fire" title="concept-event-fire" data-anolis-spec="w3c-html" class="external">fire an
+        event</a> named <code>availablechange</code> at all the event
+        handlers added to <code>NavigatorPresentation.onavailablechange</code>
+        with the event's <code>available</code> property set to
+        <code>false</code>.
       </li>
     </ol>
     <h3 id="start-session"><span class="secno">7.4 </span>
       Start Session
     </h3>
     <p>
-      When <code>NaviagatorPresentaton.startSession(presentationUrl,
+      When <code>NavigatorPresentaton.startSession(presentationUrl,
       presentationId)</code> is called, the user agent must run the following
       steps.
     </p>
@@ -1001,7 +1009,7 @@ interface PresentationSession : EventTarget {
         Input
       </dt>
       <dd>
-        <code>presentationUrl</code>, the URL of the document to be presented
+        <code>presentationUrl</code>, the <a href="https://url.spec.whatwg.org/#url" data-anolis-spec="url" class="external">URL</a> of the document to be presented
       </dd>
       <dd>
         <code>presentationId</code>, an optional identifier for the
@@ -1011,18 +1019,20 @@ interface PresentationSession : EventTarget {
         Output
       </dt>
       <dd>
-        <em>P</em>, a Promise
+        <em>P</em>, a <a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-promise-objects" title="promise-objects" data-anolis-spec="es6" class="external">Promise</a>
       </dd>
     </dl>
     <ol>
-      <li>Let <em>P</em> be a new Promise.
+      <li>Let <em>P</em> be a new <a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-promise-objects" title="promise-objects" data-anolis-spec="es6" class="external">Promise</a>.
       </li>
       <li>Return <em>P</em>.
       </li>
       <li>If no screens are available that are compatible with the Presentation
       API, run these steps:
         <ol>
-          <li>Reject <em>P</em> with a "NoScreensAvailable" exception.
+          <li>
+            <a href="http://www.w3.org/2001/tag/doc/promises-guide#shorthand-manipulating" title="resolve-reject" data-anolis-spec="promguide" class="external">Reject</a> <em>P</em> with a
+            "NoScreensAvailable" exception.
           </li>
           <li>Abort all remaining steps.
           </li>
@@ -1060,16 +1070,20 @@ interface PresentationSession : EventTarget {
                     <ol>
                       <li>Add <em>(S.url, S.id, S)</em> to <em>D</em>.
                       </li>
-                      <li>Resolve <em>P</em> with <em>S</em>.
+                      <li>
+                        <a href="http://www.w3.org/2001/tag/doc/promises-guide#shorthand-manipulating" title="resolve-reject" data-anolis-spec="promguide" class="external">Resolve</a> <em>P</em> with
+                        <em>S</em>.
                       </li>
-                      <li>Initiate the <em>Presentation Connection</em>
+                      <li>Initiate the <a href="#presentation-connection">Presentation Connection</a>
                       algorithm for <em>S</em>.
                       </li>
                     </ol>
                   </li>
                   <li>If <em>C</em> fails, run the following steps:
                     <ol>
-                      <li>Reject P with a "failed" exception.
+                      <li>
+                        <a href="http://www.w3.org/2001/tag/doc/promises-guide#shorthand-manipulating" title="resolve-reject" data-anolis-spec="promguide" class="external">Reject</a> P with a "failed"
+                        exception.
                       </li>
                     </ol>
                   </li>
@@ -1080,7 +1094,9 @@ interface PresentationSession : EventTarget {
           <li>If <em>T</em> completes with the user <em>denying
           permission</em>, run the following steps:
             <ol>
-              <li>Reject <em>P</em> with a "PermissionDenied" exception.
+              <li>
+                <a href="http://www.w3.org/2001/tag/doc/promises-guide#shorthand-manipulating" title="resolve-reject" data-anolis-spec="promguide" class="external">Reject</a> <em>P</em> with a
+                "PermissionDenied" exception.
               </li>
             </ol>
           </li>
@@ -1104,14 +1120,14 @@ interface PresentationSession : EventTarget {
     <p>
       When <code>NavigatorPresentation.joinSession(presentationUrl,
       presentationId)</code> is called, the user agent must run the following
-      steps.
+      steps:
     </p>
     <dl>
       <dt>
         Input
       </dt>
       <dd>
-        <code>presentationUrl</code>, the URL of the document being presented
+        <code>presentationUrl</code>, the <a href="https://url.spec.whatwg.org/#url" data-anolis-spec="url" class="external">URL</a> of the document being presented
       </dd>
       <dd>
         <code>presentationId</code>, the identifier for the presentation
@@ -1120,17 +1136,19 @@ interface PresentationSession : EventTarget {
         Output
       </dt>
       <dd>
-        <em>P</em>, a Promise
+        <em>P</em>, a <a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-promise-objects" title="promise-objects" data-anolis-spec="es6" class="external">Promise</a>
       </dd>
     </dl>
     <ol>
-      <li>Let <em>P</em> be a new Promise.
+      <li>Let <em>P</em> be a new <a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-promise-objects" title="promise-objects" data-anolis-spec="es6" class="external">Promise</a>.
       </li>
       <li>Return <em>P</em>.
       </li>
       <li>Let <em>D</em> be the set of presentations known by the user agent.
       </li>
-      <li>Queue a task <em>T</em> to run the following steps in order:
+      <li>
+        <a href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#queue-a-task" data-anolis-spec="w3c-html" class="external">Queue a task</a> <em>T</em> to run
+        the following steps in order:
         <ol>
           <li>For each presentation <em>(U, I, S)</em> in <em>D</em>,
             <ol>
@@ -1141,10 +1159,11 @@ interface PresentationSession : EventTarget {
               <em>i</em> is equal to <code>presentationId</code>, run the
               following steps:
                 <ol>
-                  <li>Resolve <em>P</em> with <em>S</em>.
+                  <li>
+                    <a href="http://www.w3.org/2001/tag/doc/promises-guide#shorthand-manipulating" title="resolve-reject" data-anolis-spec="promguide" class="external">Resolve</a> <em>P</em> with <em>S</em>.
                   </li>
-                  <li>Initiate the <em>Presentation Connection</em> algorithm
-                  for <em>S</em>.
+                  <li>Initiate the <a href="#presentation-connection">Presentation Connection</a>
+                  algorithm for <em>S</em>.
                   </li>
                   <li>Abort the remaining steps of <em>T</em>.
                   </li>
@@ -1152,7 +1171,9 @@ interface PresentationSession : EventTarget {
               </li>
             </ol>
           </li>
-          <li>Reject <em>P</em> with a "NoPresentationFound" exception.
+          <li>
+            <a href="http://www.w3.org/2001/tag/doc/promises-guide#shorthand-manipulating" title="resolve-reject" data-anolis-spec="promguide" class="external">Reject</a> <em>P</em> with a
+            "NoPresentationFound" exception.
           </li>
         </ol>
       </li>
@@ -1176,11 +1197,13 @@ interface PresentationSession : EventTarget {
           </li>
         </ol>
       </li>
-      <li>Set <em>S.state</em> to <code>disconnected.</code>
+      <li>Set <em>S.state</em> to <code>disconnected</code>.
       </li>
       <li>Let <em>D</em> be the set of presentations known by the user agent.
       </li>
-      <li>Queue a task <em>T</em> to run the following steps in order:
+      <li>
+        <a href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#queue-a-task" data-anolis-spec="w3c-html" class="external">Queue a task</a> <em>T</em> to run
+        the following steps in order:
         <ol>
           <li>For each presentation <em>(U, I, S')</em> in <em>D</em>,
             <ol>
@@ -1190,8 +1213,10 @@ interface PresentationSession : EventTarget {
               <li>If <em>u</em> is equal to <em>S.url</em> and <em>i</em> is
               equal to <em>S.id</em>, run the following steps:
                 <ol>
-                  <li>Queue a task to fire an event named
-                  <code>statechange</code> at <em>s.onstatechange</em>.
+                  <li>
+                    <a href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#queue-a-task" data-anolis-spec="w3c-html" class="external">Queue a task</a> to
+                    <a href="http://www.w3.org/html/wg/drafts/html/master/infrastructure.html#concept-event-fire" title="concept-event-fire" data-anolis-spec="w3c-html" class="external">fire an event</a> named
+                    <code>statechange</code> at <em>s.onstatechange</em>.
                   </li>
                 </ol>
               </li>
@@ -1217,8 +1242,9 @@ interface PresentationSession : EventTarget {
           </li>
         </ol>
       </li>
-      <li>Queue a task <em>T</em> to connect <em>S</em> to the document that is
-      presenting <em>S.url</em>.
+      <li>
+        <a href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#queue-a-task" data-anolis-spec="w3c-html" class="external">Queue a task</a> <em>T</em> to
+        connect <em>S</em> to the document that is presenting <em>S.url</em>.
       </li>
       <li>If <em>T</em> completes successfully, run the following steps:
         <ol>
@@ -1237,8 +1263,10 @@ interface PresentationSession : EventTarget {
                   <li>If <em>u</em> is equal to <em>S.url</em> and <em>i</em>
                   is equal to <em>S.id</em>, run the following steps:
                     <ol>
-                      <li>Queue a task to fire an event named
-                      <code>statechange</code> at <em>s.onstatechange</em>.
+                      <li>
+                        <a href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#queue-a-task" data-anolis-spec="w3c-html" class="external">Queue a task</a>
+                        to <a href="http://www.w3.org/html/wg/drafts/html/master/infrastructure.html#concept-event-fire" title="concept-event-fire" data-anolis-spec="w3c-html" class="external">fire an event</a> named
+                        <code>statechange</code> at <em>s.onstatechange</em>.
                       </li>
                     </ol>
                   </li>
@@ -1298,6 +1326,9 @@ interface PresentationSession : EventTarget {
 
 <dt id="refsHTML5">[HTML5]
 <dd><cite><a href="http://www.w3.org/html/wg/drafts/html/CR/">HTML5</a></cite>, Robin Berjon, Steve Faulkner, Travis Leithead et al.. W3C.
+
+<dt id="refsPROMGUIDE">[PROMGUIDE]
+<dd><cite><a href="http://www.w3.org/2001/tag/doc/promises-guide">Writing Promise-Using Specifications</a></cite>, Domenic Denicola. W3C.
 
 <dt id="refsRFC2119">[RFC2119]
 <dd><cite><a href="http://tools.ietf.org/html/rfc2119">Key words for use in RFCs to Indicate Requirement Levels</a></cite>, Scott Bradner. IETF.

--- a/index.html
+++ b/index.html
@@ -73,8 +73,8 @@
       <h1>
         Presentation API
       </h1>
-      <h2 class="no-num no-toc" id="editor's-draft-9-january-2015">
-        Editor's Draft - 9 January 2015
+      <h2 class="no-num no-toc" id="editor's-draft-12-january-2015">
+        Editor's Draft - 12 January 2015
       </h2>
       <dl>
         <dt>
@@ -270,7 +270,7 @@
       Availability Listener Removed
     </a></li>
      <li><a href="#monitor-availability-algorithm"><span class="secno">7.1.3 </span>
-      Algorithm to Monitor Availability Change
+      Algorithm to Monitor Presentation Display Availability Change
     </a></ol></li>
    <li><a href="#start-session"><span class="secno">7.2 </span>
       Start Session
@@ -529,8 +529,8 @@
     <p>
       The term <dfn title="presentation display" id="presentation-display">presentation display</dfn>
       refers to an external screen available to the opening user agent via an
-      imlementation specific connection technology and compatible with
-      Presentation API for display content on it.
+      implementation specific connection technology and compatible with the
+      Presentation API for the display content on it.
     </p>
     <p>
       The terms <a href="http://www.w3.org/html/wg/drafts/html/master/browsers.html#browsing-context" data-anolis-spec="w3c-html" class="external">browsing context</a>,
@@ -920,14 +920,14 @@ interface PresentationSession : EventTarget {
       <em>I</em> together uniquely identify the
       <code>PresentationSession</code> of the corresponding presentation.
     </p>
-    <h3 id="presentation-display-availability"><span class="secno">7.1 </span>
-      Presentation Display Availability
-    </h3>
     <p>
       Let <a id="availabledisplays"><em>availableDisplays</em></a> be the list
       of available <a href="presentation-display">presentation displays</a>
       that are currently known to the user agent.
     </p>
+    <h3 id="presentation-display-availability"><span class="secno">7.1 </span>
+      Presentation Display Availability
+    </h3>
     <h4 id="availability-listener-added"><span class="secno">7.1.1 </span>
       Availability Listener Added
     </h4>
@@ -962,7 +962,7 @@ interface PresentationSession : EventTarget {
       </li>
     </ol>
     <h4 id="monitor-availability-algorithm"><span class="secno">7.1.3 </span>
-      Algorithm to Monitor Availability Change
+      Algorithm to Monitor Presentation Display Availability Change
     </h4>
     <p>
       While there are <a href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#event-handlers" data-anolis-spec="w3c-html" class="external">event handlers</a>
@@ -1081,7 +1081,7 @@ interface PresentationSession : EventTarget {
                 <a href="http://www.w3.org/html/wg/drafts/html/master/browsers.html#navigate" data-anolis-spec="w3c-html" class="external">navigate</a> to
                 <code>presentationUrl</code> in it.
                 <ol>
-                  <li>If <em>C</em> completes succesfully, run the following
+                  <li>If <em>C</em> completes successfully, run the following
                   steps:
                     <ol>
                       <li>Add <em>(S.url, S.id, S)</em> to <em>D</em>.

--- a/index.html
+++ b/index.html
@@ -524,20 +524,15 @@
     </h2>
     <p>
       The term <dfn title="presentation display" id="presentation-display">presentation display</dfn>
-      refers to an external screen connected to the device that the user agent
-      runs on.
-    </p><!--    <p>
-      The terms <span title="opener-browsing-context" data-anolis-spec=
-      "w3c-html">opener browsing context</span> and <span title=
-      "auxiliary browsing context" data-anolis-spec="w3c-html">auxiliary
-      browsing context</span> are defined in <span data-anolis-ref=
-      "">HTML5</span>.
+      refers to an external screen available to the opening user agent via an
+      imlementation specific connection technology.
     </p>
--->
     <p>
-      The terms <a href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#event-handlers" data-anolis-spec="w3c-html" class="external">event handlers</a>,
-      <a href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#event-handler-event-type" data-anolis-spec="w3c-html" title="event handler event type" class="external">event
-      handler event types</a>, <a href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#queue-a-task" title="queue a task" data-anolis-spec="w3c-html" class="external">queing a task</a> are defined in <a href="#refsHTML5">[HTML5]</a>.
+      The terms <a href="http://www.w3.org/html/wg/drafts/html/master/browsers.html#browsing-context" data-anolis-spec="w3c-html" class="external">browsing context</a>,
+      <a href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#event-handlers" data-anolis-spec="w3c-html" class="external">event handlers</a>, <a href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#event-handler-event-type" data-anolis-spec="w3c-html" title="event handler event type" class="external">event handler
+      event types</a>, <a href="http://www.w3.org/html/wg/drafts/html/master/browsers.html#navigate" data-anolis-spec="w3c-html" class="external">navigate</a>,
+      <a href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#queue-a-task" title="queue a task" data-anolis-spec="w3c-html" class="external">queing a
+      task</a> are defined in <a href="#refsHTML5">[HTML5]</a>.
     </p>
     <p>
       The term <a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-promise-objects" title="promise-objects" data-anolis-spec="es6" class="external">Promise</a> is defined in <a href="#refsES6">[ES6]</a>.
@@ -949,9 +944,9 @@ interface PresentationSession : EventTarget {
       </li>
     </ol>
     <p class="note">
-      The mechanism used to search for compatible screens is up to the user
-      agent. The user agent may choose search for screens at any time, not just
-      when event handlers are added to
+      The mechanism used to search for compatible screens is to the user agent.
+      The user agent may choose search for screens at any time, not just when
+      event handlers are added to
       <code>NavigatorPresentation.onavailablechange</code>.
     </p>
     <p class="open-issue">
@@ -1034,7 +1029,8 @@ interface PresentationSession : EventTarget {
         </ol>
       </li>
       <li>Queue a task <em>T</em> to request user permission for the use of a
-      presentation screen.
+      <a href="#presentation-display" data-anolis-ref="presentation">presentation display</a> and
+      selection of one presentation display.
         <ol>
           <li>If <em>T</em> completes with the user <em>granting
           permission</em> to use a screen, run the following steps:
@@ -1052,12 +1048,32 @@ interface PresentationSession : EventTarget {
               <code>S.id</code> to <em>I</em>, and set <code>S.state</code> to
               <code>disconnected</code>.
               </li>
-              <li>Add <em>(S.url, S.id, S)</em> to <em>D</em>.
-              </li>
-              <li>Resolve <em>P</em> with <em>S</em>.
-              </li>
-              <li>Initiate the <em>Presentation Connection</em> algorithm for
-              <em>S</em>.
+              <li>
+                <a href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#queue-a-task" data-anolis-spec="w3c-html" class="external">Queue a task</a>
+                <em>C</em> to create a new <a href="http://www.w3.org/html/wg/drafts/html/master/browsers.html#browsing-context" data-anolis-spec="w3c-html" class="external">browsing context</a> on the user-selected
+                <a href="presentation-display">presentation display</a> and
+                <a href="http://www.w3.org/html/wg/drafts/html/master/browsers.html#navigate" data-anolis-spec="w3c-html" class="external">navigate</a> to
+                <code>presentationUrl</code> in it.
+                <ol>
+                  <li>If <em>C</em> completes succesfully, run the following
+                  steps:
+                    <ol>
+                      <li>Add <em>(S.url, S.id, S)</em> to <em>D</em>.
+                      </li>
+                      <li>Resolve <em>P</em> with <em>S</em>.
+                      </li>
+                      <li>Initiate the <em>Presentation Connection</em>
+                      algorithm for <em>S</em>.
+                      </li>
+                    </ol>
+                  </li>
+                  <li>If <em>C</em> fails, run the following steps:
+                    <ol>
+                      <li>Reject P with a "failed" exception.
+                      </li>
+                    </ol>
+                  </li>
+                </ol>
               </li>
             </ol>
           </li>
@@ -1072,10 +1088,10 @@ interface PresentationSession : EventTarget {
       </li>
     </ol>
     <p class="note">
-      The implementation of the permission request is up to the user agent; for
-      example it may show the user a dialog and allow the user to select an
-      available screen (granting permission), or cancel the selection (denying
-      permission).
+      The details of implementing the permission request and display selection
+      are left to the user agent; for example it may show the user a dialog and
+      allow the user to select an available screen (granting permission), or
+      cancel the selection (denying permission).
     </p>
     <p class="open-issue">
       Do we want to distinguish the permission-denied outcome from the
@@ -1234,16 +1250,16 @@ interface PresentationSession : EventTarget {
       </li>
     </ol>
     <p class="note">
-      If <em>T</em> does not complete successfully, the user agent may choose
-      to re-execute the Presentation Connection algorithm at a later time.
+      The mechanism that is used to present on the remote display and connect
+      the opening document with the presented document is an implementation
+      choice of the user agent. The connection must provide a two-way messaging
+      abstraction capable of carrying <code>DOMString</code> payloads in a
+      reliable and in-order fashion as described in the <em>Send Message</em>
+      and <em>Receive Message</em> steps below.
     </p>
     <p class="note">
-      The mechanism that is used to connect the opening document with the
-      presented document is an implementation choice of the user agent. The
-      connection must provide a two-way messaging abstraction capable of
-      carrying <code>DOMString</code> payloads in a reliable and in-order
-      fashion as described in the <em>Send Message</em> and <em>Receive
-      Message</em> steps below.
+      If <em>T</em> does not complete successfully, the user agent may choose
+      to re-execute the Presentation Connection algorithm at a later time.
     </p>
     <p class="open-issue">
       Do we want to notify the caller of a failure to connect, i.e. with an


### PR DESCRIPTION
Update @mfoltzgoogle 's pull request in the following ways:

* Rebased on top of w3c/presentation-api
* Added terminology items and references to respective external specs, highlighted usage of these terms in the algorithms seciton.
* Added a step in the Start Session section to bring up a browsing context and display the page on the presentation display.
* Rephrased and compacted availability monitoring section, trying to incorporate @mfoltzgoogle and @tidoust 's suggestions.
* Added step to trigger availability monitoring in the Start Session algorithm
