### PR TITLE
Addressing Anssi's feedback, expanding the noted items

### DIFF
--- a/Overview.src.html
+++ b/Overview.src.html
@@ -65,6 +65,11 @@
     }
 
     code { color: orangered; }
+    .XXX { background: white; border: solid #78AB46; padding: 0.5em; margin: 1em 0; }
+    table { border-collapse: collapse; border-style: hidden hidden none hidden; }
+    table thead, table tbody { border-bottom: solid; }
+    table td, table th { border-left: solid; border-right: solid; border-bottom: solid thin; vertical-align: top; padding: 0.2em; }
+    dfn { font-weight: bolder; font-style: normal; }
     </style>
   </head>
   <body>
@@ -255,7 +260,7 @@
       devices through any of the above means.
     </p>
     <h3 id="use-cases">
-      Use Cases
+      Use cases
     </h3>
     <h4>
       Presentations
@@ -275,7 +280,7 @@
       <b>Requirements:</b> R1, R3, R4, R5, R7
     </p>
     <h4>
-      <a id="video-sharing">Video and Image Sharing</a>
+      <a id="video-sharing">Video and image sharing</a>
     </h4>
     <p>
       Using an online video or image sharing service, a user would like to show
@@ -306,7 +311,7 @@
       <b>Requirements:</b> R1, R3, R4, R5, R7
     </p>
     <h4>
-      Media Flinging to Multiple Screens
+      Media flinging to multiple screens
     </h4>Alice enters a video sharing site using a browser on her tablet. Next,
     Alice picks her favorite video from the site, and the video starts to play
     on her tablet. While the video is playing Alice clicks a button "Share on
@@ -332,7 +337,7 @@
       Requirements
     </h2>
     <h3>
-      Functional Requirements
+      Functional requirements
     </h3>
     <ul>
       <li>
@@ -394,7 +399,7 @@
       </li>
     </ul>
     <h3>
-      <span id="Non-Functional_Requirements">Non-Functional Requirements</span>
+      <span id="non-functional_requirements">Non-functional requirements</span>
     </h3>
     <ul>
       <li>
@@ -440,12 +445,6 @@
     <h2>
       Terminology
     </h2>
-    <p>
-      The term <dfn title="presentation display">presentation display</dfn>
-      refers to an external screen available to the opening user agent via an
-      implementation specific connection technology and compatible with the
-      Presentation API for the display content on it.
-    </p>
     <p>
       The terms <span data-anolis-spec="w3c-html">browsing context</span>,
       <span data-anolis-spec="w3c-html">event handlers</span>, <span title=
@@ -570,7 +569,7 @@ function setSession(theSession) {
     <p class="open-issue">
       Do we want to fire an event immediately after the page registers for it?
       What's a best practice method for asynchronous notifications of this
-      kind? See below in the <a href="#open-questions">Open Questions</a>
+      kind? See below in the <a href="#open-questions">Open questions</a>
       section.
     </p>
     <p class="open-issue">
@@ -634,7 +633,7 @@ function setSession(theSession) {
       presentation page will also have access to
       <code>PresentationSession</code> that it can use to send and receive
       messages with the opener page (see <a href=
-      "#usage-on-remote-screen">Usage on Remote Screen</a>).
+      "#usage-on-remote-screen">Usage on remote screen</a>).
     </p>
     <p>
       If the user cancels screen selection, the <code>Promise</code> returned
@@ -695,7 +694,7 @@ function setSession(theSession) {
       the <code>Promise</code> from <code>joinSession</code> will not.
     </p>
     <h4>
-      Open Questions
+      Open questions
     </h4>
     <p class="open-issue">
       Do we need to insert into the description an additional permission prompt
@@ -719,7 +718,7 @@ function setSession(theSession) {
       <code>"new"</code> or <code>"resumed"</code>.
     </p>
     <h3>
-      Usage on Remote Screen
+      Usage on remote screen
     </h3>
     <p>
       For addressing the requirement of communication between originating page
@@ -768,170 +767,166 @@ if (navigator.presentation.session) {
       is communicated to the presentation page (if at all).
     </p>
     <h2>
-      Interfaces
+      APIs for interacting with presentation sessions
     </h2>
     <h3>
-      <code>NavigatorPresentation</code>
-    </h3>
-    <pre class="idl">
-interface NavigatorPresentation : EventTarget {
-  readonly attribute PresentationSession? session;
-  Promise&lt;PresentationSession&gt; startSession(DOMString url, DOMString? presentationId);
-  Promise&lt;PresentationSession&gt; joinSession(DOMString url, DOMString? presentationId);
-  attribute EventHandler onavailablechange;
-};
-
-partial interface Navigator {
-  readonly attribute NavigatorPresentation presentation;
-};
-</pre>
-    <h3>
-      <code>AvailableChangeEvent</code>
+      Introduction
     </h3>
     <p>
-      Fired at the primary screen's <code>NavigatorPresentation</code> object,
-      when screen availability changes.
+      A <dfn title="presentation display">presentation display</dfn> refers to
+      an external screen available to the user agent via an implementation
+      specific connection technology.
     </p>
-    <pre class="idl">
-[Constructor(DOMString type, optional AvailableChangeEventInit eventInitDict)]
-interface AvailableChangeEvent : Event {
-  readonly attribute boolean available;
-};
-
-dictionary AvailableChangeEventInit : EventInit {
-  boolean available;
-};
-</pre>
-    <h3>
-      <code>PresentationSession</code>
-    </h3>
-    <p>
-      An object representing the established presentation session.
-    </p>
-    <pre class="idl">
-enum PresentationSessionState { "connected", "disconnected" /*, "resumed" */ };
-
-interface PresentationSession : EventTarget {
-  readonly DOMString? id;
-  readonly attribute PresentationSessionState state;
-  void postMessage(DOMString message);
-  void close();
-  attribute EventHandler onmessage;
-  attribute EventHandler onstatechange;
-};
-</pre>
-    <h2>
-      Algorithms
-    </h2>
-    <p>
-      These algorithms define the behavior of the
-      <code>NavigatorPresentation</code> and <code>PresentationSession</code>
-      interfaces declared in the <a href="#interfaces">Interfaces</a> section.
-    </p>
-    <p>
-      Let <em>D</em> be the set of presentations that are currently known to
-      the user agent (regardles of their state). <em>D</em> is represented as a
-      set of tuples <em>(U, I, S)</em> where <em>U</em> is the URL that is
-      being presented; <em>I</em> is an alphanumeric identifier for the
-      presentation; and <em>S</em> is the user agent's
-      <code>PresentationSession</code> for the presentation. <em>U</em> and
-      <em>I</em> together uniquely identify the
-      <code>PresentationSession</code> of the corresponding presentation.
-    </p>
-    <p>
-      Let <a id="availabledisplays"><em>availableDisplays</em></a> be the list
-      of available <a href="presentation-display">presentation displays</a>
-      that are currently known to the user agent.
+    <p class="XXX">
+      A <dfn title="concept-presentation-session">presentation session</dfn> is
+      ... and its relationship to a <span>presentation display</span> is ...
+      Each <span>presentation session</span> has a <dfn>presentation session
+      identifier</dfn> and a <dfn>presentation session state</dfn>.
     </p>
     <h3>
-      Presentation Display Availability
+      Interface <code>PresentationSession</code>
     </h3>
-    <h4>
-      Availability Listener Added
-    </h4>
     <p>
-      When a new <span data-anolis-spec="w3c-html" title="event handlers">event
-      handler</span> <em>E</em> is added to
-      <code>NavigatorPresentation.onavailablechange</code>, the user agent must
-      run the <a href="monitor-availability-algorithm">algorithm to monitor
-      availability</a>.
+      Each <span title="concept-presentation-session">presentation
+      session</span> is represented by a <code>PresentationSession</code>
+      object.
     </p>
-    <p class="note">
-      The mechanism used to monitor <a href="#presentation-display">presention
-      displays</a> availability is left to the user agent. The user agent may
-      choose search for screens at any time, not just when event handlers are
-      added to <code>NavigatorPresentation.onavailablechange</code>.
+    <pre class="idl">
+enum <dfn>PresentationSessionState</dfn> { "connected", "disconnected" /*, "resumed" */ };
+
+interface <dfn>PresentationSession</dfn> : EventTarget {
+  readonly DOMString? <span>id</span>;
+  readonly attribute <span>PresentationSessionState</span> <span>state</span>;
+  void <span>postMessage</span>(DOMString message);
+  void <span>close</span>();
+  attribute <span data-anolis-spec=
+"w3c-html">EventHandler</span> <span>onmessage</span>;
+  attribute <span data-anolis-spec=
+"w3c-html">EventHandler</span> <span>onstatechange</span>;
+};
+</pre>
+    <p class="XXX">
+      The <dfn><code>id</code></dfn> attribute, on getting, must return the
+      <span>presentation session identifier</span>.
     </p>
-    <p class="open-issue">
-      Do we want to fire the event at all handlers, or only the newly added
-      one?
+    <p class="XXX">
+      The <dfn><code>state</code></dfn> attribute represents the
+      <span>presentation session</span>'s current state. On getting, it must
+      return one of the following values: ...
     </p>
-    <h4>
-      Availability Listener Removed
-    </h4>
+    <p class="XXX">
+      The <dfn><code>postMessage</code></dfn>() method, when invoked on a
+      <code>PresentationSesssion</code> object with an argument message, must
+      ...
+    </p>
     <p>
-      When the last <span data-anolis-spec="w3c-html" title=
-      "event handlers">event handler</span> is removed from
-      <code>NavigatorPresentation.onavailablechange</code>, the user agent may
-      run the following steps:
-    </p>
-    <ol>
-      <li>Cancel the <a href="monitor-availability-algorithm">algorithm to
-      monitor availability change.</a>
-      </li>
-    </ol>
-    <h4 id="monitor-availability-algorithm">
-      Algorithm to Monitor Presentation Display Availability Change
-    </h4>
-    <p>
-      While there are <span data-anolis-spec="w3c-html">event handlers</span>
-      added to NavigatorPresentation.onavailablechange, the user agent must
-      continuously keep track of the available <a href=
-      "#presentation-display">presentation displays</a> and repeat the
+      When the <dfn><code>close</code></dfn>() method is called on a
+      <code>PresentationSession</code> <em>S</em>, the user agent must run the
       following steps:
     </p>
     <ol>
-      <li>
-        <span data-anolis-spec="w3c-html">Queue a task</span> to retrieve the
-        the list of curently available <a href=
-        "#presentation-display">presentation displays</a> and let <a id=
-        "newdisplays"><em>newDisplays</em></a> be this list.
-      </li>
-      <li>Wait for the completion of that task.
-      </li>
-      <li>If <a href="#availabledisplays">availableDisplays</a> is empty and
-      <a href="#newdisplays">newDisplays</a> is not empty, then
+      <li>If <em>S.state</em> is not <code>connected</code>, then:
         <ol>
-          <li>
-            <span data-anolis-spec="w3c-html">Queue a task</span> to
-            <span data-anolis-spec="w3c-html" title="concept-event-fire">fire
-            an event</span> named <code>availablechange</code> at <em>E</em>
-            (and only <em>E</em>) with the event's <code>available</code>
-            property set to <code>true</code>.
+          <li>Abort these steps.
           </li>
         </ol>
       </li>
-      <li>If <a href="#availabledisplays">availableDisplays</a> is not empty
-      and <a href="#newdisplays">newDisplays</a> is empty, then:
-        <div style="margin-left: 2em">
-          <span data-anolis-spec="w3c-html">Queue a task</span> to
-          <span data-anolis-spec="w3c-html" title="concept-event-fire">fire an
-          event</span> named <code>availablechange</code> at <em>E</em> (and
-          only <em>E</em>) with the event's <code>available</code> property set
-          to <code>false</code>.
-        </div>
+      <li>Set <em>S.state</em> to <code>disconnected</code>.
       </li>
-      <li>Set <a href="#availableDisplays">availableDisplays</a> to the value
-      of <a href="#newDisplays">newDisplays</a>.
+      <li>Let <em>D</em> be the set of presentations known by the user agent.
+      </li>
+      <li>
+        <span data-anolis-spec="w3c-html">Queue a task</span> <em>T</em> to run
+        the following steps in order:
+        <ol>
+          <li>For each presentation <em>(U, I, S')</em> in <em>D</em>,
+            <ol>
+              <li>Let <em>u</em> equal <em>U</em>, <em>i</em> equal <em>I</em>,
+              and <em>s</em> equal <em>S'</em>.
+              </li>
+              <li>If <em>u</em> is equal to <em>S.url</em> and <em>i</em> is
+              equal to <em>S.id</em>, run the following steps:
+                <ol>
+                  <li>
+                    <span data-anolis-spec="w3c-html">Queue a task</span> to
+                    <span data-anolis-spec="w3c-html" title=
+                    "concept-event-fire">fire an event</span> named
+                    <code>statechange</code> at <em>s.onstatechange</em>.
+                  </li>
+                </ol>
+              </li>
+            </ol>
+          </li>
+        </ol>
       </li>
     </ol>
-    <h3>
-      Start Session
-    </h3>
     <p>
-      When <code>NavigatorPresentaton.startSession(presentationUrl,
+      The following are the event handlers (and their corresponding event
+      handler event types) that must be supported, as event handler IDL
+      attributes, by objects implementing the <code>PresentationSession</code>
+      interface:
+    </p>
+    <table>
+      <thead>
+        <tr>
+          <th>
+            Event handler
+          </th>
+          <th>
+            Event handler event type
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            <dfn><code>onmessage</code></dfn>
+          </td>
+          <td>
+            <code>message</code>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <dfn><code>onstatechange</code></dfn>
+          </td>
+          <td>
+            <code>statechange</code>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+    <h3>
+      Interface <code>NavigatorPresentation</code>
+    </h3>
+    <pre class="idl">
+partial interface <span data-anolis-spec="w3c-html">Navigator</span> {
+  readonly attribute <span>NavigatorPresentation</span> <span>presentation</span>;
+};
+</pre>
+    <p class="XXX">
+      The <dfn><code>presentation</code></dfn> attribute must return the
+      <code>NavigatorPresentation</code> object.
+    </p>
+    <pre class="idl">
+interface <dfn>NavigatorPresentation</dfn> : EventTarget {
+  readonly attribute <span>PresentationSession</span>? <span>session</span>;
+  Promise&lt;<span>PresentationSession</span>&gt; <span>startSession</span>(DOMString url, DOMString? presentationId);
+  Promise&lt;<span>PresentationSession</span>&gt; <span>joinSession</span>(DOMString url, DOMString? presentationId);
+  attribute <span data-anolis-spec=
+"w3c-html">EventHandler</span> <span>onavailablechange</span>;
+};
+</pre>
+    <p class="XXX">
+      On getting, the <dfn><code>session</code></dfn> attribute must return ...
+    </p>
+    <h4>
+      Starting a presentation session
+    </h4>
+    <p>
+      When <code><dfn>startSession</dfn>(presentationUrl,
       presentationId)</code> is called, the user agent must run the following
-      steps.
+      steps:
     </p>
     <dl>
       <dt>
@@ -959,11 +954,11 @@ interface PresentationSession : EventTarget {
       </li>
       <li>Return <em>P</em>.
       </li>
-      <li>If the user agent is currently not running the <a href=
-      "#monitor-availability-algorithm">presentation display availability
-      monitoring algorithm</a>:
+      <li>If the user agent does not <span>monitor presentation display
+      availability</span>, run the following steps:
         <ol>
-          <li>Start the algorithm.
+          <li>
+            <span>Monitor presentation display availability</span>.
           </li>
           <li>Wait until the algorithm completes.
           </li>
@@ -1019,9 +1014,9 @@ interface PresentationSession : EventTarget {
                         "resolve-reject">Resolve</span> <em>P</em> with
                         <em>S</em>.
                       </li>
-                      <li>Initiate the <a href=
-                      "#presentation-connection">Presentation Connection</a>
-                      algorithm for <em>S</em>.
+                      <li>
+                        <span>Establish a presentation connection</span> with
+                        <em>S</em>.
                       </li>
                     </ol>
                   </li>
@@ -1062,13 +1057,12 @@ interface PresentationSession : EventTarget {
       no-screens-available outcome? Developers would be able to infer it anyway
       from <code>onavailablechange</code>.
     </p>
-    <h3>
-      Join Session
-    </h3>
+    <h4>
+      Joining a presentation session
+    </h4>
     <p>
-      When <code>NavigatorPresentation.joinSession(presentationUrl,
-      presentationId)</code> is called, the user agent must run the following
-      steps:
+      When <code><dfn>joinSession</dfn>(presentationUrl, presentationId)</code>
+      is called, the user agent must run the following steps:
     </p>
     <dl>
       <dt>
@@ -1114,9 +1108,9 @@ interface PresentationSession : EventTarget {
                     <span data-anolis-spec="promguide" title=
                     "resolve-reject">Resolve</span> <em>P</em> with <em>S</em>.
                   </li>
-                  <li>Initiate the <a href=
-                  "#presentation-connection">Presentation Connection</a>
-                  algorithm for <em>S</em>.
+                  <li>
+                    <span>Establish a presentation connection</span> with
+                    <em>S</em>.
                   </li>
                   <li>Abort the remaining steps of <em>T</em>.
                   </li>
@@ -1136,59 +1130,41 @@ interface PresentationSession : EventTarget {
       If no matching presentation is found, we could leave the Promise pending
       in case a matching presentation is started in the future.
     </p>
-    <h3>
-      Session Close
-    </h3>
     <p>
-      When <code>PresentationSession.close()</code> is called on a
-      <code>PresentationSession</code> <em>S</em>, the user agent must run the
-      following steps:
+      <span>The following are the event handlers (and their corresponding event
+      handler event types) that must be supported, as event handler IDL
+      attributes, by objects implementing the <code>PresentationSession</code>
+      interface:</span>
     </p>
-    <ol>
-      <li>If <em>S.state</em> is not <code>connected</code>, then:
-        <ol>
-          <li>Abort these steps.
-          </li>
-        </ol>
-      </li>
-      <li>Set <em>S.state</em> to <code>disconnected</code>.
-      </li>
-      <li>Let <em>D</em> be the set of presentations known by the user agent.
-      </li>
-      <li>
-        <span data-anolis-spec="w3c-html">Queue a task</span> <em>T</em> to run
-        the following steps in order:
-        <ol>
-          <li>For each presentation <em>(U, I, S')</em> in <em>D</em>,
-            <ol>
-              <li>Let <em>u</em> equal <em>U</em>, <em>i</em> equal <em>I</em>,
-              and <em>s</em> equal <em>S'</em>.
-              </li>
-              <li>If <em>u</em> is equal to <em>S.url</em> and <em>i</em> is
-              equal to <em>S.id</em>, run the following steps:
-                <ol>
-                  <li>
-                    <span data-anolis-spec="w3c-html">Queue a task</span> to
-                    <span data-anolis-spec="w3c-html" title=
-                    "concept-event-fire">fire an event</span> named
-                    <code>statechange</code> at <em>s.onstatechange</em>.
-                  </li>
-                </ol>
-              </li>
-            </ol>
-          </li>
-        </ol>
-      </li>
-    </ol>
-    <h3>
-      Presentation Connection
-    </h3>
-    <p>
-      When the user agent has created a <code>PresentationSession</code>
-      <em>S</em> to resolve a promise returned from
-      <code>NavigatorPresentation.startSession</code>, or resolved a promise
-      returned from to <code>NavigatorPresentation.joinSession</code> with
-      <em>S</em>, it must run the following steps:
+    <table>
+      <thead>
+        <tr>
+          <th>
+            Event handler
+          </th>
+          <th>
+            Event handler event type
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            <dfn><code>onavailablechange</code></dfn>
+          </td>
+          <td>
+            <code>availablechange</code>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+    <h4>
+      Establishing a presentation connection
+    </h4>
+    <p class="XXX">
+      When the user agent is to <dfn>establish a presentation connection</dfn>
+      using a <span>presentation session</span> <em>S</em>, it must run the
+      following steps:
     </p>
     <ol>
       <li>If <em>S.state</em> is <code>connected</code>, then:
@@ -1256,6 +1232,137 @@ interface PresentationSession : EventTarget {
       Need to further specify the semantics of the messaging channel (using
       WebSockets or MessagePort as a reference).
     </p>
+    <h3>
+      <span>Interface <code>AvailableChangeEvent</code></span>
+    </h3>
+    <pre class="idl">
+<span>[Constructor(DOMString type, optional <span>AvailableChangeEventInit</span> eventInitDict)]
+interface <dfn>AvailableChangeEvent</dfn> : Event {
+  readonly attribute boolean available;
+};
+
+dictionary <dfn>AvailableChangeEventInit</dfn> : EventInit {
+  boolean available;
+};
+</span>
+</pre>
+    <p class="XXX">
+      When the <dfn>presentation display availability</dfn> changes, the user
+      agent must fire an event with the name <code>availablechange</code> at
+      the <span><code>PresentationSession</code></span> object, using the
+      <code>AvailableChangeEvent</code> interface, with the
+      <code>available</code> attribute initialized to ...
+    </p>
+    <h4>
+      Monitoring presentation display availability
+    </h4>
+    <p class="XXX">
+      Each <code>Document</code> object must have a <dfn>list of available
+      presentation displays</dfn>. Each display in this list is identified by a
+      tuple (U, I, S) as follows:
+    </p>
+    <p>
+      Let <em>D</em> be the set of presentations that are currently known to
+      the user agent (regardles of their state). <em>D</em> is represented as a
+      set of tuples <em>(U, I, S)</em> where <em>U</em> is the URL that is
+      being presented; <em>I</em> is an alphanumeric identifier for the
+      presentation; and <em>S</em> is the user agent's
+      <code>PresentationSession</code> for the presentation. <em>U</em> and
+      <em>I</em> together uniquely identify the
+      <code>PresentationSession</code> of the corresponding presentation.
+    </p>
+    <p class="XXX">
+      When the user agent is to <dfn>update the list of available presentation
+      displays</dfn>, it must run the following steps:
+    </p>
+    <ol>
+      <li>Let <a id="availabledisplays"><em>availableDisplays</em></a> be the
+      <span>list of available presentation displays</span> that are currently
+      known to the user agent.
+      </li>
+    </ol>
+    <p class="XXX">
+      When the user agent is to <dfn>start monitoring for changes to
+      presentation display availability</dfn>, it must run the following steps:
+    </p>
+    <p>
+      When a new <span data-anolis-spec="w3c-html" title="event handlers">event
+      handler</span> <em>E</em> is added to
+      <code><span>NavigatorPresentation</span>.onavailablechange</code>, the
+      user agent must run the <a href=
+      "monitor-availability-algorithm">algorithm to monitor availability</a>.
+    </p>
+    <p class="note">
+      The mechanism used to monitor <a href="#presentation-display">presention
+      displays</a> availability is left to the user agent. The user agent may
+      choose search for screens at any time, not just when event handlers are
+      added to <code>NavigatorPresentation.onavailablechange</code>.
+    </p>
+    <p class="open-issue">
+      Do we want to fire the event at all handlers, or only the newly added
+      one?
+    </p>
+    <p class="XXX">
+      When the user agent is to <dfn>stop monitoring for changes to
+      presentation display availability</dfn>, it must run the following steps:
+    </p>
+    <p>
+      When the last <span data-anolis-spec="w3c-html" title=
+      "event handlers">event handler</span> is removed from
+      <code>NavigatorPresentation.onavailablechange</code>, the user agent may
+      run the following steps:
+    </p>
+    <ol>
+      <li>Cancel the <a href="monitor-availability-algorithm">algorithm to
+      monitor availability change.</a>
+      </li>
+    </ol>
+    <p class="XXX">
+      When the user agent is required to <dfn>monitor presentation display
+      availability</dfn>, it must run the following steps ...
+    </p>
+    <p>
+      While there are <span data-anolis-spec="w3c-html">event handlers</span>
+      added to NavigatorPresentation.onavailablechange, the user agent must
+      continuously keep track of the available <a href=
+      "#presentation-display">presentation displays</a> and repeat the
+      following steps:
+    </p>
+    <ol>
+      <li>
+        <span data-anolis-spec="w3c-html">Queue a task</span> to retrieve the
+        the list of curently available <a href=
+        "#presentation-display">presentation displays</a> and let <a id=
+        "newdisplays"><em>newDisplays</em></a> be this list.
+      </li>
+      <li>Wait for the completion of that task.
+      </li>
+      <li>If <a href="#availabledisplays">availableDisplays</a> is empty and
+      <a href="#newdisplays">newDisplays</a> is not empty, then
+        <ol>
+          <li>
+            <span data-anolis-spec="w3c-html">Queue a task</span> to
+            <span data-anolis-spec="w3c-html" title="concept-event-fire">fire
+            an event</span> named <code>availablechange</code> at <em>E</em>
+            (and only <em>E</em>) with the event's <code>available</code>
+            property set to <code>true</code>.
+          </li>
+        </ol>
+      </li>
+      <li>If <a href="#availabledisplays">availableDisplays</a> is not empty
+      and <a href="#newdisplays">newDisplays</a> is empty, then:
+        <div style="margin-left: 2em">
+          <span data-anolis-spec="w3c-html">Queue a task</span> to
+          <span data-anolis-spec="w3c-html" title="concept-event-fire">fire an
+          event</span> named <code>availablechange</code> at <em>E</em> (and
+          only <em>E</em>) with the event's <code>available</code> property set
+          to <code>false</code>.
+        </div>
+      </li>
+      <li>Set <a href="#availableDisplays">availableDisplays</a> to the value
+      of <a href="#newDisplays">newDisplays</a>.
+      </li>
+    </ol>
     <h3>
       TODO
     </h3>

--- a/Overview.src.html
+++ b/Overview.src.html
@@ -777,7 +777,7 @@ if (navigator.presentation.session) {
       API
     </h2>
     <h3>
-      Common Idioms
+      Common idioms
     </h3>
     <p>
       A <dfn>presentation display</dfn> refers to an external screen available
@@ -805,7 +805,7 @@ if (navigator.presentation.session) {
       sessions</span> are initiated.
     </p>
     <h3>
-      Common Definitions
+      Common definitions
     </h3>
     <p>
       Let <em>D</em> be the set of presentations that are currently known to

--- a/Overview.src.html
+++ b/Overview.src.html
@@ -770,11 +770,17 @@ if (navigator.presentation.session) {
       API
     </h2>
     <h3>
-      Common idioms
+      Common Idioms
     </h3>
     <p>
       A <dfn>presentation display</dfn> refers to an external screen available
       to the user agent via an implementation specific connection technology.
+    </p>
+    <p>
+      A <dfn title="concept-presentation">presentation</dfn>, in the context of
+      this specification, is an active connection between a user agent and a
+      <span>presentation display</span> with the intent of displaying web
+      content on the latter.
     </p>
     <p>
       A <dfn title="concept-presentation-session">presentation session</dfn> is
@@ -814,8 +820,8 @@ interface <dfn>PresentationSession</dfn> : EventTarget {
 };
 </pre>
     <p>
-      The <dfn><code>id</code></dfn> attribute holds the <span>presentation
-      session identifier</span>.
+      The <dfn><code>id</code></dfn> attribute holds the alphanumeric
+      <span>presentation session identifier</span>.
     </p>
     <p>
       The <dfn><code>state</code></dfn> attribute represents the
@@ -1338,11 +1344,11 @@ dictionary <dfn>AvailableChangeEventInit</dfn> : EventInit {
     </p><a href="monitor-availability-algorithm">algorithm to monitor
     availability</a>.
     <p class="note">
-      The mechanism used to monitor
-    </p><a href="#presentation-display">presention displays</a> availability is
-    left to the user agent. The user agent may choose search for screens at any
-    time, not just when event handlers are added to
-    <code>NavigatorPresentation.onavailablechange</code>.
+      The mechanism used to monitor <a href="#presentation-display">presention
+      displays</a> availability is left to the user agent. The user agent may
+      choose search for screens at any time, not just when event handlers are
+      added to <code>NavigatorPresentation.onavailablechange</code>.
+    </p>
     <p class="open-issue">
       Do we want to fire the event at all handlers, or only the newly added
       one?

--- a/Overview.src.html
+++ b/Overview.src.html
@@ -65,7 +65,6 @@
     }
 
     code { color: orangered; }
-    .XXX { background: white; border: solid #78AB46; padding: 0.5em; margin: 1em 0; }
     table { border-collapse: collapse; border-style: hidden hidden none hidden; }
     table thead, table tbody { border-bottom: solid; }
     table td, table th { border-left: solid; border-right: solid; border-bottom: solid thin; vertical-align: top; padding: 0.2em; }

--- a/Overview.src.html
+++ b/Overview.src.html
@@ -971,6 +971,19 @@ interface <dfn>NavigatorPresentation</dfn> : EventTarget {
       and it's not compatible with multiple calls to startSession, for example.
     </p>
     <h4>
+      Common Definitions for this Section
+    </h4>
+    <p>
+      Let <em>D</em> be the set of presentations that are currently known to
+      the user agent (regardles of their state). <em>D</em> is represented as a
+      set of tuples <em>(U, I, S)</em> where <em>U</em> is the
+      <span data-anolis-spec="url">URL</span> that is being presented;
+      <em>I</em> is an alphanumeric identifier for the presentation; and
+      <em>S</em> is the user agent's <code>PresentationSession</code> for the
+      presentation. <em>U</em> and <em>I</em> together uniquely identify the
+      <code>PresentationSession</code> of the corresponding presentation.
+    </p>
+    <h4>
       Starting a presentation session
     </h4>
     <p>
@@ -1183,7 +1196,7 @@ interface <dfn>NavigatorPresentation</dfn> : EventTarget {
     <h4>
       Establishing a presentation connection
     </h4>
-    <p class="XXX">
+    <p>
       When the user agent is to <dfn>establish a presentation connection</dfn>
       using a <span>presentation session</span> <em>S</em>, it must run the
       following steps:
@@ -1296,20 +1309,43 @@ interface <dfn>NavigatorPresentation</dfn> : EventTarget {
       registered <code>EventHandler</code>s, is described.
     </p>
     <h5>
-      Updating the list of available presentation displays
+      Adding an <code>EventHandler</code> to <code>onavailablechange</code>
+    </h5>
+    <p>
+      When an event handler is added to the list of event handlers subscribed
+      to the <code>onavailablechange</code> event, the user agent must run the
+      <span title="algorithm-monitor-available">algorithm to monitor the list
+      of available presentation displays</span>.
+    </p>
+    <h5>
+      Removing an <code>EventHandler</code>
+    </h5>
+    <p>
+      When an event handler is removed from the list of event handlers
+      subscribed to the <code>onavailablechange</code> event, the user agent
+      must run the following steps:
+    </p>
+    <ol>
+      <li>If the removed event handler was the last one in the list,
+      <span>cancel monitoring the list of available presentation
+      displays</span>.
+      </li>
+    </ol>
+    <h5>
+      Monitoring the list of available presentation displays
     </h5>
     <p>
       The user agent must maintain a <dfn>list of available presentation
       displays</dfn>. When the user agent is to <dfn title=
-      "algorithm-update-available">update the list of available presentation
+      "algorithm-monitor-available">monitor the list of available presentation
       displays</dfn>, it must run the following steps:
     </p>
     <p>
       While there are <span data-anolis-spec="w3c-html">event handlers</span>
       added to NavigatorPresentation.onavailablechange, the user agent must
-      continuously keep track of the available
-    </p><a href="#presentation-display">presentation displays</a> and repeat
-    the following steps:
+      continuously keep track the <span>list of available presentation
+      displays</span> and repeat the following steps:
+    </p>
     <ol>
       <li>
         <span data-anolis-spec="w3c-html">Queue a task</span> to retrieve the
@@ -1325,86 +1361,55 @@ interface <dfn>NavigatorPresentation</dfn> : EventTarget {
           <li>
             <span data-anolis-spec="w3c-html">Queue a task</span> to
             <span data-anolis-spec="w3c-html" title="concept-event-fire">fire
-            an event</span> named <code>availablechange</code> at <em>E</em>
-            (and only <em>E</em>) with the event's <code>available</code>
-            property set to <code>true</code>.
+            an event</span> named <code>availablechange</code> at with the
+            event's <code>available</code> property set to <code>true</code>.
           </li>
         </ol>
       </li>
       <li>If <a href="#availabledisplays">availableDisplays</a> is not empty
       and <a href="#newdisplays">newDisplays</a> is empty, then:
-        <div style="margin-left: 2em">
-          <span data-anolis-spec="w3c-html">Queue a task</span> to
-          <span data-anolis-spec="w3c-html" title="concept-event-fire">fire an
-          event</span> named <code>availablechange</code> at <em>E</em> (and
-          only <em>E</em>) with the event's <code>available</code> property set
-          to <code>false</code>.
-        </div>
+        <ol>
+          <li>
+            <span data-anolis-spec="w3c-html">Queue a task</span> to
+            <span data-anolis-spec="w3c-html" title="concept-event-fire">fire
+            an event</span> named <code>availablechange</code> with the event's
+            <code>available</code> property set to <code>false</code>.
+          </li>
+        </ol>
       </li>
-      <li>Set <a href="#availableDisplays">availableDisplays</a> to the value
-      of <a href="#newDisplays">newDisplays</a>.
-      </li>
-    </ol>
-    <p>
-      Let <em>D</em> be the set of presentations that are currently known to
-      the user agent (regardles of their state). <em>D</em> is represented as a
-      set of tuples <em>(U, I, S)</em> where <em>U</em> is the URL that is
-      being presented; <em>I</em> is an alphanumeric identifier for the
-      presentation; and <em>S</em> is the user agent's
-      <code>PresentationSession</code> for the presentation. <em>U</em> and
-      <em>I</em> together uniquely identify the
-      <code>PresentationSession</code> of the corresponding presentation.
-    </p>
-    <p class="XXX">
-      When the user agent is to <dfn>update the list of available presentation
-      displays</dfn>, it must run the following steps:
-    </p>
-    <ol>
-      <li>Let <a id="availabledisplays"><em>availableDisplays</em></a> be the
-      <span>list of available presentation displays</span> that are currently
-      known to the user agent.
+      <li>Set the <span>list of available presentation displays</span> to the
+      value of <a href="#newDisplays">newDisplays</a>.
       </li>
     </ol>
-    <p class="XXX">
-      When the user agent is to <dfn>start monitoring for changes to
-      presentation display availability</dfn>, it must run the following steps:
+    <p class="open-issue">
+      Do we want to fire the event at all handlers, or only the newly added
+      one?
     </p>
-    <p>
-      When a new <span data-anolis-spec="w3c-html" title="event handlers">event
-      handler</span> <em>E</em> is added to
-      <code><span>NavigatorPresentation</span>.onavailablechange</code>, the
-      user agent must run the
-    </p><a href="monitor-availability-algorithm">algorithm to monitor
-    availability</a>.
     <p class="note">
       The mechanism used to monitor <a href="#presentation-display">presention
       displays</a> availability is left to the user agent. The user agent may
       choose search for screens at any time, not just when event handlers are
       added to <code>NavigatorPresentation.onavailablechange</code>.
     </p>
-    <p class="open-issue">
-      Do we want to fire the event at all handlers, or only the newly added
-      one?
-    </p>
-    <p class="XXX">
-      When the user agent is to <dfn>stop monitoring for changes to
-      presentation display availability</dfn>, it must run the following steps:
-    </p>
     <p>
-      When the last <span data-anolis-spec="w3c-html" title=
-      "event handlers">event handler</span> is removed from
-      <code>NavigatorPresentation.onavailablechange</code>, the user agent may
-      run the following steps:
+      When the user agent is to <dfn>cancel monitoring the list of available
+      presentation displays</dfn>, it must run the following steps:
     </p>
     <ol>
-      <li>Cancel the <a href="monitor-availability-algorithm">algorithm to
-      monitor availability change.</a>
+      <li>Cancel any tasks to retrieve the list of available <span title=
+      "presentation display">presentation displays</span>.
+      </li>
+      <li>Set the <span>list of available presentation displays</span> to
+      empty.
+      </li>
+      <li>
+        <span data-anolis-spec="w3c-html">Queue a task</span> to
+        <span data-anolis-spec="w3c-html" title="concept-event-fire">fire an
+        event</span> named <code>availablechange</code> at <em>E</em> (and only
+        <em>E</em>) with the event's <code>available</code> property set to
+        <code>false</code>.
       </li>
     </ol>
-    <p class="XXX">
-      When the user agent is required to <dfn>monitor presentation display
-      availability</dfn>, it must run the following steps ...
-    </p>
     <h3>
       <span>Interface <code>AvailableChangeEvent</code></span>
     </h3>

--- a/Overview.src.html
+++ b/Overview.src.html
@@ -1312,8 +1312,8 @@ interface <dfn>NavigatorPresentation</dfn> : EventTarget {
       Adding an <code>EventHandler</code> to <code>onavailablechange</code>
     </h5>
     <p>
-      When an event handler is added to the list of event handlers subscribed
-      to the <code>onavailablechange</code> event, the user agent must run the
+      When an event handler is added to the list of event handlers registered
+      for the <code>onavailablechange</code> event, the user agent must run the
       <span title="algorithm-monitor-available">algorithm to monitor the list
       of available presentation displays</span>.
     </p>
@@ -1322,7 +1322,7 @@ interface <dfn>NavigatorPresentation</dfn> : EventTarget {
     </h5>
     <p>
       When an event handler is removed from the list of event handlers
-      subscribed to the <code>onavailablechange</code> event, the user agent
+      registered to the <code>onavailablechange</code> event, the user agent
       must run the following steps:
     </p>
     <ol>

--- a/Overview.src.html
+++ b/Overview.src.html
@@ -612,28 +612,30 @@ function setSession(theSession) {
     <p>
       If the user selects a screen with an existing presentation showing the
       same <code>url</code> under the same <code>presentationId</code>, the
-      opener page is connected to that existing presentation. If the user
-      selects a screen without an existing presentation, or a screen presenting
-      a different <code>url</code> or <code>presentationId</code>, the UA
-      connects to the selected screen, brings up a new presentation window on
-      it, and starts to show the content denoted by the <code>url</code>
-      argument. The UA then connects the opener page to this new presentation
-      and allows the opener page to exchange messages with it.
+      <span>opening browsing context</span> is connected to that existing
+      presentation. If the user selects a screen without an existing
+      presentation, or a screen presenting a different <code>url</code> or
+      <code>presentationId</code>, the UA connects to the selected screen,
+      brings up a new presentation window on it, and starts to show the content
+      denoted by the <code>url</code> argument. The UA then connects the
+      <span>opening browsing context</span> to this new presentation and allows
+      the <span>opening browsing context</span> to exchange messages with it.
     </p>
     <p>
       <code>navigator.presentation.startSession(url, presentationId)</code>
-      returns a <code>Promise</code> to the opener page. When the user selects
-      a screen, the presentation page is shown and a communication channel has
-      been established the <code>Promise</code> resolves to a
-      <code>PresentationSession</code> object, which acts as a handle to the
-      presentation for communication and state handling. Initially, the state
-      of the <code>PresentationSession</code> is <code>"connected"</code>. At
-      this point, the opener page can communicate with the presentation page
-      using the session's <code>postMessage()</code> to send messages and its
-      <code>onmessage</code> event handler to receive messages. The
-      presentation page will also have access to
+      returns a <code>Promise</code> to the <span>opening browsing
+      context</span>. When the user selects a screen, the presentation page is
+      shown and a communication channel has been established the
+      <code>Promise</code> resolves to a <code>PresentationSession</code>
+      object, which acts as a handle to the presentation for communication and
+      state handling. Initially, the state of the
+      <code>PresentationSession</code> is <code>"connected"</code>. At this
+      point, the <span>opening browsing context</span> can communicate with the
+      presentation page using the session's <code>postMessage()</code> to send
+      messages and its <code>onmessage</code> event handler to receive
+      messages. The presentation page will also have access to
       <code>PresentationSession</code> that it can use to send and receive
-      messages with the opener page (see <a href=
+      messages with the <span>opening browsing context</span> (see <a href=
       "#usage-on-remote-screen">Usage on remote screen</a>).
     </p>
     <p>
@@ -652,18 +654,19 @@ function setSession(theSession) {
       Automatically reconnecting to existing presentations
     </h4>
     <p>
-      The opener page may wish to reconnect to an existing presentation without
-      prompting the user to select a screen. For example, the site could allow
-      media items from different pages to be shown on the same presentation
-      page, and does not want to prompt the user on each page to reconnect to
-      that presentation. To reconnect automatically, the page may call
-      <code>joinSession(url, presentationId)</code>, which returns a
-      <code>Promise</code> that resolves to an existing
-      <code>PresentationSession</code> if one exists that is presenting the
-      same <code>url</code> with the same <code>presentationId</code> as was
-      passed originally into <code>startSession</code>. The requesting page can
-      then communicate with the presentation as if the user had manually
-      connected to it via <code>startSession</code>.
+      The <span>opening browsing context</span> may wish to reconnect to an
+      existing presentation without prompting the user to select a screen. For
+      example, the site could allow media items from different pages to be
+      shown on the same presentation page, and does not want to prompt the user
+      on each page to reconnect to that presentation. To reconnect
+      automatically, the page may call <code>joinSession(url,
+      presentationId)</code>, which returns a <code>Promise</code> that
+      resolves to an existing <code>PresentationSession</code> if one exists
+      that is presenting the same <code>url</code> with the same
+      <code>presentationId</code> as was passed originally into
+      <code>startSession</code>. The requesting page can then communicate with
+      the presentation as if the user had manually connected to it via
+      <code>startSession</code>.
     </p>
     <p>
       At the time <code>joinSession(url, presentationId)</code> is called, if
@@ -715,8 +718,8 @@ function setSession(theSession) {
     <p class="open-issue">
       Do we need an additional state like resumed in order to identify resumed
       session? It seems that this could be handled on the page level. The
-      opener page could ask the presentation page whether it is
-      <code>"new"</code> or <code>"resumed"</code>.
+      <span>opening browsing context</span> could ask the presentation page
+      whether it is <code>"new"</code> or <code>"resumed"</code>.
     </p>
     <h3>
       Usage on remote screen
@@ -731,14 +734,14 @@ function setSession(theSession) {
     <pre class="example">
 if (navigator.presentation.session) {
   var session = navigator.presentation.session;
-  // Communicate with opener page.
+  // Communicate with opening browsing context
   session.postMessage(/*...*/);
   session.onmessage = function() {/*...*/};
 
   session.onstatechange = function() {
     switch (this.state) {
       case "disconnected":
-        // Handle disconnection from opener page.
+        // Handle disconnection from opening browsing context
     }
   };
 };
@@ -750,22 +753,23 @@ if (navigator.presentation.session) {
       <code>navigator.presentation.session</code> property set to the session.
       This session is a similar object as in the first example. Here, its
       initial state is <code>"connected"</code>, which means we can use it to
-      communicate with the opener page using <code>postMessage()</code> and
-      <code>onmessage</code>.
+      communicate with the <span>opening browsing context</span> using
+      <code>postMessage()</code> and <code>onmessage</code>.
     </p>
     <p>
       The presentation page can also monitor the connection state by listening
       for <code>statechange</code> events. When the state changes to
       <code>"disconnected"</code> the page is made aware of the fact that
-      communication with the opener page was lost, but it can continue to
-      display the current content. The communication can be re-established when
-      a <code>statechange</code> event fires with a new state of
-      <code>"connected"</code>.
+      communication with the <span>opening browsing context</span> was lost,
+      but it can continue to display the current content. The communication can
+      be re-established when a <code>statechange</code> event fires with a new
+      state of <code>"connected"</code>.
     </p>
     <p class="open-issue">
-      Since we permit multiple opener pages to connect the same presentation
-      page, we need to define how connection and disconnection of these pages
-      is communicated to the presentation page (if at all).
+      Since we permit multiple <span title="opening-browsing-context">opening
+      browsing context</span> to connect the same presentation page, we need to
+      define how connection and disconnection of these pages is communicated to
+      the presentation page (if at all).
     </p>
     <h2>
       API
@@ -1246,11 +1250,11 @@ interface <dfn>NavigatorPresentation</dfn> : EventTarget {
     </ol>
     <p class="note">
       The mechanism that is used to present on the remote display and connect
-      the opening document with the presented document is an implementation
-      choice of the user agent. The connection must provide a two-way messaging
-      abstraction capable of carrying <code>DOMString</code> payloads in a
-      reliable and in-order fashion as described in the <em>Send Message</em>
-      and <em>Receive Message</em> steps below.
+      the <span>opening browsing context</span> with the presented document is
+      an implementation choice of the user agent. The connection must provide a
+      two-way messaging abstraction capable of carrying <code>DOMString</code>
+      payloads in a reliable and in-order fashion as described in the <em>Send
+      Message</em> and <em>Receive Message</em> steps below.
     </p>
     <p class="note">
       If <em>T</em> does not complete successfully, the user agent may choose

--- a/Overview.src.html
+++ b/Overview.src.html
@@ -69,6 +69,9 @@
     table thead, table tbody { border-bottom: solid; }
     table td, table th { border-left: solid; border-right: solid; border-bottom: solid thin; vertical-align: top; padding: 0.2em; }
     dfn { font-weight: bolder; font-style: normal; }
+
+    h2, h3 { padding-top: 1.3em; }
+    h4 { padding-top: 1.2em; }
     </style>
   </head>
   <body>
@@ -802,6 +805,19 @@ if (navigator.presentation.session) {
       sessions</span> are initiated.
     </p>
     <h3>
+      Common Definitions
+    </h3>
+    <p>
+      Let <em>D</em> be the set of presentations that are currently known to
+      the user agent (regardles of their state). <em>D</em> is represented as a
+      set of tuples <em>(U, I, S)</em> where <em>U</em> is the
+      <span data-anolis-spec="url">URL</span> that is being presented;
+      <em>I</em> is an alphanumeric identifier for the presentation; and
+      <em>S</em> is the user agent's <code>PresentationSession</code> for the
+      presentation. <em>U</em> and <em>I</em> together uniquely identify the
+      <code>PresentationSession</code> of the corresponding presentation.
+    </p>
+    <h3>
       Interface <code>PresentationSession</code>
     </h3>
     <p>
@@ -842,16 +858,15 @@ interface <dfn>PresentationSession</dfn> : EventTarget {
     </p>
     <p>
       When the <dfn><code>close</code></dfn>() method is called on a
-      <code>PresentationSession</code> <em>S</em>, the user agent must run the
-      algorithm to <span title="close-algorithm">close a presentation
-      session</span>.
+      <code>PresentationSession</code>, the user agent must run the algorithm
+      to <span title="close-algorithm">close a presentation session</span>.
     </p>
     <h4>
       Posting a message through <code>PresentationSession</code>
     </h4>
     <p>
       When the user agent is to <dfn title="algorithm-post-message">post a
-      message through a <code>PresentationSession</code> S</dfn>, it mus run
+      message through a <code>PresentationSession</code> S</dfn>, it must run
       the following steps:
     </p>
     <p class="open-issue">
@@ -972,19 +987,6 @@ interface <dfn>NavigatorPresentation</dfn> : EventTarget {
       <code>session</code> attribute? Do we want to keep it? It's somewhat hard
       to define, when it should contain a value, and when it should be empty -
       and it's not compatible with multiple calls to startSession, for example.
-    </p>
-    <h4>
-      Common Definitions for this Section
-    </h4>
-    <p>
-      Let <em>D</em> be the set of presentations that are currently known to
-      the user agent (regardles of their state). <em>D</em> is represented as a
-      set of tuples <em>(U, I, S)</em> where <em>U</em> is the
-      <span data-anolis-spec="url">URL</span> that is being presented;
-      <em>I</em> is an alphanumeric identifier for the presentation; and
-      <em>S</em> is the user agent's <code>PresentationSession</code> for the
-      presentation. <em>U</em> and <em>I</em> together uniquely identify the
-      <code>PresentationSession</code> of the corresponding presentation.
     </p>
     <h4>
       Starting a presentation session

--- a/Overview.src.html
+++ b/Overview.src.html
@@ -666,9 +666,9 @@ function setSession(theSession) {
       resolves to an existing <code>PresentationSession</code> if one exists
       that is presenting the same <code>url</code> with the same
       <code>presentationId</code> as was passed originally into
-      <code>startSession</code>. The requesting page can then communicate with
-      the presentation as if the user had manually connected to it via
-      <code>startSession</code>.
+      <code>startSession</code>. The <span>opening browsing context</span> can
+      then communicate with the presentation as if the user had manually
+      connected to it via <code>startSession</code>.
     </p>
     <p>
       At the time <code>joinSession(url, presentationId)</code> is called, if
@@ -784,25 +784,23 @@ if (navigator.presentation.session) {
       to the user agent via an implementation specific connection technology.
     </p>
     <p>
-      A <dfn title="concept-presentation">presentation</dfn>, in the context of
-      this specification, is an active connection between a user agent and a
-      <span>presentation display</span> with the intent of displaying web
-      content on the latter.
+      A <dfn title="concept-presentation">presentation</dfn>is an active
+      connection between a user agent and a <span>presentation display</span>
+      for displaying web content on the latter at the request of the former.
     </p>
     <p>
       A <dfn title="concept-presentation-session">presentation session</dfn> is
-      an object refering to the relationship between an <span>opening browsing
-      context</span> and a <span>presentation display</span> with a
-      <dfn>presentation session state</dfn> and a <dfn>presentation session
-      identifier</dfn> to distinguish a set of <span title=
-      "concept-presentation-session">presentation sessions</span>.
+      an object relating an <span>opening browsing context</span> to its
+      <span>presentation display</span> and enabling two-way-messaging between
+      them. Each such object has a <dfn>presentation session state</dfn> and a
+      <dfn>presentation session identifier</dfn> to distinguish it from other
+      <span title="concept-presentation-session">presentation sessions</span>.
     </p>
     <p>
       An <dfn>opening browsing context</dfn> is a <span data-anolis-spec=
-      "w3c-html">browsing context</span> from which calls are made to
-      <span>startSession</span>, <span>joinSession</span>, in other words from
-      which <span title="concept-presentation-session">presentation
-      sessions</span> are initiated.
+      "w3c-html">browsing context</span> that has initiated or resumed a
+      <span>presentation session</span> by calling <span>startSession</span> or
+      <span>joinSession</span>.
     </p>
     <h3>
       Common definitions
@@ -983,10 +981,13 @@ interface <dfn>NavigatorPresentation</dfn> : EventTarget {
 };
 </pre>
     <p class="open-issue">
-      <i>(drott)</i> What would be a good definition of the
-      <code>session</code> attribute? Do we want to keep it? It's somewhat hard
-      to define, when it should contain a value, and when it should be empty -
-      and it's not compatible with multiple calls to startSession, for example.
+      TODO: Define contents of <code>session</code> attribute. Clarification:
+      The purpose of the session attribute is to provide the presented page
+      with access to the PresentationSession without allowing a potential race
+      condition between the registration of an event handler and the firing of
+      an event, or complicating the browser implementation to fix this case. It
+      should be null in an opening context and non-null in a presented
+      document.
     </p>
     <h4>
       Starting a presentation session
@@ -1309,10 +1310,13 @@ interface <dfn>NavigatorPresentation</dfn> : EventTarget {
       track of the number of <code>EventHandler</code>s registered to the
       <code>onavailable</code> event. Using this information, implementation
       specific discovery of <span title="presentation-display">presentation
-      displays</span> can be resumed or suspended, in order to save power. In
-      the following, the user agent behavior, depending on the number of
-      registered <code>EventHandler</code>s, is described.
-    </p>
+      displays</span> can be resumed or suspended, in order to save power.
+    </p>The user agent must keep a list of available presentation displays.
+    According to the number of event handlers for
+    <code>onavailablechange</code>, the user agent must also keep the list up
+    to date by running the algorithm for <span title=
+    "algorithm-monitor-available">monitoring the list of available presentation
+    displays</span>.
     <h5>
       Adding an <code>EventHandler</code> to <code>onavailablechange</code>
     </h5>
@@ -1340,8 +1344,7 @@ interface <dfn>NavigatorPresentation</dfn> : EventTarget {
       Monitoring the list of available presentation displays
     </h5>
     <p>
-      The user agent must maintain a <dfn>list of available presentation
-      displays</dfn>. When the user agent is to <dfn title=
+      When the user agent is to <dfn title=
       "algorithm-monitor-available">monitor the list of available presentation
       displays</dfn>, it must run the following steps:
     </p>

--- a/Overview.src.html
+++ b/Overview.src.html
@@ -399,7 +399,8 @@
       </li>
     </ul>
     <h3>
-      <span id="non-functional_requirements">Non-functional requirements</span>
+      <dfn title="non-functional-requirements">Non-functional
+      requirements</dfn>
     </h3>
     <ul>
       <li>
@@ -1179,34 +1180,6 @@ interface <dfn>NavigatorPresentation</dfn> : EventTarget {
       If no matching presentation is found, we could leave the Promise pending
       in case a matching presentation is started in the future.
     </p>
-    <p>
-      <span>The following are the event handlers (and their corresponding event
-      handler event types) that must be supported, as event handler IDL
-      attributes, by objects implementing the <code>PresentationSession</code>
-      interface:</span>
-    </p>
-    <table>
-      <thead>
-        <tr>
-          <th>
-            Event handler
-          </th>
-          <th>
-            Event handler event type
-          </th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td>
-            <dfn><code>onavailablechange</code></dfn>
-          </td>
-          <td>
-            <code>availablechange</code>
-          </td>
-        </tr>
-      </tbody>
-    </table>
     <h4>
       Establishing a presentation connection
     </h4>
@@ -1281,37 +1254,97 @@ interface <dfn>NavigatorPresentation</dfn> : EventTarget {
       Need to further specify the semantics of the messaging channel (using
       WebSockets or MessagePort as a reference).
     </p>
-    <h3>
-      <span>Interface <code>AvailableChangeEvent</code></span>
-    </h3>
-    <pre class="idl">
-<span>[Constructor(DOMString type, optional <span>AvailableChangeEventInit</span> eventInitDict)]
-interface <dfn>AvailableChangeEvent</dfn> : Event {
-  readonly attribute boolean available;
-};
-
-dictionary <dfn>AvailableChangeEventInit</dfn> : EventInit {
-  boolean available;
-};
-</span>
-</pre>
-    <p>
-      An event named <code>availablechange</code> is fired during the execution
-      of the <span>monitoring presentation display availability</span>
-      algorithm when the <dfn>presentation display availability</dfn> changes.
-      It is fired at the <span><code>PresentationSession</code></span> object,
-      using the <code>AvailableChangeEvent</code> interface, with the
-      <code>available</code> attribute set to the boolean value that the
-      algorithm determined.
-    </p>
     <h4>
-      Monitoring presentation display availability
+      The <code>onavailablechange</code> EventHandler
     </h4>
-    <p class="XXX">
-      Each <code>Document</code> object must have a <dfn>list of available
-      presentation displays</dfn>. Each display in this list is identified by a
-      tuple (U, I, S) as follows:
+    <p>
+      <span>The following are the event handlers (and their corresponding event
+      handler event types) that must be supported, as event handler IDL
+      attributes, by objects implementing the <code>PresentationSession</code>
+      interface:</span>
     </p>
+    <table>
+      <thead>
+        <tr>
+          <th>
+            Event handler
+          </th>
+          <th>
+            Event handler event type
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            <dfn><code>onavailablechange</code></dfn>
+          </td>
+          <td>
+            <code>availablechange</code>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+    <p>
+      In order to satisfy the <span title="non-functional-requirements">power
+      saving non-functionional requirements</span> the user agent must keep
+      track of the number of <code>EventHandler</code>s registered to the
+      <code>onavailable</code> event. Using this information, implementation
+      specific discovery of <span title="presentation-display">presentation
+      displays</span> can be resumed or suspended, in order to save power. In
+      the following, the user agent behavior, depending on the number of
+      registered <code>EventHandler</code>s, is described.
+    </p>
+    <h5>
+      Updating the list of available presentation displays
+    </h5>
+    <p>
+      The user agent must maintain a <dfn>list of available presentation
+      displays</dfn>. When the user agent is to <dfn title=
+      "algorithm-update-available">update the list of available presentation
+      displays</dfn>, it must run the following steps:
+    </p>
+    <p>
+      While there are <span data-anolis-spec="w3c-html">event handlers</span>
+      added to NavigatorPresentation.onavailablechange, the user agent must
+      continuously keep track of the available
+    </p><a href="#presentation-display">presentation displays</a> and repeat
+    the following steps:
+    <ol>
+      <li>
+        <span data-anolis-spec="w3c-html">Queue a task</span> to retrieve the
+        the list of curently available <a href=
+        "#presentation-display">presentation displays</a> and let <a id=
+        "newdisplays"><em>newDisplays</em></a> be this list.
+      </li>
+      <li>Wait for the completion of that task.
+      </li>
+      <li>If <a href="#availabledisplays">availableDisplays</a> is empty and
+      <a href="#newdisplays">newDisplays</a> is not empty, then
+        <ol>
+          <li>
+            <span data-anolis-spec="w3c-html">Queue a task</span> to
+            <span data-anolis-spec="w3c-html" title="concept-event-fire">fire
+            an event</span> named <code>availablechange</code> at <em>E</em>
+            (and only <em>E</em>) with the event's <code>available</code>
+            property set to <code>true</code>.
+          </li>
+        </ol>
+      </li>
+      <li>If <a href="#availabledisplays">availableDisplays</a> is not empty
+      and <a href="#newdisplays">newDisplays</a> is empty, then:
+        <div style="margin-left: 2em">
+          <span data-anolis-spec="w3c-html">Queue a task</span> to
+          <span data-anolis-spec="w3c-html" title="concept-event-fire">fire an
+          event</span> named <code>availablechange</code> at <em>E</em> (and
+          only <em>E</em>) with the event's <code>available</code> property set
+          to <code>false</code>.
+        </div>
+      </li>
+      <li>Set <a href="#availableDisplays">availableDisplays</a> to the value
+      of <a href="#newDisplays">newDisplays</a>.
+      </li>
+    </ol>
     <p>
       Let <em>D</em> be the set of presentations that are currently known to
       the user agent (regardles of their state). <em>D</em> is represented as a
@@ -1372,47 +1405,29 @@ dictionary <dfn>AvailableChangeEventInit</dfn> : EventInit {
       When the user agent is required to <dfn>monitor presentation display
       availability</dfn>, it must run the following steps ...
     </p>
+    <h3>
+      <span>Interface <code>AvailableChangeEvent</code></span>
+    </h3>
+    <pre class="idl">
+<span>[Constructor(DOMString type, optional <span>AvailableChangeEventInit</span> eventInitDict)]
+interface <dfn>AvailableChangeEvent</dfn> : Event {
+  readonly attribute boolean available;
+};
+
+dictionary <dfn>AvailableChangeEventInit</dfn> : EventInit {
+  boolean available;
+};
+</span>
+</pre>
     <p>
-      While there are <span data-anolis-spec="w3c-html">event handlers</span>
-      added to NavigatorPresentation.onavailablechange, the user agent must
-      continuously keep track of the available
-    </p><a href="#presentation-display">presentation displays</a> and repeat
-    the following steps:
-    <ol>
-      <li>
-        <span data-anolis-spec="w3c-html">Queue a task</span> to retrieve the
-        the list of curently available <a href=
-        "#presentation-display">presentation displays</a> and let <a id=
-        "newdisplays"><em>newDisplays</em></a> be this list.
-      </li>
-      <li>Wait for the completion of that task.
-      </li>
-      <li>If <a href="#availabledisplays">availableDisplays</a> is empty and
-      <a href="#newdisplays">newDisplays</a> is not empty, then
-        <ol>
-          <li>
-            <span data-anolis-spec="w3c-html">Queue a task</span> to
-            <span data-anolis-spec="w3c-html" title="concept-event-fire">fire
-            an event</span> named <code>availablechange</code> at <em>E</em>
-            (and only <em>E</em>) with the event's <code>available</code>
-            property set to <code>true</code>.
-          </li>
-        </ol>
-      </li>
-      <li>If <a href="#availabledisplays">availableDisplays</a> is not empty
-      and <a href="#newdisplays">newDisplays</a> is empty, then:
-        <div style="margin-left: 2em">
-          <span data-anolis-spec="w3c-html">Queue a task</span> to
-          <span data-anolis-spec="w3c-html" title="concept-event-fire">fire an
-          event</span> named <code>availablechange</code> at <em>E</em> (and
-          only <em>E</em>) with the event's <code>available</code> property set
-          to <code>false</code>.
-        </div>
-      </li>
-      <li>Set <a href="#availableDisplays">availableDisplays</a> to the value
-      of <a href="#newDisplays">newDisplays</a>.
-      </li>
-    </ol>
+      An event named <code>availablechange</code> is fired during the execution
+      of the <span>monitoring presentation display availability</span>
+      algorithm when the <dfn>presentation display availability</dfn> changes.
+      It is fired at the <span><code>PresentationSession</code></span> object,
+      using the <code>AvailableChangeEvent</code> interface, with the
+      <code>available</code> attribute set to the boolean value that the
+      algorithm determined.
+    </p>
     <h3>
       TODO
     </h3>

--- a/Overview.src.html
+++ b/Overview.src.html
@@ -770,7 +770,7 @@ if (navigator.presentation.session) {
       APIs for interacting with presentation sessions
     </h2>
     <h3>
-      Introduction
+      Common idioms
     </h3>
     <p>
       A <dfn title="presentation display">presentation display</dfn> refers to

--- a/Overview.src.html
+++ b/Overview.src.html
@@ -770,18 +770,6 @@ if (navigator.presentation.session) {
     <h2>
       Interfaces
     </h2>
-    <p>
-      The interfaces described herein address the requirements outlined in the
-      <a href="#use-cases">Use Cases</a> section, and specifically, also
-      consider the <a href="#media-flinging-to-multiple-screens">Media Flinging
-      to Multiple Screens</a> use case unaddressed by the <a href=
-      "#previous-version">previous version of the Presentation API</a>. This
-      section describes the interfaces to the extend discussed in the Second
-      Screen Presentation Community Group. Readers are encouraged to consult
-      the <a href="#example">Example</a> and <a href=
-      "#algorithms">Algorithms</a> sections together with this section for a
-      more complete understanding of the technical parts of this specification.
-    </p>
     <h3>
       <code>NavigatorPresentation</code>
     </h3>

--- a/Overview.src.html
+++ b/Overview.src.html
@@ -767,21 +767,29 @@ if (navigator.presentation.session) {
       is communicated to the presentation page (if at all).
     </p>
     <h2>
-      APIs for interacting with presentation sessions
+      API
     </h2>
     <h3>
       Common idioms
     </h3>
     <p>
-      A <dfn title="presentation display">presentation display</dfn> refers to
-      an external screen available to the user agent via an implementation
-      specific connection technology.
+      A <dfn>presentation display</dfn> refers to an external screen available
+      to the user agent via an implementation specific connection technology.
     </p>
-    <p class="XXX">
+    <p>
       A <dfn title="concept-presentation-session">presentation session</dfn> is
-      ... and its relationship to a <span>presentation display</span> is ...
-      Each <span>presentation session</span> has a <dfn>presentation session
-      identifier</dfn> and a <dfn>presentation session state</dfn>.
+      an object refering to the relationship between an <span>opening browsing
+      context</span> and a <span>presentation display</span> with a
+      <dfn>presentation session state</dfn> and a <dfn>presentation session
+      identifier</dfn> to distinguish a set of <span title=
+      "concept-presentation-session">presentation sessions</span>.
+    </p>
+    <p>
+      An <dfn>opening browsing context</dfn> is a <span data-anolis-spec=
+      "w3c-html">browsing context</span> from which calls are made to
+      <span>startSession</span>, <span>joinSession</span>, in other words from
+      which <span title="concept-presentation-session">presentation
+      sessions</span> are initiated.
     </p>
     <h3>
       Interface <code>PresentationSession</code>
@@ -805,24 +813,46 @@ interface <dfn>PresentationSession</dfn> : EventTarget {
 "w3c-html">EventHandler</span> <span>onstatechange</span>;
 };
 </pre>
-    <p class="XXX">
-      The <dfn><code>id</code></dfn> attribute, on getting, must return the
-      <span>presentation session identifier</span>.
+    <p>
+      The <dfn><code>id</code></dfn> attribute holds the <span>presentation
+      session identifier</span>.
     </p>
-    <p class="XXX">
+    <p>
       The <dfn><code>state</code></dfn> attribute represents the
-      <span>presentation session</span>'s current state. On getting, it must
-      return one of the following values: ...
+      <span>presentation session</span>'s current state. It can take one of the
+      values of <span><code>PresentationSessionState</code></span> depending on
+      connection state.
     </p>
-    <p class="XXX">
-      The <dfn><code>postMessage</code></dfn>() method, when invoked on a
-      <code>PresentationSesssion</code> object with an argument message, must
-      ...
+    <p>
+      When the <dfn><code>postMessage</code></dfn>() method is called on a
+      <code>PresentationSession</code> object with a <code>message</code>, the
+      user agent must run the algorithm to <span title=
+      "algorithm-post-message">post a message through a
+      <span><code>PresentationSession</code></span></span>.
     </p>
     <p>
       When the <dfn><code>close</code></dfn>() method is called on a
       <code>PresentationSession</code> <em>S</em>, the user agent must run the
-      following steps:
+      algorithm to <span title="close-algorithm">close a presentation
+      session</span>.
+    </p>
+    <h4>
+      Posting a message through <code>PresentationSession</code>
+    </h4>
+    <p>
+      When the user agent is to <dfn title="algorithm-post-message">post a
+      message through a <code>PresentationSession</code> S</dfn>, it mus run
+      the following steps:
+    </p>
+    <p class="open-issue">
+      Need algorithm for send message
+    </p>
+    <h4>
+      Closing a <code>PresentationSession</code>
+    </h4>
+    <p>
+      When the user agent is to <dfn title="close-algorithm">close a
+      presentation session S</dfn>, it must run the following steps:
     </p>
     <ol>
       <li>If <em>S.state</em> is not <code>connected</code>, then:
@@ -860,6 +890,9 @@ interface <dfn>PresentationSession</dfn> : EventTarget {
         </ol>
       </li>
     </ol>
+    <h4>
+      Event Handlers
+    </h4>
     <p>
       The following are the event handlers (and their corresponding event
       handler event types) that must be supported, as event handler IDL
@@ -1366,9 +1399,6 @@ dictionary <dfn>AvailableChangeEventInit</dfn> : EventInit {
     <h3>
       TODO
     </h3>
-    <p class="open-issue">
-      Need algorithm for send message
-    </p>
     <p class="open-issue">
       Need algorithm for receive message
     </p>

--- a/Overview.src.html
+++ b/Overview.src.html
@@ -845,7 +845,13 @@ interface <dfn>PresentationSession</dfn> : EventTarget {
       the following steps:
     </p>
     <p class="open-issue">
-      Need algorithm for send message
+      Needs algorithm for send message and more fine-grained definition of data
+      types for sending. Candidates, similar interfaces, are found in the
+      <a href=
+      "https://html.spec.whatwg.org/multipage/comms.html#the-messageevent-interfaces">
+      WHATWG HTML spec's <code>MessageEvent</code> section</a>, or the <a href=
+      "http://w3c.github.io/webrtc-pc/#rtcdatachannel">WebRTC's spec
+      <code>RPCDataChannel</code>.</a>
     </p>
     <h4>
       Closing a <code>PresentationSession</code>
@@ -937,9 +943,10 @@ partial interface <span data-anolis-spec="w3c-html">Navigator</span> {
   readonly attribute <span>NavigatorPresentation</span> <span>presentation</span>;
 };
 </pre>
-    <p class="XXX">
-      The <dfn><code>presentation</code></dfn> attribute must return the
-      <code>NavigatorPresentation</code> object.
+    <p>
+      The <dfn><code>presentation</code></dfn> attribute is used to retrieve an
+      instance of the <code>NavigatorPresentation</code> interface, the main
+      interface of Presentation API.
     </p>
     <pre class="idl">
 interface <dfn>NavigatorPresentation</dfn> : EventTarget {
@@ -950,8 +957,11 @@ interface <dfn>NavigatorPresentation</dfn> : EventTarget {
 "w3c-html">EventHandler</span> <span>onavailablechange</span>;
 };
 </pre>
-    <p class="XXX">
-      On getting, the <dfn><code>session</code></dfn> attribute must return ...
+    <p class="open-issue">
+      <i>(drott)</i> What would be a good definition of the
+      <code>session</code> attribute? Do we want to keep it? It's somewhat hard
+      to define, when it should contain a value, and when it should be empty -
+      and it's not compatible with multiple calls to startSession, for example.
     </p>
     <h4>
       Starting a presentation session
@@ -1279,12 +1289,14 @@ dictionary <dfn>AvailableChangeEventInit</dfn> : EventInit {
 };
 </span>
 </pre>
-    <p class="XXX">
-      When the <dfn>presentation display availability</dfn> changes, the user
-      agent must fire an event with the name <code>availablechange</code> at
-      the <span><code>PresentationSession</code></span> object, using the
-      <code>AvailableChangeEvent</code> interface, with the
-      <code>available</code> attribute initialized to ...
+    <p>
+      An event named <code>availablechange</code> is fired during the execution
+      of the <span>monitoring presentation display availability</span>
+      algorithm when the <dfn>presentation display availability</dfn> changes.
+      It is fired at the <span><code>PresentationSession</code></span> object,
+      using the <code>AvailableChangeEvent</code> interface, with the
+      <code>available</code> attribute set to the boolean value that the
+      algorithm determined.
     </p>
     <h4>
       Monitoring presentation display availability
@@ -1322,15 +1334,15 @@ dictionary <dfn>AvailableChangeEventInit</dfn> : EventInit {
       When a new <span data-anolis-spec="w3c-html" title="event handlers">event
       handler</span> <em>E</em> is added to
       <code><span>NavigatorPresentation</span>.onavailablechange</code>, the
-      user agent must run the <a href=
-      "monitor-availability-algorithm">algorithm to monitor availability</a>.
-    </p>
+      user agent must run the
+    </p><a href="monitor-availability-algorithm">algorithm to monitor
+    availability</a>.
     <p class="note">
-      The mechanism used to monitor <a href="#presentation-display">presention
-      displays</a> availability is left to the user agent. The user agent may
-      choose search for screens at any time, not just when event handlers are
-      added to <code>NavigatorPresentation.onavailablechange</code>.
-    </p>
+      The mechanism used to monitor
+    </p><a href="#presentation-display">presention displays</a> availability is
+    left to the user agent. The user agent may choose search for screens at any
+    time, not just when event handlers are added to
+    <code>NavigatorPresentation.onavailablechange</code>.
     <p class="open-issue">
       Do we want to fire the event at all handlers, or only the newly added
       one?
@@ -1357,10 +1369,9 @@ dictionary <dfn>AvailableChangeEventInit</dfn> : EventInit {
     <p>
       While there are <span data-anolis-spec="w3c-html">event handlers</span>
       added to NavigatorPresentation.onavailablechange, the user agent must
-      continuously keep track of the available <a href=
-      "#presentation-display">presentation displays</a> and repeat the
-      following steps:
-    </p>
+      continuously keep track of the available
+    </p><a href="#presentation-display">presentation displays</a> and repeat
+    the following steps:
     <ol>
       <li>
         <span data-anolis-spec="w3c-html">Queue a task</span> to retrieve the

--- a/index.html
+++ b/index.html
@@ -80,8 +80,8 @@
       <h1>
         Presentation API
       </h1>
-      <h2 class="no-num no-toc" id="w3c-editor's-draft-21-january-2015">
-        W3C Editor's Draft 21 January 2015
+      <h2 class="no-num no-toc" id="w3c-editor's-draft-22-january-2015">
+        W3C Editor's Draft 22 January 2015
       </h2>
       <dl>
         <dt>
@@ -753,9 +753,9 @@ function setSession(theSession) {
       resolves to an existing <a href="#presentationsession"><code>PresentationSession</code></a> if one exists
       that is presenting the same <code>url</code> with the same
       <code>presentationId</code> as was passed originally into
-      <a href="#startsession"><code>startSession</code></a>. The requesting page can then communicate with
-      the presentation as if the user had manually connected to it via
-      <a href="#startsession"><code>startSession</code></a>.
+      <a href="#startsession"><code>startSession</code></a>. The <a href="#opening-browsing-context">opening browsing context</a> can
+      then communicate with the presentation as if the user had manually
+      connected to it via <a href="#startsession"><code>startSession</code></a>.
     </p>
     <p>
       At the time <code>joinSession(url, presentationId)</code> is called, if
@@ -870,23 +870,22 @@ function setSession(theSession) {
       to the user agent via an implementation specific connection technology.
     </p>
     <p>
-      A <dfn title="concept-presentation" id="concept-presentation">presentation</dfn>, in the context of
-      this specification, is an active connection between a user agent and a
-      <a href="#presentation-display">presentation display</a> with the intent of displaying web
-      content on the latter.
+      A <dfn title="concept-presentation" id="concept-presentation">presentation</dfn>is an active
+      connection between a user agent and a <a href="#presentation-display">presentation display</a>
+      for displaying web content on the latter at the request of the former.
     </p>
     <p>
       A <dfn title="concept-presentation-session" id="concept-presentation-session">presentation session</dfn> is
-      an object refering to the relationship between an <a href="#opening-browsing-context">opening browsing
-      context</a> and a <a href="#presentation-display">presentation display</a> with a
-      <dfn id="presentation-session-state">presentation session state</dfn> and a <dfn id="presentation-session-identifier">presentation session
-      identifier</dfn> to distinguish a set of <a href="#concept-presentation-session" title="concept-presentation-session">presentation sessions</a>.
+      an object relating an <a href="#opening-browsing-context">opening browsing context</a> to its
+      <a href="#presentation-display">presentation display</a> and enabling two-way-messaging between
+      them. Each such object has a <dfn id="presentation-session-state">presentation session state</dfn> and a
+      <dfn id="presentation-session-identifier">presentation session identifier</dfn> to distinguish it from other
+      <a href="#concept-presentation-session" title="concept-presentation-session">presentation sessions</a>.
     </p>
     <p>
-      An <dfn id="opening-browsing-context">opening browsing context</dfn> is a <a href="http://www.w3.org/html/wg/drafts/html/master/browsers.html#browsing-context" data-anolis-spec="w3c-html" class="external">browsing context</a> from which calls are made to
-      <a href="#startsession">startSession</a>, <a href="#joinsession">joinSession</a>, in other words from
-      which <a href="#concept-presentation-session" title="concept-presentation-session">presentation
-      sessions</a> are initiated.
+      An <dfn id="opening-browsing-context">opening browsing context</dfn> is a <a href="http://www.w3.org/html/wg/drafts/html/master/browsers.html#browsing-context" data-anolis-spec="w3c-html" class="external">browsing context</a> that has initiated or resumed a
+      <span>presentation session</span> by calling <a href="#startsession">startSession</a> or
+      <a href="#joinsession">joinSession</a>.
     </p>
     <h3 id="common-definitions"><span class="secno">6.2 </span>
       Common definitions
@@ -1057,10 +1056,13 @@ interface <dfn id="presentationsession">PresentationSession</dfn> : EventTarget 
 };
 </pre>
     <p class="open-issue">
-      <i>(drott)</i> What would be a good definition of the
-      <code>session</code> attribute? Do we want to keep it? It's somewhat hard
-      to define, when it should contain a value, and when it should be empty -
-      and it's not compatible with multiple calls to startSession, for example.
+      TODO: Define contents of <code>session</code> attribute. Clarification:
+      The purpose of the session attribute is to provide the presented page
+      with access to the PresentationSession without allowing a potential race
+      condition between the registration of an event handler and the firing of
+      an event, or complicating the browser implementation to fix this case. It
+      should be null in an opening context and non-null in a presented
+      document.
     </p>
     <h4 id="starting-a-presentation-session"><span class="secno">6.4.1 </span>
       Starting a presentation session
@@ -1369,10 +1371,12 @@ interface <dfn id="presentationsession">PresentationSession</dfn> : EventTarget 
       track of the number of <code>EventHandler</code>s registered to the
       <code>onavailable</code> event. Using this information, implementation
       specific discovery of <span title="presentation-display">presentation
-      displays</span> can be resumed or suspended, in order to save power. In
-      the following, the user agent behavior, depending on the number of
-      registered <code>EventHandler</code>s, is described.
-    </p>
+      displays</span> can be resumed or suspended, in order to save power.
+    </p>The user agent must keep a list of available presentation displays.
+    According to the number of event handlers for
+    <a href="#onavailablechange"><code>onavailablechange</code></a>, the user agent must also keep the list up
+    to date by running the algorithm for <a href="#algorithm-monitor-available" title="algorithm-monitor-available">monitoring the list of available presentation
+    displays</a>.
     <h5 id="adding-an-eventhandler-to-onavailablechange"><span class="secno">6.4.4.1 </span>
       Adding an <code>EventHandler</code> to <a href="#onavailablechange"><code>onavailablechange</code></a>
     </h5>
@@ -1400,15 +1404,14 @@ interface <dfn id="presentationsession">PresentationSession</dfn> : EventTarget 
       Monitoring the list of available presentation displays
     </h5>
     <p>
-      The user agent must maintain a <dfn id="list-of-available-presentation-displays">list of available presentation
-      displays</dfn>. When the user agent is to <dfn title="algorithm-monitor-available" id="algorithm-monitor-available">monitor the list of available presentation
+      When the user agent is to <dfn title="algorithm-monitor-available" id="algorithm-monitor-available">monitor the list of available presentation
       displays</dfn>, it must run the following steps:
     </p>
     <p>
       While there are <a href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#event-handlers" data-anolis-spec="w3c-html" class="external">event handlers</a>
       added to NavigatorPresentation.onavailablechange, the user agent must
-      continuously keep track the <a href="#list-of-available-presentation-displays">list of available presentation
-      displays</a> and repeat the following steps:
+      continuously keep track the <span>list of available presentation
+      displays</span> and repeat the following steps:
     </p>
     <ol>
       <li>
@@ -1439,7 +1442,7 @@ interface <dfn id="presentationsession">PresentationSession</dfn> : EventTarget 
           </li>
         </ol>
       </li>
-      <li>Set the <a href="#list-of-available-presentation-displays">list of available presentation displays</a> to the
+      <li>Set the <span>list of available presentation displays</span> to the
       value of <a href="#newDisplays">newDisplays</a>.
       </li>
     </ol>
@@ -1460,7 +1463,7 @@ interface <dfn id="presentationsession">PresentationSession</dfn> : EventTarget 
     <ol>
       <li>Cancel any tasks to retrieve the list of available <a href="#presentation-display" title="presentation display">presentation displays</a>.
       </li>
-      <li>Set the <a href="#list-of-available-presentation-displays">list of available presentation displays</a> to
+      <li>Set the <span>list of available presentation displays</span> to
       empty.
       </li>
       <li>

--- a/index.html
+++ b/index.html
@@ -78,8 +78,8 @@
       <h1>
         Presentation API
       </h1>
-      <h2 class="no-num no-toc" id="w3c-editor's-draft-20-january-2015">
-        W3C Editor's Draft 20 January 2015
+      <h2 class="no-num no-toc" id="w3c-editor's-draft-21-january-2015">
+        W3C Editor's Draft 21 January 2015
       </h2>
       <dl>
         <dt>
@@ -1372,8 +1372,8 @@ interface <dfn id="presentationsession">PresentationSession</dfn> : EventTarget 
       Adding an <code>EventHandler</code> to <a href="#onavailablechange"><code>onavailablechange</code></a>
     </h5>
     <p>
-      When an event handler is added to the list of event handlers subscribed
-      to the <a href="#onavailablechange"><code>onavailablechange</code></a> event, the user agent must run the
+      When an event handler is added to the list of event handlers registered
+      for the <a href="#onavailablechange"><code>onavailablechange</code></a> event, the user agent must run the
       <a href="#algorithm-monitor-available" title="algorithm-monitor-available">algorithm to monitor the list
       of available presentation displays</a>.
     </p>
@@ -1382,7 +1382,7 @@ interface <dfn id="presentationsession">PresentationSession</dfn> : EventTarget 
     </h5>
     <p>
       When an event handler is removed from the list of event handlers
-      subscribed to the <a href="#onavailablechange"><code>onavailablechange</code></a> event, the user agent
+      registered to the <a href="#onavailablechange"><code>onavailablechange</code></a> event, the user agent
       must run the following steps:
     </p>
     <ol>

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
      [data-anolis-spec]::after { content:"[" attr(data-anolis-spec) "]"; font-size:.6em; vertical-align:super; text-transform:uppercase }
     }
     </style>
-    <link href="http://www.w3.org/StyleSheets/TR/W3C-ED.css" type="text/css" rel="stylesheet">
+    <link href="http://www.w3.org/StyleSheets/TR/W3C-ED" rel="stylesheet" type="text/css">
     <style type="text/css">
 /* Note formatting taken from HTML5 spec */
     .note { border-left-style: solid; border-left-width: 0.25em; background: none repeat scroll 0 0 #E9FBE9; border-color: #52E052; }
@@ -68,13 +68,13 @@
     <div class="head">
       
 <!--begin-logo-->
-<p><a href="http://www.w3.org/"><img width="72" alt="W3C" height="48" src="https://www.w3.org/Icons/w3c_home"></a></p>
+<p><a href="http://www.w3.org/"><img alt="W3C" height="48" src="https://www.w3.org/Icons/w3c_home" width="72"></a></p>
 <!--end-logo-->
       <h1>
         Presentation API
       </h1>
-      <h2 class="no-num no-toc" id="editor's-draft-12-january-2015">
-        Editor's Draft - 12 January 2015
+      <h2 class="no-num no-toc" id="w3c-editor's-draft-19-january-2015">
+        W3C Editor's Draft 19 January 2015
       </h2>
       <dl>
         <dt>
@@ -287,10 +287,10 @@
    <li><a href="#todo"><span class="secno">7.6 </span>
       TODO
     </a></ol></li>
- <li><a href="#references" class="no-num">
+ <li><a class="no-num" href="#references">
       References
     </a></li>
- <li><a href="#acknowledgments" class="no-num">
+ <li><a class="no-num" href="#acknowledgments">
       Acknowledgments
     </a></ol>
 <!--end-toc-->
@@ -434,7 +434,7 @@
     </ul>
     <p class="note">
       Multi-Screen enumeration and named identification removed, after
-      discussion on the mailing list, cmp. <a href="http://lists.w3.org/Archives/Public/public-webscreens/2014Feb/0021.html" class="external free" rel="nofollow">
+      discussion on the mailing list, cmp. <a class="external free" href="http://lists.w3.org/Archives/Public/public-webscreens/2014Feb/0021.html" rel="nofollow">
       http://lists.w3.org/Archives/Public/public-webscreens/2014Feb/0021.html</a> :
     </p>
     <ul>
@@ -527,22 +527,22 @@
       Terminology
     </h2>
     <p>
-      The term <dfn title="presentation display" id="presentation-display">presentation display</dfn>
+      The term <dfn id="presentation-display" title="presentation display">presentation display</dfn>
       refers to an external screen available to the opening user agent via an
       implementation specific connection technology and compatible with the
       Presentation API for the display content on it.
     </p>
     <p>
-      The terms <a href="http://www.w3.org/html/wg/drafts/html/master/browsers.html#browsing-context" data-anolis-spec="w3c-html" class="external">browsing context</a>,
-      <a href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#event-handlers" data-anolis-spec="w3c-html" class="external">event handlers</a>, <a href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#event-handler-event-type" data-anolis-spec="w3c-html" title="event handler event type" class="external">event handler
-      event types</a>, <a href="http://www.w3.org/html/wg/drafts/html/master/infrastructure.html#concept-event-fire" title="concept-event-fire" data-anolis-spec="w3c-html" class="external">firing an event</a>, <a href="http://www.w3.org/html/wg/drafts/html/master/browsers.html#navigate" data-anolis-spec="w3c-html" class="external">navigate</a>, <a href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#queue-a-task" title="queue a task" data-anolis-spec="w3c-html" class="external">queing a task</a> are defined in <a href="#refsHTML5">[HTML5]</a>.
+      The terms <a class="external" data-anolis-spec="w3c-html" href="http://www.w3.org/html/wg/drafts/html/master/browsers.html#browsing-context">browsing context</a>,
+      <a class="external" data-anolis-spec="w3c-html" href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#event-handlers">event handlers</a>, <a class="external" data-anolis-spec="w3c-html" href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#event-handler-event-type" title="event handler event type">event handler
+      event types</a>, <a class="external" data-anolis-spec="w3c-html" href="http://www.w3.org/html/wg/drafts/html/master/infrastructure.html#concept-event-fire" title="concept-event-fire">firing an event</a>, <a class="external" data-anolis-spec="w3c-html" href="http://www.w3.org/html/wg/drafts/html/master/browsers.html#navigate">navigate</a>, <a class="external" data-anolis-spec="w3c-html" href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#queue-a-task" title="queue a task">queing a task</a> are defined in <a href="#refsHTML5">[HTML5]</a>.
     </p>
     <p>
-      The term <a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-promise-objects" title="promise-objects" data-anolis-spec="es6" class="external">Promise</a> is defined in <a href="#refsES6">[ES6]</a>. The terms <a href="http://www.w3.org/2001/tag/doc/promises-guide#shorthand-manipulating" title="resolve-reject" data-anolis-spec="promguide" class="external">resolving a Promise, and rejecting a Promise</a> are
+      The term <a class="external" data-anolis-spec="es6" href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-promise-objects" title="promise-objects">Promise</a> is defined in <a href="#refsES6">[ES6]</a>. The terms <a class="external" data-anolis-spec="promguide" href="http://www.w3.org/2001/tag/doc/promises-guide#shorthand-manipulating" title="resolve-reject">resolving a Promise, and rejecting a Promise</a> are
       used as explained in <a href="#refsPROMGUIDE">[PROMGUIDE]</a>.
     </p>
     <p>
-      The term <a href="https://url.spec.whatwg.org/#url" data-anolis-spec="url" class="external">URL</a> is defined in the WHATWG
+      The term <a class="external" data-anolis-spec="url" href="https://url.spec.whatwg.org/#url">URL</a> is defined in the WHATWG
       URL standard: <a href="#refsURL">[URL]</a>.
     </p>
     <p>
@@ -845,16 +845,6 @@ function setSession(theSession) {
     <h2 id="interfaces"><span class="secno">6 </span>
       Interfaces
     </h2>
-    <p>
-      The interfaces described herein address the requirements outlined in the
-      <a href="#use-cases">Use Cases</a> section, and specifically, also
-      consider the <a href="#media-flinging-to-multiple-screens">Media Flinging
-      to Multiple Screens</a> use case unaddressed by the <a href="#previous-version">previous version of the Presentation API</a>. This
-      section describes the interfaces to the extend discussed in the Second
-      Screen Presentation Community Group. Readers are encouraged to consult
-      the <a href="#example">Example</a> and <a href="#algorithms">Algorithms</a> sections together with this section for a
-      more complete understanding of the technical parts of this specification.
-    </p>
     <h3 id="navigatorpresentation"><span class="secno">6.1 </span>
       <code>NavigatorPresentation</code>
     </h3>
@@ -932,7 +922,7 @@ interface PresentationSession : EventTarget {
       Availability Listener Added
     </h4>
     <p>
-      When a new <a href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#event-handlers" title="event handlers" data-anolis-spec="w3c-html" class="external">event
+      When a new <a class="external" data-anolis-spec="w3c-html" href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#event-handlers" title="event handlers">event
       handler</a> <em>E</em> is added to
       <code>NavigatorPresentation.onavailablechange</code>, the user agent must
       run the <a href="monitor-availability-algorithm">algorithm to monitor
@@ -952,7 +942,7 @@ interface PresentationSession : EventTarget {
       Availability Listener Removed
     </h4>
     <p>
-      When the last <a href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#event-handlers" title="event handlers" data-anolis-spec="w3c-html" class="external">event handler</a> is removed from
+      When the last <a class="external" data-anolis-spec="w3c-html" href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#event-handlers" title="event handlers">event handler</a> is removed from
       <code>NavigatorPresentation.onavailablechange</code>, the user agent may
       run the following steps:
     </p>
@@ -965,14 +955,14 @@ interface PresentationSession : EventTarget {
       Algorithm to Monitor Presentation Display Availability Change
     </h4>
     <p>
-      While there are <a href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#event-handlers" data-anolis-spec="w3c-html" class="external">event handlers</a>
+      While there are <a class="external" data-anolis-spec="w3c-html" href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#event-handlers">event handlers</a>
       added to NavigatorPresentation.onavailablechange, the user agent must
       continuously keep track of the available <a href="#presentation-display">presentation displays</a> and repeat the
       following steps:
     </p>
     <ol>
       <li>
-        <a href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#queue-a-task" data-anolis-spec="w3c-html" class="external">Queue a task</a> to retrieve the
+        <a class="external" data-anolis-spec="w3c-html" href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#queue-a-task">Queue a task</a> to retrieve the
         the list of curently available <a href="#presentation-display">presentation displays</a> and let <a id="newdisplays"><em>newDisplays</em></a> be this list.
       </li>
       <li>Wait for the completion of that task.
@@ -981,8 +971,8 @@ interface PresentationSession : EventTarget {
       <a href="#newdisplays">newDisplays</a> is not empty, then
         <ol>
           <li>
-            <a href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#queue-a-task" data-anolis-spec="w3c-html" class="external">Queue a task</a> to
-            <a href="http://www.w3.org/html/wg/drafts/html/master/infrastructure.html#concept-event-fire" title="concept-event-fire" data-anolis-spec="w3c-html" class="external">fire
+            <a class="external" data-anolis-spec="w3c-html" href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#queue-a-task">Queue a task</a> to
+            <a class="external" data-anolis-spec="w3c-html" href="http://www.w3.org/html/wg/drafts/html/master/infrastructure.html#concept-event-fire" title="concept-event-fire">fire
             an event</a> named <code>availablechange</code> at <em>E</em>
             (and only <em>E</em>) with the event's <code>available</code>
             property set to <code>true</code>.
@@ -992,8 +982,8 @@ interface PresentationSession : EventTarget {
       <li>If <a href="#availabledisplays">availableDisplays</a> is not empty
       and <a href="#newdisplays">newDisplays</a> is empty, then:
         <div style="margin-left: 2em">
-          <a href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#queue-a-task" data-anolis-spec="w3c-html" class="external">Queue a task</a> to
-          <a href="http://www.w3.org/html/wg/drafts/html/master/infrastructure.html#concept-event-fire" title="concept-event-fire" data-anolis-spec="w3c-html" class="external">fire an
+          <a class="external" data-anolis-spec="w3c-html" href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#queue-a-task">Queue a task</a> to
+          <a class="external" data-anolis-spec="w3c-html" href="http://www.w3.org/html/wg/drafts/html/master/infrastructure.html#concept-event-fire" title="concept-event-fire">fire an
           event</a> named <code>availablechange</code> at <em>E</em> (and
           only <em>E</em>) with the event's <code>available</code> property set
           to <code>false</code>.
@@ -1016,7 +1006,7 @@ interface PresentationSession : EventTarget {
         Input
       </dt>
       <dd>
-        <code>presentationUrl</code>, the <a href="https://url.spec.whatwg.org/#url" data-anolis-spec="url" class="external">URL</a> of the document to be presented
+        <code>presentationUrl</code>, the <a class="external" data-anolis-spec="url" href="https://url.spec.whatwg.org/#url">URL</a> of the document to be presented
       </dd>
       <dd>
         <code>presentationId</code>, an optional identifier for the
@@ -1026,11 +1016,11 @@ interface PresentationSession : EventTarget {
         Output
       </dt>
       <dd>
-        <em>P</em>, a <a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-promise-objects" title="promise-objects" data-anolis-spec="es6" class="external">Promise</a>
+        <em>P</em>, a <a class="external" data-anolis-spec="es6" href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-promise-objects" title="promise-objects">Promise</a>
       </dd>
     </dl>
     <ol>
-      <li>Let <em>P</em> be a new <a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-promise-objects" title="promise-objects" data-anolis-spec="es6" class="external">Promise</a>.
+      <li>Let <em>P</em> be a new <a class="external" data-anolis-spec="es6" href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-promise-objects" title="promise-objects">Promise</a>.
       </li>
       <li>Return <em>P</em>.
       </li>
@@ -1047,7 +1037,7 @@ interface PresentationSession : EventTarget {
       empty, then:
         <ol>
           <li>
-            <a href="http://www.w3.org/2001/tag/doc/promises-guide#shorthand-manipulating" title="resolve-reject" data-anolis-spec="promguide" class="external">Reject</a> <em>P</em> with a
+            <a class="external" data-anolis-spec="promguide" href="http://www.w3.org/2001/tag/doc/promises-guide#shorthand-manipulating" title="resolve-reject">Reject</a> <em>P</em> with a
             "NoScreensAvailable" exception.
           </li>
           <li>Abort all remaining steps.
@@ -1055,7 +1045,7 @@ interface PresentationSession : EventTarget {
         </ol>
       </li>
       <li>Queue a task <em>T</em> to request user permission for the use of a
-      <a href="#presentation-display" data-anolis-ref="presentation">presentation display</a> and
+      <a data-anolis-ref="presentation" href="#presentation-display">presentation display</a> and
       selection of one presentation display.
         <ol>
           <li>If <em>T</em> completes with the user <em>granting
@@ -1075,10 +1065,10 @@ interface PresentationSession : EventTarget {
               <code>disconnected</code>.
               </li>
               <li>
-                <a href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#queue-a-task" data-anolis-spec="w3c-html" class="external">Queue a task</a>
-                <em>C</em> to create a new <a href="http://www.w3.org/html/wg/drafts/html/master/browsers.html#browsing-context" data-anolis-spec="w3c-html" class="external">browsing context</a> on the user-selected
+                <a class="external" data-anolis-spec="w3c-html" href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#queue-a-task">Queue a task</a>
+                <em>C</em> to create a new <a class="external" data-anolis-spec="w3c-html" href="http://www.w3.org/html/wg/drafts/html/master/browsers.html#browsing-context">browsing context</a> on the user-selected
                 <a href="presentation-display">presentation display</a> and
-                <a href="http://www.w3.org/html/wg/drafts/html/master/browsers.html#navigate" data-anolis-spec="w3c-html" class="external">navigate</a> to
+                <a class="external" data-anolis-spec="w3c-html" href="http://www.w3.org/html/wg/drafts/html/master/browsers.html#navigate">navigate</a> to
                 <code>presentationUrl</code> in it.
                 <ol>
                   <li>If <em>C</em> completes successfully, run the following
@@ -1087,7 +1077,7 @@ interface PresentationSession : EventTarget {
                       <li>Add <em>(S.url, S.id, S)</em> to <em>D</em>.
                       </li>
                       <li>
-                        <a href="http://www.w3.org/2001/tag/doc/promises-guide#shorthand-manipulating" title="resolve-reject" data-anolis-spec="promguide" class="external">Resolve</a> <em>P</em> with
+                        <a class="external" data-anolis-spec="promguide" href="http://www.w3.org/2001/tag/doc/promises-guide#shorthand-manipulating" title="resolve-reject">Resolve</a> <em>P</em> with
                         <em>S</em>.
                       </li>
                       <li>Initiate the <a href="#presentation-connection">Presentation Connection</a>
@@ -1098,7 +1088,7 @@ interface PresentationSession : EventTarget {
                   <li>If <em>C</em> fails, run the following steps:
                     <ol>
                       <li>
-                        <a href="http://www.w3.org/2001/tag/doc/promises-guide#shorthand-manipulating" title="resolve-reject" data-anolis-spec="promguide" class="external">Reject</a> P with a "failed"
+                        <a class="external" data-anolis-spec="promguide" href="http://www.w3.org/2001/tag/doc/promises-guide#shorthand-manipulating" title="resolve-reject">Reject</a> P with a "failed"
                         exception.
                       </li>
                     </ol>
@@ -1111,7 +1101,7 @@ interface PresentationSession : EventTarget {
           permission</em>, run the following steps:
             <ol>
               <li>
-                <a href="http://www.w3.org/2001/tag/doc/promises-guide#shorthand-manipulating" title="resolve-reject" data-anolis-spec="promguide" class="external">Reject</a> <em>P</em> with a
+                <a class="external" data-anolis-spec="promguide" href="http://www.w3.org/2001/tag/doc/promises-guide#shorthand-manipulating" title="resolve-reject">Reject</a> <em>P</em> with a
                 "PermissionDenied" exception.
               </li>
             </ol>
@@ -1143,7 +1133,7 @@ interface PresentationSession : EventTarget {
         Input
       </dt>
       <dd>
-        <code>presentationUrl</code>, the <a href="https://url.spec.whatwg.org/#url" data-anolis-spec="url" class="external">URL</a> of the document being presented
+        <code>presentationUrl</code>, the <a class="external" data-anolis-spec="url" href="https://url.spec.whatwg.org/#url">URL</a> of the document being presented
       </dd>
       <dd>
         <code>presentationId</code>, the identifier for the presentation
@@ -1152,18 +1142,18 @@ interface PresentationSession : EventTarget {
         Output
       </dt>
       <dd>
-        <em>P</em>, a <a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-promise-objects" title="promise-objects" data-anolis-spec="es6" class="external">Promise</a>
+        <em>P</em>, a <a class="external" data-anolis-spec="es6" href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-promise-objects" title="promise-objects">Promise</a>
       </dd>
     </dl>
     <ol>
-      <li>Let <em>P</em> be a new <a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-promise-objects" title="promise-objects" data-anolis-spec="es6" class="external">Promise</a>.
+      <li>Let <em>P</em> be a new <a class="external" data-anolis-spec="es6" href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-promise-objects" title="promise-objects">Promise</a>.
       </li>
       <li>Return <em>P</em>.
       </li>
       <li>Let <em>D</em> be the set of presentations known by the user agent.
       </li>
       <li>
-        <a href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#queue-a-task" data-anolis-spec="w3c-html" class="external">Queue a task</a> <em>T</em> to run
+        <a class="external" data-anolis-spec="w3c-html" href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#queue-a-task">Queue a task</a> <em>T</em> to run
         the following steps in order:
         <ol>
           <li>For each presentation <em>(U, I, S)</em> in <em>D</em>,
@@ -1176,7 +1166,7 @@ interface PresentationSession : EventTarget {
               following steps:
                 <ol>
                   <li>
-                    <a href="http://www.w3.org/2001/tag/doc/promises-guide#shorthand-manipulating" title="resolve-reject" data-anolis-spec="promguide" class="external">Resolve</a> <em>P</em> with <em>S</em>.
+                    <a class="external" data-anolis-spec="promguide" href="http://www.w3.org/2001/tag/doc/promises-guide#shorthand-manipulating" title="resolve-reject">Resolve</a> <em>P</em> with <em>S</em>.
                   </li>
                   <li>Initiate the <a href="#presentation-connection">Presentation Connection</a>
                   algorithm for <em>S</em>.
@@ -1188,7 +1178,7 @@ interface PresentationSession : EventTarget {
             </ol>
           </li>
           <li>
-            <a href="http://www.w3.org/2001/tag/doc/promises-guide#shorthand-manipulating" title="resolve-reject" data-anolis-spec="promguide" class="external">Reject</a> <em>P</em> with a
+            <a class="external" data-anolis-spec="promguide" href="http://www.w3.org/2001/tag/doc/promises-guide#shorthand-manipulating" title="resolve-reject">Reject</a> <em>P</em> with a
             "NoPresentationFound" exception.
           </li>
         </ol>
@@ -1218,7 +1208,7 @@ interface PresentationSession : EventTarget {
       <li>Let <em>D</em> be the set of presentations known by the user agent.
       </li>
       <li>
-        <a href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#queue-a-task" data-anolis-spec="w3c-html" class="external">Queue a task</a> <em>T</em> to run
+        <a class="external" data-anolis-spec="w3c-html" href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#queue-a-task">Queue a task</a> <em>T</em> to run
         the following steps in order:
         <ol>
           <li>For each presentation <em>(U, I, S')</em> in <em>D</em>,
@@ -1230,8 +1220,8 @@ interface PresentationSession : EventTarget {
               equal to <em>S.id</em>, run the following steps:
                 <ol>
                   <li>
-                    <a href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#queue-a-task" data-anolis-spec="w3c-html" class="external">Queue a task</a> to
-                    <a href="http://www.w3.org/html/wg/drafts/html/master/infrastructure.html#concept-event-fire" title="concept-event-fire" data-anolis-spec="w3c-html" class="external">fire an event</a> named
+                    <a class="external" data-anolis-spec="w3c-html" href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#queue-a-task">Queue a task</a> to
+                    <a class="external" data-anolis-spec="w3c-html" href="http://www.w3.org/html/wg/drafts/html/master/infrastructure.html#concept-event-fire" title="concept-event-fire">fire an event</a> named
                     <code>statechange</code> at <em>s.onstatechange</em>.
                   </li>
                 </ol>
@@ -1259,7 +1249,7 @@ interface PresentationSession : EventTarget {
         </ol>
       </li>
       <li>
-        <a href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#queue-a-task" data-anolis-spec="w3c-html" class="external">Queue a task</a> <em>T</em> to
+        <a class="external" data-anolis-spec="w3c-html" href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#queue-a-task">Queue a task</a> <em>T</em> to
         connect <em>S</em> to the document that is presenting <em>S.url</em>.
       </li>
       <li>If <em>T</em> completes successfully, run the following steps:
@@ -1280,8 +1270,8 @@ interface PresentationSession : EventTarget {
                   is equal to <em>S.id</em>, run the following steps:
                     <ol>
                       <li>
-                        <a href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#queue-a-task" data-anolis-spec="w3c-html" class="external">Queue a task</a>
-                        to <a href="http://www.w3.org/html/wg/drafts/html/master/infrastructure.html#concept-event-fire" title="concept-event-fire" data-anolis-spec="w3c-html" class="external">fire an event</a> named
+                        <a class="external" data-anolis-spec="w3c-html" href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#queue-a-task">Queue a task</a>
+                        to <a class="external" data-anolis-spec="w3c-html" href="http://www.w3.org/html/wg/drafts/html/master/infrastructure.html#concept-event-fire" title="concept-event-fire">fire an event</a> named
                         <code>statechange</code> at <em>s.onstatechange</em>.
                       </li>
                     </ol>

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
      [data-anolis-spec]::after { content:"[" attr(data-anolis-spec) "]"; font-size:.6em; vertical-align:super; text-transform:uppercase }
     }
     </style>
-    <link href="http://www.w3.org/StyleSheets/TR/W3C-ED" rel="stylesheet" type="text/css">
+    <link href="http://www.w3.org/StyleSheets/TR/W3C-ED" type="text/css" rel="stylesheet">
     <style type="text/css">
 /* Note formatting taken from HTML5 spec */
     .note { border-left-style: solid; border-left-width: 0.25em; background: none repeat scroll 0 0 #E9FBE9; border-color: #52E052; }
@@ -73,13 +73,13 @@
     <div class="head">
       
 <!--begin-logo-->
-<p><a href="http://www.w3.org/"><img alt="W3C" height="48" src="https://www.w3.org/Icons/w3c_home" width="72"></a></p>
+<p><a href="http://www.w3.org/"><img width="72" alt="W3C" height="48" src="https://www.w3.org/Icons/w3c_home"></a></p>
 <!--end-logo-->
       <h1>
         Presentation API
       </h1>
-      <h2 class="no-num no-toc" id="w3c-editor's-draft-19-january-2015">
-        W3C Editor's Draft 19 January 2015
+      <h2 class="no-num no-toc" id="w3c-editor's-draft-20-january-2015">
+        W3C Editor's Draft 20 January 2015
       </h2>
       <dl>
         <dt>
@@ -247,8 +247,8 @@
    <li><a href="#usage-on-remote-screen"><span class="secno">5.4 </span>
       Usage on remote screen
     </a></ol></li>
- <li><a href="#apis-for-interacting-with-presentation-sessions"><span class="secno">6 </span>
-      APIs for interacting with presentation sessions
+ <li><a href="#api"><span class="secno">6 </span>
+      API
     </a>
   <ol>
    <li><a href="#common-idioms"><span class="secno">6.1 </span>
@@ -256,7 +256,17 @@
     </a></li>
    <li><a href="#interface-presentationsession"><span class="secno">6.2 </span>
       Interface <code>PresentationSession</code>
+    </a>
+    <ol>
+     <li><a href="#posting-a-message-through-presentationsession"><span class="secno">6.2.1 </span>
+      Posting a message through <code>PresentationSession</code>
     </a></li>
+     <li><a href="#closing-a-presentationsession"><span class="secno">6.2.2 </span>
+      Closing a <code>PresentationSession</code>
+    </a></li>
+     <li><a href="#event-handlers"><span class="secno">6.2.3 </span>
+      Event Handlers
+    </a></ol></li>
    <li><a href="#interface-navigatorpresentation"><span class="secno">6.3 </span>
       Interface <code>NavigatorPresentation</code>
     </a>
@@ -280,10 +290,10 @@
    <li><a href="#todo"><span class="secno">6.5 </span>
       TODO
     </a></ol></li>
- <li><a class="no-num" href="#references">
+ <li><a href="#references" class="no-num">
       References
     </a></li>
- <li><a class="no-num" href="#acknowledgments">
+ <li><a href="#acknowledgments" class="no-num">
       Acknowledgments
     </a></ol>
 <!--end-toc-->
@@ -427,7 +437,7 @@
     </ul>
     <p class="note">
       Multi-Screen enumeration and named identification removed, after
-      discussion on the mailing list, cmp. <a class="external free" href="http://lists.w3.org/Archives/Public/public-webscreens/2014Feb/0021.html" rel="nofollow">
+      discussion on the mailing list, cmp. <a href="http://lists.w3.org/Archives/Public/public-webscreens/2014Feb/0021.html" class="external free" rel="nofollow">
       http://lists.w3.org/Archives/Public/public-webscreens/2014Feb/0021.html</a> :
     </p>
     <ul>
@@ -520,16 +530,16 @@
       Terminology
     </h2>
     <p>
-      The terms <a class="external" data-anolis-spec="w3c-html" href="http://www.w3.org/html/wg/drafts/html/master/browsers.html#browsing-context">browsing context</a>,
-      <a class="external" data-anolis-spec="w3c-html" href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#event-handlers">event handlers</a>, <a class="external" data-anolis-spec="w3c-html" href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#event-handler-event-type" title="event handler event type">event handler
-      event types</a>, <a class="external" data-anolis-spec="w3c-html" href="http://www.w3.org/html/wg/drafts/html/master/infrastructure.html#concept-event-fire" title="concept-event-fire">firing an event</a>, <a class="external" data-anolis-spec="w3c-html" href="http://www.w3.org/html/wg/drafts/html/master/browsers.html#navigate">navigate</a>, <a class="external" data-anolis-spec="w3c-html" href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#queue-a-task" title="queue a task">queing a task</a> are defined in <a href="#refsHTML5">[HTML5]</a>.
+      The terms <a href="http://www.w3.org/html/wg/drafts/html/master/browsers.html#browsing-context" data-anolis-spec="w3c-html" class="external">browsing context</a>,
+      <a href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#event-handlers" data-anolis-spec="w3c-html" class="external">event handlers</a>, <a href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#event-handler-event-type" data-anolis-spec="w3c-html" title="event handler event type" class="external">event handler
+      event types</a>, <a href="http://www.w3.org/html/wg/drafts/html/master/infrastructure.html#concept-event-fire" title="concept-event-fire" data-anolis-spec="w3c-html" class="external">firing an event</a>, <a href="http://www.w3.org/html/wg/drafts/html/master/browsers.html#navigate" data-anolis-spec="w3c-html" class="external">navigate</a>, <a href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#queue-a-task" title="queue a task" data-anolis-spec="w3c-html" class="external">queing a task</a> are defined in <a href="#refsHTML5">[HTML5]</a>.
     </p>
     <p>
-      The term <a class="external" data-anolis-spec="es6" href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-promise-objects" title="promise-objects">Promise</a> is defined in <a href="#refsES6">[ES6]</a>. The terms <a class="external" data-anolis-spec="promguide" href="http://www.w3.org/2001/tag/doc/promises-guide#shorthand-manipulating" title="resolve-reject">resolving a Promise, and rejecting a Promise</a> are
+      The term <a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-promise-objects" title="promise-objects" data-anolis-spec="es6" class="external">Promise</a> is defined in <a href="#refsES6">[ES6]</a>. The terms <a href="http://www.w3.org/2001/tag/doc/promises-guide#shorthand-manipulating" title="resolve-reject" data-anolis-spec="promguide" class="external">resolving a Promise, and rejecting a Promise</a> are
       used as explained in <a href="#refsPROMGUIDE">[PROMGUIDE]</a>.
     </p>
     <p>
-      The term <a class="external" data-anolis-spec="url" href="https://url.spec.whatwg.org/#url">URL</a> is defined in the WHATWG
+      The term <a href="https://url.spec.whatwg.org/#url" data-anolis-spec="url" class="external">URL</a> is defined in the WHATWG
       URL standard: <a href="#refsURL">[URL]</a>.
     </p>
     <p>
@@ -829,22 +839,28 @@ function setSession(theSession) {
       page, we need to define how connection and disconnection of these pages
       is communicated to the presentation page (if at all).
     </p>
-    <h2 id="apis-for-interacting-with-presentation-sessions"><span class="secno">6 </span>
-      APIs for interacting with presentation sessions
+    <h2 id="api"><span class="secno">6 </span>
+      API
     </h2>
     <h3 id="common-idioms"><span class="secno">6.1 </span>
       Common idioms
     </h3>
     <p>
-      A <dfn id="presentation-display" title="presentation display">presentation display</dfn> refers to
-      an external screen available to the user agent via an implementation
-      specific connection technology.
+      A <dfn id="presentation-display">presentation display</dfn> refers to an external screen available
+      to the user agent via an implementation specific connection technology.
     </p>
-    <p class="XXX">
-      A <dfn id="concept-presentation-session" title="concept-presentation-session">presentation session</dfn> is
-      ... and its relationship to a <a href="#presentation-display">presentation display</a> is ...
-      Each <span>presentation session</span> has a <dfn id="presentation-session-identifier">presentation session
-      identifier</dfn> and a <dfn id="presentation-session-state">presentation session state</dfn>.
+    <p>
+      A <dfn title="concept-presentation-session" id="concept-presentation-session">presentation session</dfn> is
+      an object refering to the relationship between an <a href="#opening-browsing-context">opening browsing
+      context</a> and a <a href="#presentation-display">presentation display</a> with a
+      <dfn id="presentation-session-state">presentation session state</dfn> and a <dfn id="presentation-session-identifier">presentation session
+      identifier</dfn> to distinguish a set of <a href="#concept-presentation-session" title="concept-presentation-session">presentation sessions</a>.
+    </p>
+    <p>
+      An <dfn id="opening-browsing-context">opening browsing context</dfn> is a <a href="http://www.w3.org/html/wg/drafts/html/master/browsers.html#browsing-context" data-anolis-spec="w3c-html" class="external">browsing context</a> from which calls are made to
+      <a href="#startsession">startSession</a>, <a href="#joinsession">joinSession</a>, in other words from
+      which <a href="#concept-presentation-session" title="concept-presentation-session">presentation
+      sessions</a> are initiated.
     </p>
     <h3 id="interface-presentationsession"><span class="secno">6.2 </span>
       Interface <a href="#presentationsession"><code>PresentationSession</code></a>
@@ -861,28 +877,49 @@ interface <dfn id="presentationsession">PresentationSession</dfn> : EventTarget 
   readonly attribute <a href="#presentationsessionstate">PresentationSessionState</a> <a href="#state">state</a>;
   void <a href="#postmessage">postMessage</a>(DOMString message);
   void <a href="#close">close</a>();
-  attribute <a class="external" data-anolis-spec="w3c-html" href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#eventhandler">EventHandler</a> <a href="#onmessage">onmessage</a>;
-  attribute <a class="external" data-anolis-spec="w3c-html" href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#eventhandler">EventHandler</a> <a href="#onstatechange">onstatechange</a>;
+  attribute <a href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#eventhandler" data-anolis-spec="w3c-html" class="external">EventHandler</a> <a href="#onmessage">onmessage</a>;
+  attribute <a href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#eventhandler" data-anolis-spec="w3c-html" class="external">EventHandler</a> <a href="#onstatechange">onstatechange</a>;
 };
 </pre>
-    <p class="XXX">
-      The <dfn id="id"><code>id</code></dfn> attribute, on getting, must return the
-      <a href="#presentation-session-identifier">presentation session identifier</a>.
+    <p>
+      The <dfn id="id"><code>id</code></dfn> attribute holds the <a href="#presentation-session-identifier">presentation
+      session identifier</a>.
     </p>
-    <p class="XXX">
+    <p>
       The <dfn id="state"><code>state</code></dfn> attribute represents the
-      <span>presentation session</span>'s current state. On getting, it must
-      return one of the following values: ...
+      <span>presentation session</span>'s current state. It can take one of the
+      values of <a href="#presentationsessionstate"><code>PresentationSessionState</code></a> depending on
+      connection state.
     </p>
-    <p class="XXX">
-      The <dfn id="postmessage"><code>postMessage</code></dfn>() method, when invoked on a
-      <code>PresentationSesssion</code> object with an argument message, must
-      ...
+    <p>
+      When the <dfn id="postmessage"><code>postMessage</code></dfn>() method is called on a
+      <a href="#presentationsession"><code>PresentationSession</code></a> object with a <code>message</code>, the
+      user agent must run the algorithm to <a href="#algorithm-post-message" title="algorithm-post-message">post a message through a
+      <span><code>PresentationSession</code></span></a>.
     </p>
     <p>
       When the <dfn id="close"><code>close</code></dfn>() method is called on a
       <a href="#presentationsession"><code>PresentationSession</code></a> <em>S</em>, the user agent must run the
-      following steps:
+      algorithm to <a href="#close-algorithm" title="close-algorithm">close a presentation
+      session</a>.
+    </p>
+    <h4 id="posting-a-message-through-presentationsession"><span class="secno">6.2.1 </span>
+      Posting a message through <a href="#presentationsession"><code>PresentationSession</code></a>
+    </h4>
+    <p>
+      When the user agent is to <dfn title="algorithm-post-message" id="algorithm-post-message">post a
+      message through a <code>PresentationSession</code> S</dfn>, it mus run
+      the following steps:
+    </p>
+    <p class="open-issue">
+      Need algorithm for send message
+    </p>
+    <h4 id="closing-a-presentationsession"><span class="secno">6.2.2 </span>
+      Closing a <a href="#presentationsession"><code>PresentationSession</code></a>
+    </h4>
+    <p>
+      When the user agent is to <dfn title="close-algorithm" id="close-algorithm">close a
+      presentation session S</dfn>, it must run the following steps:
     </p>
     <ol>
       <li>If <em>S.state</em> is not <code>connected</code>, then:
@@ -896,7 +933,7 @@ interface <dfn id="presentationsession">PresentationSession</dfn> : EventTarget 
       <li>Let <em>D</em> be the set of presentations known by the user agent.
       </li>
       <li>
-        <a class="external" data-anolis-spec="w3c-html" href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#queue-a-task">Queue a task</a> <em>T</em> to run
+        <a href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#queue-a-task" data-anolis-spec="w3c-html" class="external">Queue a task</a> <em>T</em> to run
         the following steps in order:
         <ol>
           <li>For each presentation <em>(U, I, S')</em> in <em>D</em>,
@@ -908,8 +945,8 @@ interface <dfn id="presentationsession">PresentationSession</dfn> : EventTarget 
               equal to <em>S.id</em>, run the following steps:
                 <ol>
                   <li>
-                    <a class="external" data-anolis-spec="w3c-html" href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#queue-a-task">Queue a task</a> to
-                    <a class="external" data-anolis-spec="w3c-html" href="http://www.w3.org/html/wg/drafts/html/master/infrastructure.html#concept-event-fire" title="concept-event-fire">fire an event</a> named
+                    <a href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#queue-a-task" data-anolis-spec="w3c-html" class="external">Queue a task</a> to
+                    <a href="http://www.w3.org/html/wg/drafts/html/master/infrastructure.html#concept-event-fire" title="concept-event-fire" data-anolis-spec="w3c-html" class="external">fire an event</a> named
                     <code>statechange</code> at <em>s.onstatechange</em>.
                   </li>
                 </ol>
@@ -919,6 +956,9 @@ interface <dfn id="presentationsession">PresentationSession</dfn> : EventTarget 
         </ol>
       </li>
     </ol>
+    <h4 id="event-handlers"><span class="secno">6.2.3 </span>
+      Event Handlers
+    </h4>
     <p>
       The following are the event handlers (and their corresponding event
       handler event types) that must be supported, as event handler IDL
@@ -958,7 +998,7 @@ interface <dfn id="presentationsession">PresentationSession</dfn> : EventTarget 
     <h3 id="interface-navigatorpresentation"><span class="secno">6.3 </span>
       Interface <a href="#navigatorpresentation"><code>NavigatorPresentation</code></a>
     </h3>
-    <pre class="idl">partial interface <a class="external" data-anolis-spec="w3c-html" href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#navigator">Navigator</a> {
+    <pre class="idl">partial interface <a href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#navigator" data-anolis-spec="w3c-html" class="external">Navigator</a> {
   readonly attribute <a href="#navigatorpresentation">NavigatorPresentation</a> <a href="#presentation">presentation</a>;
 };
 </pre>
@@ -970,7 +1010,7 @@ interface <dfn id="presentationsession">PresentationSession</dfn> : EventTarget 
   readonly attribute <a href="#presentationsession">PresentationSession</a>? <a href="#session">session</a>;
   Promise&lt;<a href="#presentationsession">PresentationSession</a>&gt; <a href="#startsession">startSession</a>(DOMString url, DOMString? presentationId);
   Promise&lt;<a href="#presentationsession">PresentationSession</a>&gt; <a href="#joinsession">joinSession</a>(DOMString url, DOMString? presentationId);
-  attribute <a class="external" data-anolis-spec="w3c-html" href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#eventhandler">EventHandler</a> <a href="#onavailablechange">onavailablechange</a>;
+  attribute <a href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#eventhandler" data-anolis-spec="w3c-html" class="external">EventHandler</a> <a href="#onavailablechange">onavailablechange</a>;
 };
 </pre>
     <p class="XXX">
@@ -989,7 +1029,7 @@ interface <dfn id="presentationsession">PresentationSession</dfn> : EventTarget 
         Input
       </dt>
       <dd>
-        <code>presentationUrl</code>, the <a class="external" data-anolis-spec="url" href="https://url.spec.whatwg.org/#url">URL</a> of the document to be presented
+        <code>presentationUrl</code>, the <a href="https://url.spec.whatwg.org/#url" data-anolis-spec="url" class="external">URL</a> of the document to be presented
       </dd>
       <dd>
         <code>presentationId</code>, an optional identifier for the
@@ -999,11 +1039,11 @@ interface <dfn id="presentationsession">PresentationSession</dfn> : EventTarget 
         Output
       </dt>
       <dd>
-        <em>P</em>, a <a class="external" data-anolis-spec="es6" href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-promise-objects" title="promise-objects">Promise</a>
+        <em>P</em>, a <a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-promise-objects" title="promise-objects" data-anolis-spec="es6" class="external">Promise</a>
       </dd>
     </dl>
     <ol>
-      <li>Let <em>P</em> be a new <a class="external" data-anolis-spec="es6" href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-promise-objects" title="promise-objects">Promise</a>.
+      <li>Let <em>P</em> be a new <a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-promise-objects" title="promise-objects" data-anolis-spec="es6" class="external">Promise</a>.
       </li>
       <li>Return <em>P</em>.
       </li>
@@ -1021,7 +1061,7 @@ interface <dfn id="presentationsession">PresentationSession</dfn> : EventTarget 
       empty, then:
         <ol>
           <li>
-            <a class="external" data-anolis-spec="promguide" href="http://www.w3.org/2001/tag/doc/promises-guide#shorthand-manipulating" title="resolve-reject">Reject</a> <em>P</em> with a
+            <a href="http://www.w3.org/2001/tag/doc/promises-guide#shorthand-manipulating" title="resolve-reject" data-anolis-spec="promguide" class="external">Reject</a> <em>P</em> with a
             "NoScreensAvailable" exception.
           </li>
           <li>Abort all remaining steps.
@@ -1029,7 +1069,7 @@ interface <dfn id="presentationsession">PresentationSession</dfn> : EventTarget 
         </ol>
       </li>
       <li>Queue a task <em>T</em> to request user permission for the use of a
-      <a data-anolis-ref="presentation" href="#presentation-display">presentation display</a> and
+      <a href="#presentation-display" data-anolis-ref="presentation">presentation display</a> and
       selection of one presentation display.
         <ol>
           <li>If <em>T</em> completes with the user <em>granting
@@ -1049,10 +1089,10 @@ interface <dfn id="presentationsession">PresentationSession</dfn> : EventTarget 
               <code>disconnected</code>.
               </li>
               <li>
-                <a class="external" data-anolis-spec="w3c-html" href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#queue-a-task">Queue a task</a>
-                <em>C</em> to create a new <a class="external" data-anolis-spec="w3c-html" href="http://www.w3.org/html/wg/drafts/html/master/browsers.html#browsing-context">browsing context</a> on the user-selected
+                <a href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#queue-a-task" data-anolis-spec="w3c-html" class="external">Queue a task</a>
+                <em>C</em> to create a new <a href="http://www.w3.org/html/wg/drafts/html/master/browsers.html#browsing-context" data-anolis-spec="w3c-html" class="external">browsing context</a> on the user-selected
                 <a href="presentation-display">presentation display</a> and
-                <a class="external" data-anolis-spec="w3c-html" href="http://www.w3.org/html/wg/drafts/html/master/browsers.html#navigate">navigate</a> to
+                <a href="http://www.w3.org/html/wg/drafts/html/master/browsers.html#navigate" data-anolis-spec="w3c-html" class="external">navigate</a> to
                 <code>presentationUrl</code> in it.
                 <ol>
                   <li>If <em>C</em> completes successfully, run the following
@@ -1061,7 +1101,7 @@ interface <dfn id="presentationsession">PresentationSession</dfn> : EventTarget 
                       <li>Add <em>(S.url, S.id, S)</em> to <em>D</em>.
                       </li>
                       <li>
-                        <a class="external" data-anolis-spec="promguide" href="http://www.w3.org/2001/tag/doc/promises-guide#shorthand-manipulating" title="resolve-reject">Resolve</a> <em>P</em> with
+                        <a href="http://www.w3.org/2001/tag/doc/promises-guide#shorthand-manipulating" title="resolve-reject" data-anolis-spec="promguide" class="external">Resolve</a> <em>P</em> with
                         <em>S</em>.
                       </li>
                       <li>
@@ -1073,7 +1113,7 @@ interface <dfn id="presentationsession">PresentationSession</dfn> : EventTarget 
                   <li>If <em>C</em> fails, run the following steps:
                     <ol>
                       <li>
-                        <a class="external" data-anolis-spec="promguide" href="http://www.w3.org/2001/tag/doc/promises-guide#shorthand-manipulating" title="resolve-reject">Reject</a> P with a "failed"
+                        <a href="http://www.w3.org/2001/tag/doc/promises-guide#shorthand-manipulating" title="resolve-reject" data-anolis-spec="promguide" class="external">Reject</a> P with a "failed"
                         exception.
                       </li>
                     </ol>
@@ -1086,7 +1126,7 @@ interface <dfn id="presentationsession">PresentationSession</dfn> : EventTarget 
           permission</em>, run the following steps:
             <ol>
               <li>
-                <a class="external" data-anolis-spec="promguide" href="http://www.w3.org/2001/tag/doc/promises-guide#shorthand-manipulating" title="resolve-reject">Reject</a> <em>P</em> with a
+                <a href="http://www.w3.org/2001/tag/doc/promises-guide#shorthand-manipulating" title="resolve-reject" data-anolis-spec="promguide" class="external">Reject</a> <em>P</em> with a
                 "PermissionDenied" exception.
               </li>
             </ol>
@@ -1117,7 +1157,7 @@ interface <dfn id="presentationsession">PresentationSession</dfn> : EventTarget 
         Input
       </dt>
       <dd>
-        <code>presentationUrl</code>, the <a class="external" data-anolis-spec="url" href="https://url.spec.whatwg.org/#url">URL</a> of the document being presented
+        <code>presentationUrl</code>, the <a href="https://url.spec.whatwg.org/#url" data-anolis-spec="url" class="external">URL</a> of the document being presented
       </dd>
       <dd>
         <code>presentationId</code>, the identifier for the presentation
@@ -1126,18 +1166,18 @@ interface <dfn id="presentationsession">PresentationSession</dfn> : EventTarget 
         Output
       </dt>
       <dd>
-        <em>P</em>, a <a class="external" data-anolis-spec="es6" href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-promise-objects" title="promise-objects">Promise</a>
+        <em>P</em>, a <a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-promise-objects" title="promise-objects" data-anolis-spec="es6" class="external">Promise</a>
       </dd>
     </dl>
     <ol>
-      <li>Let <em>P</em> be a new <a class="external" data-anolis-spec="es6" href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-promise-objects" title="promise-objects">Promise</a>.
+      <li>Let <em>P</em> be a new <a href="https://people.mozilla.org/~jorendorff/es6-draft.html#sec-promise-objects" title="promise-objects" data-anolis-spec="es6" class="external">Promise</a>.
       </li>
       <li>Return <em>P</em>.
       </li>
       <li>Let <em>D</em> be the set of presentations known by the user agent.
       </li>
       <li>
-        <a class="external" data-anolis-spec="w3c-html" href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#queue-a-task">Queue a task</a> <em>T</em> to run
+        <a href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#queue-a-task" data-anolis-spec="w3c-html" class="external">Queue a task</a> <em>T</em> to run
         the following steps in order:
         <ol>
           <li>For each presentation <em>(U, I, S)</em> in <em>D</em>,
@@ -1150,7 +1190,7 @@ interface <dfn id="presentationsession">PresentationSession</dfn> : EventTarget 
               following steps:
                 <ol>
                   <li>
-                    <a class="external" data-anolis-spec="promguide" href="http://www.w3.org/2001/tag/doc/promises-guide#shorthand-manipulating" title="resolve-reject">Resolve</a> <em>P</em> with <em>S</em>.
+                    <a href="http://www.w3.org/2001/tag/doc/promises-guide#shorthand-manipulating" title="resolve-reject" data-anolis-spec="promguide" class="external">Resolve</a> <em>P</em> with <em>S</em>.
                   </li>
                   <li>
                     <a href="#establish-a-presentation-connection">Establish a presentation connection</a> with
@@ -1163,7 +1203,7 @@ interface <dfn id="presentationsession">PresentationSession</dfn> : EventTarget 
             </ol>
           </li>
           <li>
-            <a class="external" data-anolis-spec="promguide" href="http://www.w3.org/2001/tag/doc/promises-guide#shorthand-manipulating" title="resolve-reject">Reject</a> <em>P</em> with a
+            <a href="http://www.w3.org/2001/tag/doc/promises-guide#shorthand-manipulating" title="resolve-reject" data-anolis-spec="promguide" class="external">Reject</a> <em>P</em> with a
             "NoPresentationFound" exception.
           </li>
         </ol>
@@ -1217,7 +1257,7 @@ interface <dfn id="presentationsession">PresentationSession</dfn> : EventTarget 
         </ol>
       </li>
       <li>
-        <a class="external" data-anolis-spec="w3c-html" href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#queue-a-task">Queue a task</a> <em>T</em> to
+        <a href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#queue-a-task" data-anolis-spec="w3c-html" class="external">Queue a task</a> <em>T</em> to
         connect <em>S</em> to the document that is presenting <em>S.url</em>.
       </li>
       <li>If <em>T</em> completes successfully, run the following steps:
@@ -1238,8 +1278,8 @@ interface <dfn id="presentationsession">PresentationSession</dfn> : EventTarget 
                   is equal to <em>S.id</em>, run the following steps:
                     <ol>
                       <li>
-                        <a class="external" data-anolis-spec="w3c-html" href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#queue-a-task">Queue a task</a>
-                        to <a class="external" data-anolis-spec="w3c-html" href="http://www.w3.org/html/wg/drafts/html/master/infrastructure.html#concept-event-fire" title="concept-event-fire">fire an event</a> named
+                        <a href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#queue-a-task" data-anolis-spec="w3c-html" class="external">Queue a task</a>
+                        to <a href="http://www.w3.org/html/wg/drafts/html/master/infrastructure.html#concept-event-fire" title="concept-event-fire" data-anolis-spec="w3c-html" class="external">fire an event</a> named
                         <code>statechange</code> at <em>s.onstatechange</em>.
                       </li>
                     </ol>
@@ -1327,7 +1367,7 @@ dictionary <dfn id="availablechangeeventinit">AvailableChangeEventInit</dfn> : E
       presentation display availability</dfn>, it must run the following steps:
     </p>
     <p>
-      When a new <a class="external" data-anolis-spec="w3c-html" href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#event-handlers" title="event handlers">event
+      When a new <a href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#event-handlers" title="event handlers" data-anolis-spec="w3c-html" class="external">event
       handler</a> <em>E</em> is added to
       <code><a href="#navigatorpresentation">NavigatorPresentation</a>.onavailablechange</code>, the
       user agent must run the <a href="monitor-availability-algorithm">algorithm to monitor availability</a>.
@@ -1347,7 +1387,7 @@ dictionary <dfn id="availablechangeeventinit">AvailableChangeEventInit</dfn> : E
       presentation display availability</dfn>, it must run the following steps:
     </p>
     <p>
-      When the last <a class="external" data-anolis-spec="w3c-html" href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#event-handlers" title="event handlers">event handler</a> is removed from
+      When the last <a href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#event-handlers" title="event handlers" data-anolis-spec="w3c-html" class="external">event handler</a> is removed from
       <code>NavigatorPresentation.onavailablechange</code>, the user agent may
       run the following steps:
     </p>
@@ -1361,14 +1401,14 @@ dictionary <dfn id="availablechangeeventinit">AvailableChangeEventInit</dfn> : E
       availability</dfn>, it must run the following steps ...
     </p>
     <p>
-      While there are <a class="external" data-anolis-spec="w3c-html" href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#event-handlers">event handlers</a>
+      While there are <a href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#event-handlers" data-anolis-spec="w3c-html" class="external">event handlers</a>
       added to NavigatorPresentation.onavailablechange, the user agent must
       continuously keep track of the available <a href="#presentation-display">presentation displays</a> and repeat the
       following steps:
     </p>
     <ol>
       <li>
-        <a class="external" data-anolis-spec="w3c-html" href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#queue-a-task">Queue a task</a> to retrieve the
+        <a href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#queue-a-task" data-anolis-spec="w3c-html" class="external">Queue a task</a> to retrieve the
         the list of curently available <a href="#presentation-display">presentation displays</a> and let <a id="newdisplays"><em>newDisplays</em></a> be this list.
       </li>
       <li>Wait for the completion of that task.
@@ -1377,8 +1417,8 @@ dictionary <dfn id="availablechangeeventinit">AvailableChangeEventInit</dfn> : E
       <a href="#newdisplays">newDisplays</a> is not empty, then
         <ol>
           <li>
-            <a class="external" data-anolis-spec="w3c-html" href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#queue-a-task">Queue a task</a> to
-            <a class="external" data-anolis-spec="w3c-html" href="http://www.w3.org/html/wg/drafts/html/master/infrastructure.html#concept-event-fire" title="concept-event-fire">fire
+            <a href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#queue-a-task" data-anolis-spec="w3c-html" class="external">Queue a task</a> to
+            <a href="http://www.w3.org/html/wg/drafts/html/master/infrastructure.html#concept-event-fire" title="concept-event-fire" data-anolis-spec="w3c-html" class="external">fire
             an event</a> named <code>availablechange</code> at <em>E</em>
             (and only <em>E</em>) with the event's <code>available</code>
             property set to <code>true</code>.
@@ -1388,8 +1428,8 @@ dictionary <dfn id="availablechangeeventinit">AvailableChangeEventInit</dfn> : E
       <li>If <a href="#availabledisplays">availableDisplays</a> is not empty
       and <a href="#newdisplays">newDisplays</a> is empty, then:
         <div style="margin-left: 2em">
-          <a class="external" data-anolis-spec="w3c-html" href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#queue-a-task">Queue a task</a> to
-          <a class="external" data-anolis-spec="w3c-html" href="http://www.w3.org/html/wg/drafts/html/master/infrastructure.html#concept-event-fire" title="concept-event-fire">fire an
+          <a href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#queue-a-task" data-anolis-spec="w3c-html" class="external">Queue a task</a> to
+          <a href="http://www.w3.org/html/wg/drafts/html/master/infrastructure.html#concept-event-fire" title="concept-event-fire" data-anolis-spec="w3c-html" class="external">fire an
           event</a> named <code>availablechange</code> at <em>E</em> (and
           only <em>E</em>) with the event's <code>available</code> property set
           to <code>false</code>.
@@ -1402,9 +1442,6 @@ dictionary <dfn id="availablechangeeventinit">AvailableChangeEventInit</dfn> : E
     <h3 id="todo"><span class="secno">6.5 </span>
       TODO
     </h3>
-    <p class="open-issue">
-      Need algorithm for send message
-    </p>
     <p class="open-issue">
       Need algorithm for receive message
     </p>

--- a/index.html
+++ b/index.html
@@ -255,10 +255,10 @@
     </a>
   <ol>
    <li><a href="#common-idioms"><span class="secno">6.1 </span>
-      Common Idioms
+      Common idioms
     </a></li>
    <li><a href="#common-definitions"><span class="secno">6.2 </span>
-      Common Definitions
+      Common definitions
     </a></li>
    <li><a href="#interface-presentationsession"><span class="secno">6.3 </span>
       Interface <code>PresentationSession</code>
@@ -863,7 +863,7 @@ function setSession(theSession) {
       API
     </h2>
     <h3 id="common-idioms"><span class="secno">6.1 </span>
-      Common Idioms
+      Common idioms
     </h3>
     <p>
       A <dfn id="presentation-display">presentation display</dfn> refers to an external screen available
@@ -889,7 +889,7 @@ function setSession(theSession) {
       sessions</a> are initiated.
     </p>
     <h3 id="common-definitions"><span class="secno">6.2 </span>
-      Common Definitions
+      Common definitions
     </h3>
     <p>
       Let <em>D</em> be the set of presentations that are currently known to

--- a/index.html
+++ b/index.html
@@ -251,8 +251,8 @@
       APIs for interacting with presentation sessions
     </a>
   <ol>
-   <li><a href="#introduction-0"><span class="secno">6.1 </span>
-      Introduction
+   <li><a href="#common-idioms"><span class="secno">6.1 </span>
+      Common idioms
     </a></li>
    <li><a href="#interface-presentationsession"><span class="secno">6.2 </span>
       Interface <code>PresentationSession</code>
@@ -832,8 +832,8 @@ function setSession(theSession) {
     <h2 id="apis-for-interacting-with-presentation-sessions"><span class="secno">6 </span>
       APIs for interacting with presentation sessions
     </h2>
-    <h3 id="introduction-0"><span class="secno">6.1 </span>
-      Introduction
+    <h3 id="common-idioms"><span class="secno">6.1 </span>
+      Common idioms
     </h3>
     <p>
       A <dfn id="presentation-display" title="presentation display">presentation display</dfn> refers to

--- a/index.html
+++ b/index.html
@@ -252,7 +252,7 @@
     </a>
   <ol>
    <li><a href="#common-idioms"><span class="secno">6.1 </span>
-      Common idioms
+      Common Idioms
     </a></li>
    <li><a href="#interface-presentationsession"><span class="secno">6.2 </span>
       Interface <code>PresentationSession</code>
@@ -843,11 +843,17 @@ function setSession(theSession) {
       API
     </h2>
     <h3 id="common-idioms"><span class="secno">6.1 </span>
-      Common idioms
+      Common Idioms
     </h3>
     <p>
       A <dfn id="presentation-display">presentation display</dfn> refers to an external screen available
       to the user agent via an implementation specific connection technology.
+    </p>
+    <p>
+      A <dfn title="concept-presentation" id="concept-presentation">presentation</dfn>, in the context of
+      this specification, is an active connection between a user agent and a
+      <a href="#presentation-display">presentation display</a> with the intent of displaying web
+      content on the latter.
     </p>
     <p>
       A <dfn title="concept-presentation-session" id="concept-presentation-session">presentation session</dfn> is
@@ -882,8 +888,8 @@ interface <dfn id="presentationsession">PresentationSession</dfn> : EventTarget 
 };
 </pre>
     <p>
-      The <dfn id="id"><code>id</code></dfn> attribute holds the <a href="#presentation-session-identifier">presentation
-      session identifier</a>.
+      The <dfn id="id"><code>id</code></dfn> attribute holds the alphanumeric
+      <a href="#presentation-session-identifier">presentation session identifier</a>.
     </p>
     <p>
       The <dfn id="state"><code>state</code></dfn> attribute represents the
@@ -1384,11 +1390,11 @@ dictionary <dfn id="availablechangeeventinit">AvailableChangeEventInit</dfn> : E
     </p><a href="monitor-availability-algorithm">algorithm to monitor
     availability</a>.
     <p class="note">
-      The mechanism used to monitor
-    </p><a href="#presentation-display">presention displays</a> availability is
-    left to the user agent. The user agent may choose search for screens at any
-    time, not just when event handlers are added to
-    <code>NavigatorPresentation.onavailablechange</code>.
+      The mechanism used to monitor <a href="#presentation-display">presention
+      displays</a> availability is left to the user agent. The user agent may
+      choose search for screens at any time, not just when event handlers are
+      added to <code>NavigatorPresentation.onavailablechange</code>.
+    </p>
     <p class="open-issue">
       Do we want to fire the event at all handlers, or only the newly added
       one?

--- a/index.html
+++ b/index.html
@@ -62,11 +62,13 @@
     }
 
     code { color: orangered; }
-    .XXX { background: white; border: solid #78AB46; padding: 0.5em; margin: 1em 0; }
     table { border-collapse: collapse; border-style: hidden hidden none hidden; }
     table thead, table tbody { border-bottom: solid; }
     table td, table th { border-left: solid; border-right: solid; border-bottom: solid thin; vertical-align: top; padding: 0.2em; }
     dfn { font-weight: bolder; font-style: normal; }
+
+    h2, h3 { padding-top: 1.3em; }
+    h4 { padding-top: 1.2em; }
     </style>
   </head>
   <body>
@@ -255,52 +257,52 @@
    <li><a href="#common-idioms"><span class="secno">6.1 </span>
       Common Idioms
     </a></li>
-   <li><a href="#interface-presentationsession"><span class="secno">6.2 </span>
+   <li><a href="#common-definitions"><span class="secno">6.2 </span>
+      Common Definitions
+    </a></li>
+   <li><a href="#interface-presentationsession"><span class="secno">6.3 </span>
       Interface <code>PresentationSession</code>
     </a>
     <ol>
-     <li><a href="#posting-a-message-through-presentationsession"><span class="secno">6.2.1 </span>
+     <li><a href="#posting-a-message-through-presentationsession"><span class="secno">6.3.1 </span>
       Posting a message through <code>PresentationSession</code>
     </a></li>
-     <li><a href="#closing-a-presentationsession"><span class="secno">6.2.2 </span>
+     <li><a href="#closing-a-presentationsession"><span class="secno">6.3.2 </span>
       Closing a <code>PresentationSession</code>
     </a></li>
-     <li><a href="#event-handlers"><span class="secno">6.2.3 </span>
+     <li><a href="#event-handlers"><span class="secno">6.3.3 </span>
       Event Handlers
     </a></ol></li>
-   <li><a href="#interface-navigatorpresentation"><span class="secno">6.3 </span>
+   <li><a href="#interface-navigatorpresentation"><span class="secno">6.4 </span>
       Interface <code>NavigatorPresentation</code>
     </a>
     <ol>
-     <li><a href="#common-definitions-for-this-section"><span class="secno">6.3.1 </span>
-      Common Definitions for this Section
-    </a></li>
-     <li><a href="#starting-a-presentation-session"><span class="secno">6.3.2 </span>
+     <li><a href="#starting-a-presentation-session"><span class="secno">6.4.1 </span>
       Starting a presentation session
     </a></li>
-     <li><a href="#joining-a-presentation-session"><span class="secno">6.3.3 </span>
+     <li><a href="#joining-a-presentation-session"><span class="secno">6.4.2 </span>
       Joining a presentation session
     </a></li>
-     <li><a href="#establishing-a-presentation-connection"><span class="secno">6.3.4 </span>
+     <li><a href="#establishing-a-presentation-connection"><span class="secno">6.4.3 </span>
       Establishing a presentation connection
     </a></li>
-     <li><a href="#the-onavailablechange-eventhandler"><span class="secno">6.3.5 </span>
+     <li><a href="#the-onavailablechange-eventhandler"><span class="secno">6.4.4 </span>
       The <code>onavailablechange</code> EventHandler
     </a>
       <ol>
-       <li><a href="#adding-an-eventhandler-to-onavailablechange"><span class="secno">6.3.5.1 </span>
+       <li><a href="#adding-an-eventhandler-to-onavailablechange"><span class="secno">6.4.4.1 </span>
       Adding an <code>EventHandler</code> to <code>onavailablechange</code>
     </a></li>
-       <li><a href="#removing-an-eventhandler"><span class="secno">6.3.5.2 </span>
+       <li><a href="#removing-an-eventhandler"><span class="secno">6.4.4.2 </span>
       Removing an <code>EventHandler</code>
     </a></li>
-       <li><a href="#monitoring-the-list-of-available-presentation-displays"><span class="secno">6.3.5.3 </span>
+       <li><a href="#monitoring-the-list-of-available-presentation-displays"><span class="secno">6.4.4.3 </span>
       Monitoring the list of available presentation displays
     </a></ol></ol></li>
-   <li><a href="#interface-availablechangeevent"><span class="secno">6.4 </span>
+   <li><a href="#interface-availablechangeevent"><span class="secno">6.5 </span>
       <span>Interface <code>AvailableChangeEvent</code></span>
     </a></li>
-   <li><a href="#todo"><span class="secno">6.5 </span>
+   <li><a href="#todo"><span class="secno">6.6 </span>
       TODO
     </a></ol></li>
  <li><a href="#references" class="no-num">
@@ -886,7 +888,20 @@ function setSession(theSession) {
       which <a href="#concept-presentation-session" title="concept-presentation-session">presentation
       sessions</a> are initiated.
     </p>
-    <h3 id="interface-presentationsession"><span class="secno">6.2 </span>
+    <h3 id="common-definitions"><span class="secno">6.2 </span>
+      Common Definitions
+    </h3>
+    <p>
+      Let <em>D</em> be the set of presentations that are currently known to
+      the user agent (regardles of their state). <em>D</em> is represented as a
+      set of tuples <em>(U, I, S)</em> where <em>U</em> is the
+      <a href="https://url.spec.whatwg.org/#url" data-anolis-spec="url" class="external">URL</a> that is being presented;
+      <em>I</em> is an alphanumeric identifier for the presentation; and
+      <em>S</em> is the user agent's <a href="#presentationsession"><code>PresentationSession</code></a> for the
+      presentation. <em>U</em> and <em>I</em> together uniquely identify the
+      <a href="#presentationsession"><code>PresentationSession</code></a> of the corresponding presentation.
+    </p>
+    <h3 id="interface-presentationsession"><span class="secno">6.3 </span>
       Interface <a href="#presentationsession"><code>PresentationSession</code></a>
     </h3>
     <p>
@@ -923,16 +938,15 @@ interface <dfn id="presentationsession">PresentationSession</dfn> : EventTarget 
     </p>
     <p>
       When the <dfn id="close"><code>close</code></dfn>() method is called on a
-      <a href="#presentationsession"><code>PresentationSession</code></a> <em>S</em>, the user agent must run the
-      algorithm to <a href="#close-algorithm" title="close-algorithm">close a presentation
-      session</a>.
+      <a href="#presentationsession"><code>PresentationSession</code></a>, the user agent must run the algorithm
+      to <a href="#close-algorithm" title="close-algorithm">close a presentation session</a>.
     </p>
-    <h4 id="posting-a-message-through-presentationsession"><span class="secno">6.2.1 </span>
+    <h4 id="posting-a-message-through-presentationsession"><span class="secno">6.3.1 </span>
       Posting a message through <a href="#presentationsession"><code>PresentationSession</code></a>
     </h4>
     <p>
       When the user agent is to <dfn title="algorithm-post-message" id="algorithm-post-message">post a
-      message through a <code>PresentationSession</code> S</dfn>, it mus run
+      message through a <code>PresentationSession</code> S</dfn>, it must run
       the following steps:
     </p>
     <p class="open-issue">
@@ -942,7 +956,7 @@ interface <dfn id="presentationsession">PresentationSession</dfn> : EventTarget 
       WHATWG HTML spec's <code>MessageEvent</code> section</a>, or the <a href="http://w3c.github.io/webrtc-pc/#rtcdatachannel">WebRTC's spec
       <code>RPCDataChannel</code>.</a>
     </p>
-    <h4 id="closing-a-presentationsession"><span class="secno">6.2.2 </span>
+    <h4 id="closing-a-presentationsession"><span class="secno">6.3.2 </span>
       Closing a <a href="#presentationsession"><code>PresentationSession</code></a>
     </h4>
     <p>
@@ -984,7 +998,7 @@ interface <dfn id="presentationsession">PresentationSession</dfn> : EventTarget 
         </ol>
       </li>
     </ol>
-    <h4 id="event-handlers"><span class="secno">6.2.3 </span>
+    <h4 id="event-handlers"><span class="secno">6.3.3 </span>
       Event Handlers
     </h4>
     <p>
@@ -1023,7 +1037,7 @@ interface <dfn id="presentationsession">PresentationSession</dfn> : EventTarget 
         </tr>
       </tbody>
     </table>
-    <h3 id="interface-navigatorpresentation"><span class="secno">6.3 </span>
+    <h3 id="interface-navigatorpresentation"><span class="secno">6.4 </span>
       Interface <a href="#navigatorpresentation"><code>NavigatorPresentation</code></a>
     </h3>
     <pre class="idl">partial interface <a href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#navigator" data-anolis-spec="w3c-html" class="external">Navigator</a> {
@@ -1048,20 +1062,7 @@ interface <dfn id="presentationsession">PresentationSession</dfn> : EventTarget 
       to define, when it should contain a value, and when it should be empty -
       and it's not compatible with multiple calls to startSession, for example.
     </p>
-    <h4 id="common-definitions-for-this-section"><span class="secno">6.3.1 </span>
-      Common Definitions for this Section
-    </h4>
-    <p>
-      Let <em>D</em> be the set of presentations that are currently known to
-      the user agent (regardles of their state). <em>D</em> is represented as a
-      set of tuples <em>(U, I, S)</em> where <em>U</em> is the
-      <a href="https://url.spec.whatwg.org/#url" data-anolis-spec="url" class="external">URL</a> that is being presented;
-      <em>I</em> is an alphanumeric identifier for the presentation; and
-      <em>S</em> is the user agent's <a href="#presentationsession"><code>PresentationSession</code></a> for the
-      presentation. <em>U</em> and <em>I</em> together uniquely identify the
-      <a href="#presentationsession"><code>PresentationSession</code></a> of the corresponding presentation.
-    </p>
-    <h4 id="starting-a-presentation-session"><span class="secno">6.3.2 </span>
+    <h4 id="starting-a-presentation-session"><span class="secno">6.4.1 </span>
       Starting a presentation session
     </h4>
     <p>
@@ -1190,7 +1191,7 @@ interface <dfn id="presentationsession">PresentationSession</dfn> : EventTarget 
       no-screens-available outcome? Developers would be able to infer it anyway
       from <a href="#onavailablechange"><code>onavailablechange</code></a>.
     </p>
-    <h4 id="joining-a-presentation-session"><span class="secno">6.3.3 </span>
+    <h4 id="joining-a-presentation-session"><span class="secno">6.4.2 </span>
       Joining a presentation session
     </h4>
     <p>
@@ -1258,7 +1259,7 @@ interface <dfn id="presentationsession">PresentationSession</dfn> : EventTarget 
       If no matching presentation is found, we could leave the Promise pending
       in case a matching presentation is started in the future.
     </p>
-    <h4 id="establishing-a-presentation-connection"><span class="secno">6.3.4 </span>
+    <h4 id="establishing-a-presentation-connection"><span class="secno">6.4.3 </span>
       Establishing a presentation connection
     </h4>
     <p>
@@ -1331,7 +1332,7 @@ interface <dfn id="presentationsession">PresentationSession</dfn> : EventTarget 
       Need to further specify the semantics of the messaging channel (using
       WebSockets or MessagePort as a reference).
     </p>
-    <h4 id="the-onavailablechange-eventhandler"><span class="secno">6.3.5 </span>
+    <h4 id="the-onavailablechange-eventhandler"><span class="secno">6.4.4 </span>
       The <a href="#onavailablechange"><code>onavailablechange</code></a> EventHandler
     </h4>
     <p>
@@ -1372,7 +1373,7 @@ interface <dfn id="presentationsession">PresentationSession</dfn> : EventTarget 
       the following, the user agent behavior, depending on the number of
       registered <code>EventHandler</code>s, is described.
     </p>
-    <h5 id="adding-an-eventhandler-to-onavailablechange"><span class="secno">6.3.5.1 </span>
+    <h5 id="adding-an-eventhandler-to-onavailablechange"><span class="secno">6.4.4.1 </span>
       Adding an <code>EventHandler</code> to <a href="#onavailablechange"><code>onavailablechange</code></a>
     </h5>
     <p>
@@ -1381,7 +1382,7 @@ interface <dfn id="presentationsession">PresentationSession</dfn> : EventTarget 
       <a href="#algorithm-monitor-available" title="algorithm-monitor-available">algorithm to monitor the list
       of available presentation displays</a>.
     </p>
-    <h5 id="removing-an-eventhandler"><span class="secno">6.3.5.2 </span>
+    <h5 id="removing-an-eventhandler"><span class="secno">6.4.4.2 </span>
       Removing an <code>EventHandler</code>
     </h5>
     <p>
@@ -1395,7 +1396,7 @@ interface <dfn id="presentationsession">PresentationSession</dfn> : EventTarget 
       displays</a>.
       </li>
     </ol>
-    <h5 id="monitoring-the-list-of-available-presentation-displays"><span class="secno">6.3.5.3 </span>
+    <h5 id="monitoring-the-list-of-available-presentation-displays"><span class="secno">6.4.4.3 </span>
       Monitoring the list of available presentation displays
     </h5>
     <p>
@@ -1470,7 +1471,7 @@ interface <dfn id="presentationsession">PresentationSession</dfn> : EventTarget 
         <code>false</code>.
       </li>
     </ol>
-    <h3 id="interface-availablechangeevent"><span class="secno">6.4 </span>
+    <h3 id="interface-availablechangeevent"><span class="secno">6.5 </span>
       <span>Interface <a href="#availablechangeevent"><code>AvailableChangeEvent</code></a></span>
     </h3>
     <pre class="idl"><span>[Constructor(DOMString type, optional <a href="#availablechangeeventinit">AvailableChangeEventInit</a> eventInitDict)]
@@ -1492,7 +1493,7 @@ dictionary <dfn id="availablechangeeventinit">AvailableChangeEventInit</dfn> : E
       <code>available</code> attribute set to the boolean value that the
       algorithm determined.
     </p>
-    <h3 id="todo"><span class="secno">6.5 </span>
+    <h3 id="todo"><span class="secno">6.6 </span>
       TODO
     </h3>
     <p class="open-issue">

--- a/index.html
+++ b/index.html
@@ -700,28 +700,30 @@ function setSession(theSession) {
     <p>
       If the user selects a screen with an existing presentation showing the
       same <code>url</code> under the same <code>presentationId</code>, the
-      opener page is connected to that existing presentation. If the user
-      selects a screen without an existing presentation, or a screen presenting
-      a different <code>url</code> or <code>presentationId</code>, the UA
-      connects to the selected screen, brings up a new presentation window on
-      it, and starts to show the content denoted by the <code>url</code>
-      argument. The UA then connects the opener page to this new presentation
-      and allows the opener page to exchange messages with it.
+      <a href="#opening-browsing-context">opening browsing context</a> is connected to that existing
+      presentation. If the user selects a screen without an existing
+      presentation, or a screen presenting a different <code>url</code> or
+      <code>presentationId</code>, the UA connects to the selected screen,
+      brings up a new presentation window on it, and starts to show the content
+      denoted by the <code>url</code> argument. The UA then connects the
+      <a href="#opening-browsing-context">opening browsing context</a> to this new presentation and allows
+      the <a href="#opening-browsing-context">opening browsing context</a> to exchange messages with it.
     </p>
     <p>
       <code>navigator.presentation.startSession(url, presentationId)</code>
-      returns a <code>Promise</code> to the opener page. When the user selects
-      a screen, the presentation page is shown and a communication channel has
-      been established the <code>Promise</code> resolves to a
-      <a href="#presentationsession"><code>PresentationSession</code></a> object, which acts as a handle to the
-      presentation for communication and state handling. Initially, the state
-      of the <a href="#presentationsession"><code>PresentationSession</code></a> is <code>"connected"</code>. At
-      this point, the opener page can communicate with the presentation page
-      using the session's <code>postMessage()</code> to send messages and its
-      <a href="#onmessage"><code>onmessage</code></a> event handler to receive messages. The
-      presentation page will also have access to
+      returns a <code>Promise</code> to the <a href="#opening-browsing-context">opening browsing
+      context</a>. When the user selects a screen, the presentation page is
+      shown and a communication channel has been established the
+      <code>Promise</code> resolves to a <a href="#presentationsession"><code>PresentationSession</code></a>
+      object, which acts as a handle to the presentation for communication and
+      state handling. Initially, the state of the
+      <a href="#presentationsession"><code>PresentationSession</code></a> is <code>"connected"</code>. At this
+      point, the <a href="#opening-browsing-context">opening browsing context</a> can communicate with the
+      presentation page using the session's <code>postMessage()</code> to send
+      messages and its <a href="#onmessage"><code>onmessage</code></a> event handler to receive
+      messages. The presentation page will also have access to
       <a href="#presentationsession"><code>PresentationSession</code></a> that it can use to send and receive
-      messages with the opener page (see <a href="#usage-on-remote-screen">Usage on remote screen</a>).
+      messages with the <a href="#opening-browsing-context">opening browsing context</a> (see <a href="#usage-on-remote-screen">Usage on remote screen</a>).
     </p>
     <p>
       If the user cancels screen selection, the <code>Promise</code> returned
@@ -739,18 +741,19 @@ function setSession(theSession) {
       Automatically reconnecting to existing presentations
     </h4>
     <p>
-      The opener page may wish to reconnect to an existing presentation without
-      prompting the user to select a screen. For example, the site could allow
-      media items from different pages to be shown on the same presentation
-      page, and does not want to prompt the user on each page to reconnect to
-      that presentation. To reconnect automatically, the page may call
-      <code>joinSession(url, presentationId)</code>, which returns a
-      <code>Promise</code> that resolves to an existing
-      <a href="#presentationsession"><code>PresentationSession</code></a> if one exists that is presenting the
-      same <code>url</code> with the same <code>presentationId</code> as was
-      passed originally into <a href="#startsession"><code>startSession</code></a>. The requesting page can
-      then communicate with the presentation as if the user had manually
-      connected to it via <a href="#startsession"><code>startSession</code></a>.
+      The <a href="#opening-browsing-context">opening browsing context</a> may wish to reconnect to an
+      existing presentation without prompting the user to select a screen. For
+      example, the site could allow media items from different pages to be
+      shown on the same presentation page, and does not want to prompt the user
+      on each page to reconnect to that presentation. To reconnect
+      automatically, the page may call <code>joinSession(url,
+      presentationId)</code>, which returns a <code>Promise</code> that
+      resolves to an existing <a href="#presentationsession"><code>PresentationSession</code></a> if one exists
+      that is presenting the same <code>url</code> with the same
+      <code>presentationId</code> as was passed originally into
+      <a href="#startsession"><code>startSession</code></a>. The requesting page can then communicate with
+      the presentation as if the user had manually connected to it via
+      <a href="#startsession"><code>startSession</code></a>.
     </p>
     <p>
       At the time <code>joinSession(url, presentationId)</code> is called, if
@@ -802,8 +805,8 @@ function setSession(theSession) {
     <p class="open-issue">
       Do we need an additional state like resumed in order to identify resumed
       session? It seems that this could be handled on the page level. The
-      opener page could ask the presentation page whether it is
-      <code>"new"</code> or <code>"resumed"</code>.
+      <a href="#opening-browsing-context">opening browsing context</a> could ask the presentation page
+      whether it is <code>"new"</code> or <code>"resumed"</code>.
     </p>
     <h3 id="usage-on-remote-screen"><span class="secno">5.4 </span>
       Usage on remote screen
@@ -817,14 +820,14 @@ function setSession(theSession) {
     </p>
     <pre class="example">if (navigator.presentation.session) {
   var session = navigator.presentation.session;
-  // Communicate with opener page.
+  // Communicate with opening browsing context
   session.postMessage(/*...*/);
   session.onmessage = function() {/*...*/};
 
   session.onstatechange = function() {
     switch (this.state) {
       case "disconnected":
-        // Handle disconnection from opener page.
+        // Handle disconnection from opening browsing context
     }
   };
 };
@@ -836,22 +839,23 @@ function setSession(theSession) {
       <code>navigator.presentation.session</code> property set to the session.
       This session is a similar object as in the first example. Here, its
       initial state is <code>"connected"</code>, which means we can use it to
-      communicate with the opener page using <code>postMessage()</code> and
-      <a href="#onmessage"><code>onmessage</code></a>.
+      communicate with the <a href="#opening-browsing-context">opening browsing context</a> using
+      <code>postMessage()</code> and <a href="#onmessage"><code>onmessage</code></a>.
     </p>
     <p>
       The presentation page can also monitor the connection state by listening
       for <code>statechange</code> events. When the state changes to
       <code>"disconnected"</code> the page is made aware of the fact that
-      communication with the opener page was lost, but it can continue to
-      display the current content. The communication can be re-established when
-      a <code>statechange</code> event fires with a new state of
-      <code>"connected"</code>.
+      communication with the <a href="#opening-browsing-context">opening browsing context</a> was lost,
+      but it can continue to display the current content. The communication can
+      be re-established when a <code>statechange</code> event fires with a new
+      state of <code>"connected"</code>.
     </p>
     <p class="open-issue">
-      Since we permit multiple opener pages to connect the same presentation
-      page, we need to define how connection and disconnection of these pages
-      is communicated to the presentation page (if at all).
+      Since we permit multiple <span title="opening-browsing-context">opening
+      browsing context</span> to connect the same presentation page, we need to
+      define how connection and disconnection of these pages is communicated to
+      the presentation page (if at all).
     </p>
     <h2 id="api"><span class="secno">6 </span>
       API
@@ -1306,11 +1310,11 @@ interface <dfn id="presentationsession">PresentationSession</dfn> : EventTarget 
     </ol>
     <p class="note">
       The mechanism that is used to present on the remote display and connect
-      the opening document with the presented document is an implementation
-      choice of the user agent. The connection must provide a two-way messaging
-      abstraction capable of carrying <code>DOMString</code> payloads in a
-      reliable and in-order fashion as described in the <em>Send Message</em>
-      and <em>Receive Message</em> steps below.
+      the <a href="#opening-browsing-context">opening browsing context</a> with the presented document is
+      an implementation choice of the user agent. The connection must provide a
+      two-way messaging abstraction capable of carrying <code>DOMString</code>
+      payloads in a reliable and in-order fashion as described in the <em>Send
+      Message</em> and <em>Receive Message</em> steps below.
     </p>
     <p class="note">
       If <em>T</em> does not complete successfully, the user agent may choose

--- a/index.html
+++ b/index.html
@@ -272,21 +272,30 @@
       Interface <code>NavigatorPresentation</code>
     </a>
     <ol>
-     <li><a href="#starting-a-presentation-session"><span class="secno">6.3.1 </span>
+     <li><a href="#common-definitions-for-this-section"><span class="secno">6.3.1 </span>
+      Common Definitions for this Section
+    </a></li>
+     <li><a href="#starting-a-presentation-session"><span class="secno">6.3.2 </span>
       Starting a presentation session
     </a></li>
-     <li><a href="#joining-a-presentation-session"><span class="secno">6.3.2 </span>
+     <li><a href="#joining-a-presentation-session"><span class="secno">6.3.3 </span>
       Joining a presentation session
     </a></li>
-     <li><a href="#establishing-a-presentation-connection"><span class="secno">6.3.3 </span>
+     <li><a href="#establishing-a-presentation-connection"><span class="secno">6.3.4 </span>
       Establishing a presentation connection
     </a></li>
-     <li><a href="#the-onavailablechange-eventhandler"><span class="secno">6.3.4 </span>
+     <li><a href="#the-onavailablechange-eventhandler"><span class="secno">6.3.5 </span>
       The <code>onavailablechange</code> EventHandler
     </a>
       <ol>
-       <li><a href="#updating-the-list-of-available-presentation-displays"><span class="secno">6.3.4.1 </span>
-      Updating the list of available presentation displays
+       <li><a href="#adding-an-eventhandler-to-onavailablechange"><span class="secno">6.3.5.1 </span>
+      Adding an <code>EventHandler</code> to <code>onavailablechange</code>
+    </a></li>
+       <li><a href="#removing-an-eventhandler"><span class="secno">6.3.5.2 </span>
+      Removing an <code>EventHandler</code>
+    </a></li>
+       <li><a href="#monitoring-the-list-of-available-presentation-displays"><span class="secno">6.3.5.3 </span>
+      Monitoring the list of available presentation displays
     </a></ol></ol></li>
    <li><a href="#interface-availablechangeevent"><span class="secno">6.4 </span>
       <span>Interface <code>AvailableChangeEvent</code></span>
@@ -1035,7 +1044,20 @@ interface <dfn id="presentationsession">PresentationSession</dfn> : EventTarget 
       to define, when it should contain a value, and when it should be empty -
       and it's not compatible with multiple calls to startSession, for example.
     </p>
-    <h4 id="starting-a-presentation-session"><span class="secno">6.3.1 </span>
+    <h4 id="common-definitions-for-this-section"><span class="secno">6.3.1 </span>
+      Common Definitions for this Section
+    </h4>
+    <p>
+      Let <em>D</em> be the set of presentations that are currently known to
+      the user agent (regardles of their state). <em>D</em> is represented as a
+      set of tuples <em>(U, I, S)</em> where <em>U</em> is the
+      <a href="https://url.spec.whatwg.org/#url" data-anolis-spec="url" class="external">URL</a> that is being presented;
+      <em>I</em> is an alphanumeric identifier for the presentation; and
+      <em>S</em> is the user agent's <a href="#presentationsession"><code>PresentationSession</code></a> for the
+      presentation. <em>U</em> and <em>I</em> together uniquely identify the
+      <a href="#presentationsession"><code>PresentationSession</code></a> of the corresponding presentation.
+    </p>
+    <h4 id="starting-a-presentation-session"><span class="secno">6.3.2 </span>
       Starting a presentation session
     </h4>
     <p>
@@ -1066,11 +1088,11 @@ interface <dfn id="presentationsession">PresentationSession</dfn> : EventTarget 
       </li>
       <li>Return <em>P</em>.
       </li>
-      <li>If the user agent does not <a href="#monitor-presentation-display-availability">monitor presentation display
-      availability</a>, run the following steps:
+      <li>If the user agent does not <span>monitor presentation display
+      availability</span>, run the following steps:
         <ol>
           <li>
-            <a href="#monitor-presentation-display-availability">Monitor presentation display availability</a>.
+            <span>Monitor presentation display availability</span>.
           </li>
           <li>Wait until the algorithm completes.
           </li>
@@ -1164,7 +1186,7 @@ interface <dfn id="presentationsession">PresentationSession</dfn> : EventTarget 
       no-screens-available outcome? Developers would be able to infer it anyway
       from <a href="#onavailablechange"><code>onavailablechange</code></a>.
     </p>
-    <h4 id="joining-a-presentation-session"><span class="secno">6.3.2 </span>
+    <h4 id="joining-a-presentation-session"><span class="secno">6.3.3 </span>
       Joining a presentation session
     </h4>
     <p>
@@ -1232,10 +1254,10 @@ interface <dfn id="presentationsession">PresentationSession</dfn> : EventTarget 
       If no matching presentation is found, we could leave the Promise pending
       in case a matching presentation is started in the future.
     </p>
-    <h4 id="establishing-a-presentation-connection"><span class="secno">6.3.3 </span>
+    <h4 id="establishing-a-presentation-connection"><span class="secno">6.3.4 </span>
       Establishing a presentation connection
     </h4>
-    <p class="XXX">
+    <p>
       When the user agent is to <dfn id="establish-a-presentation-connection">establish a presentation connection</dfn>
       using a <span>presentation session</span> <em>S</em>, it must run the
       following steps:
@@ -1305,7 +1327,7 @@ interface <dfn id="presentationsession">PresentationSession</dfn> : EventTarget 
       Need to further specify the semantics of the messaging channel (using
       WebSockets or MessagePort as a reference).
     </p>
-    <h4 id="the-onavailablechange-eventhandler"><span class="secno">6.3.4 </span>
+    <h4 id="the-onavailablechange-eventhandler"><span class="secno">6.3.5 </span>
       The <a href="#onavailablechange"><code>onavailablechange</code></a> EventHandler
     </h4>
     <p>
@@ -1346,20 +1368,43 @@ interface <dfn id="presentationsession">PresentationSession</dfn> : EventTarget 
       the following, the user agent behavior, depending on the number of
       registered <code>EventHandler</code>s, is described.
     </p>
-    <h5 id="updating-the-list-of-available-presentation-displays"><span class="secno">6.3.4.1 </span>
-      Updating the list of available presentation displays
+    <h5 id="adding-an-eventhandler-to-onavailablechange"><span class="secno">6.3.5.1 </span>
+      Adding an <code>EventHandler</code> to <a href="#onavailablechange"><code>onavailablechange</code></a>
+    </h5>
+    <p>
+      When an event handler is added to the list of event handlers subscribed
+      to the <a href="#onavailablechange"><code>onavailablechange</code></a> event, the user agent must run the
+      <a href="#algorithm-monitor-available" title="algorithm-monitor-available">algorithm to monitor the list
+      of available presentation displays</a>.
+    </p>
+    <h5 id="removing-an-eventhandler"><span class="secno">6.3.5.2 </span>
+      Removing an <code>EventHandler</code>
+    </h5>
+    <p>
+      When an event handler is removed from the list of event handlers
+      subscribed to the <a href="#onavailablechange"><code>onavailablechange</code></a> event, the user agent
+      must run the following steps:
+    </p>
+    <ol>
+      <li>If the removed event handler was the last one in the list,
+      <a href="#cancel-monitoring-the-list-of-available-presentation-displays">cancel monitoring the list of available presentation
+      displays</a>.
+      </li>
+    </ol>
+    <h5 id="monitoring-the-list-of-available-presentation-displays"><span class="secno">6.3.5.3 </span>
+      Monitoring the list of available presentation displays
     </h5>
     <p>
       The user agent must maintain a <dfn id="list-of-available-presentation-displays">list of available presentation
-      displays</dfn>. When the user agent is to <dfn title="algorithm-update-available" id="algorithm-update-available">update the list of available presentation
+      displays</dfn>. When the user agent is to <dfn title="algorithm-monitor-available" id="algorithm-monitor-available">monitor the list of available presentation
       displays</dfn>, it must run the following steps:
     </p>
     <p>
       While there are <a href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#event-handlers" data-anolis-spec="w3c-html" class="external">event handlers</a>
       added to NavigatorPresentation.onavailablechange, the user agent must
-      continuously keep track of the available
-    </p><a href="#presentation-display">presentation displays</a> and repeat
-    the following steps:
+      continuously keep track the <a href="#list-of-available-presentation-displays">list of available presentation
+      displays</a> and repeat the following steps:
+    </p>
     <ol>
       <li>
         <a href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#queue-a-task" data-anolis-spec="w3c-html" class="external">Queue a task</a> to retrieve the
@@ -1373,85 +1418,54 @@ interface <dfn id="presentationsession">PresentationSession</dfn> : EventTarget 
           <li>
             <a href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#queue-a-task" data-anolis-spec="w3c-html" class="external">Queue a task</a> to
             <a href="http://www.w3.org/html/wg/drafts/html/master/infrastructure.html#concept-event-fire" title="concept-event-fire" data-anolis-spec="w3c-html" class="external">fire
-            an event</a> named <code>availablechange</code> at <em>E</em>
-            (and only <em>E</em>) with the event's <code>available</code>
-            property set to <code>true</code>.
+            an event</a> named <code>availablechange</code> at with the
+            event's <code>available</code> property set to <code>true</code>.
           </li>
         </ol>
       </li>
       <li>If <a href="#availabledisplays">availableDisplays</a> is not empty
       and <a href="#newdisplays">newDisplays</a> is empty, then:
-        <div style="margin-left: 2em">
-          <a href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#queue-a-task" data-anolis-spec="w3c-html" class="external">Queue a task</a> to
-          <a href="http://www.w3.org/html/wg/drafts/html/master/infrastructure.html#concept-event-fire" title="concept-event-fire" data-anolis-spec="w3c-html" class="external">fire an
-          event</a> named <code>availablechange</code> at <em>E</em> (and
-          only <em>E</em>) with the event's <code>available</code> property set
-          to <code>false</code>.
-        </div>
+        <ol>
+          <li>
+            <a href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#queue-a-task" data-anolis-spec="w3c-html" class="external">Queue a task</a> to
+            <a href="http://www.w3.org/html/wg/drafts/html/master/infrastructure.html#concept-event-fire" title="concept-event-fire" data-anolis-spec="w3c-html" class="external">fire
+            an event</a> named <code>availablechange</code> with the event's
+            <code>available</code> property set to <code>false</code>.
+          </li>
+        </ol>
       </li>
-      <li>Set <a href="#availableDisplays">availableDisplays</a> to the value
-      of <a href="#newDisplays">newDisplays</a>.
-      </li>
-    </ol>
-    <p>
-      Let <em>D</em> be the set of presentations that are currently known to
-      the user agent (regardles of their state). <em>D</em> is represented as a
-      set of tuples <em>(U, I, S)</em> where <em>U</em> is the URL that is
-      being presented; <em>I</em> is an alphanumeric identifier for the
-      presentation; and <em>S</em> is the user agent's
-      <a href="#presentationsession"><code>PresentationSession</code></a> for the presentation. <em>U</em> and
-      <em>I</em> together uniquely identify the
-      <a href="#presentationsession"><code>PresentationSession</code></a> of the corresponding presentation.
-    </p>
-    <p class="XXX">
-      When the user agent is to <dfn id="update-the-list-of-available-presentation-displays">update the list of available presentation
-      displays</dfn>, it must run the following steps:
-    </p>
-    <ol>
-      <li>Let <a id="availabledisplays"><em>availableDisplays</em></a> be the
-      <a href="#list-of-available-presentation-displays">list of available presentation displays</a> that are currently
-      known to the user agent.
+      <li>Set the <a href="#list-of-available-presentation-displays">list of available presentation displays</a> to the
+      value of <a href="#newDisplays">newDisplays</a>.
       </li>
     </ol>
-    <p class="XXX">
-      When the user agent is to <dfn id="start-monitoring-for-changes-to-presentation-display-availability">start monitoring for changes to
-      presentation display availability</dfn>, it must run the following steps:
+    <p class="open-issue">
+      Do we want to fire the event at all handlers, or only the newly added
+      one?
     </p>
-    <p>
-      When a new <a href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#event-handlers" title="event handlers" data-anolis-spec="w3c-html" class="external">event
-      handler</a> <em>E</em> is added to
-      <code><a href="#navigatorpresentation">NavigatorPresentation</a>.onavailablechange</code>, the
-      user agent must run the
-    </p><a href="monitor-availability-algorithm">algorithm to monitor
-    availability</a>.
     <p class="note">
       The mechanism used to monitor <a href="#presentation-display">presention
       displays</a> availability is left to the user agent. The user agent may
       choose search for screens at any time, not just when event handlers are
       added to <code>NavigatorPresentation.onavailablechange</code>.
     </p>
-    <p class="open-issue">
-      Do we want to fire the event at all handlers, or only the newly added
-      one?
-    </p>
-    <p class="XXX">
-      When the user agent is to <dfn id="stop-monitoring-for-changes-to-presentation-display-availability">stop monitoring for changes to
-      presentation display availability</dfn>, it must run the following steps:
-    </p>
     <p>
-      When the last <a href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#event-handlers" title="event handlers" data-anolis-spec="w3c-html" class="external">event handler</a> is removed from
-      <code>NavigatorPresentation.onavailablechange</code>, the user agent may
-      run the following steps:
+      When the user agent is to <dfn id="cancel-monitoring-the-list-of-available-presentation-displays">cancel monitoring the list of available
+      presentation displays</dfn>, it must run the following steps:
     </p>
     <ol>
-      <li>Cancel the <a href="monitor-availability-algorithm">algorithm to
-      monitor availability change.</a>
+      <li>Cancel any tasks to retrieve the list of available <a href="#presentation-display" title="presentation display">presentation displays</a>.
+      </li>
+      <li>Set the <a href="#list-of-available-presentation-displays">list of available presentation displays</a> to
+      empty.
+      </li>
+      <li>
+        <a href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#queue-a-task" data-anolis-spec="w3c-html" class="external">Queue a task</a> to
+        <a href="http://www.w3.org/html/wg/drafts/html/master/infrastructure.html#concept-event-fire" title="concept-event-fire" data-anolis-spec="w3c-html" class="external">fire an
+        event</a> named <code>availablechange</code> at <em>E</em> (and only
+        <em>E</em>) with the event's <code>available</code> property set to
+        <code>false</code>.
       </li>
     </ol>
-    <p class="XXX">
-      When the user agent is required to <dfn id="monitor-presentation-display-availability">monitor presentation display
-      availability</dfn>, it must run the following steps ...
-    </p>
     <h3 id="interface-availablechangeevent"><span class="secno">6.4 </span>
       <span>Interface <a href="#availablechangeevent"><code>AvailableChangeEvent</code></a></span>
     </h3>

--- a/index.html
+++ b/index.html
@@ -222,7 +222,8 @@
       Functional requirements
     </a></li>
    <li><a href="#non-functional-requirements"><span class="secno">2.2 </span>
-      <span>Non-functional requirements</span>
+      Non-functional
+      requirements
     </a></ol></li>
  <li><a href="#conformance"><span class="secno">3 </span>
       Conformance
@@ -279,14 +280,17 @@
     </a></li>
      <li><a href="#establishing-a-presentation-connection"><span class="secno">6.3.3 </span>
       Establishing a presentation connection
-    </a></ol></li>
+    </a></li>
+     <li><a href="#the-onavailablechange-eventhandler"><span class="secno">6.3.4 </span>
+      The <code>onavailablechange</code> EventHandler
+    </a>
+      <ol>
+       <li><a href="#updating-the-list-of-available-presentation-displays"><span class="secno">6.3.4.1 </span>
+      Updating the list of available presentation displays
+    </a></ol></ol></li>
    <li><a href="#interface-availablechangeevent"><span class="secno">6.4 </span>
       <span>Interface <code>AvailableChangeEvent</code></span>
-    </a>
-    <ol>
-     <li><a href="#monitoring-presentation-display-availability"><span class="secno">6.4.1 </span>
-      Monitoring presentation display availability
-    </a></ol></li>
+    </a></li>
    <li><a href="#todo"><span class="secno">6.5 </span>
       TODO
     </a></ol></li>
@@ -483,7 +487,8 @@
       </li>
     </ul>
     <h3 id="non-functional-requirements"><span class="secno">2.2 </span>
-      <span id="non-functional_requirements">Non-functional requirements</span>
+      <dfn title="non-functional-requirements">Non-functional
+      requirements</dfn>
     </h3>
     <ul>
       <li>
@@ -1227,34 +1232,6 @@ interface <dfn id="presentationsession">PresentationSession</dfn> : EventTarget 
       If no matching presentation is found, we could leave the Promise pending
       in case a matching presentation is started in the future.
     </p>
-    <p>
-      <span>The following are the event handlers (and their corresponding event
-      handler event types) that must be supported, as event handler IDL
-      attributes, by objects implementing the <a href="#presentationsession"><code>PresentationSession</code></a>
-      interface:</span>
-    </p>
-    <table>
-      <thead>
-        <tr>
-          <th>
-            Event handler
-          </th>
-          <th>
-            Event handler event type
-          </th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td>
-            <dfn id="onavailablechange"><code>onavailablechange</code></dfn>
-          </td>
-          <td>
-            <code>availablechange</code>
-          </td>
-        </tr>
-      </tbody>
-    </table>
     <h4 id="establishing-a-presentation-connection"><span class="secno">6.3.3 </span>
       Establishing a presentation connection
     </h4>
@@ -1328,36 +1305,94 @@ interface <dfn id="presentationsession">PresentationSession</dfn> : EventTarget 
       Need to further specify the semantics of the messaging channel (using
       WebSockets or MessagePort as a reference).
     </p>
-    <h3 id="interface-availablechangeevent"><span class="secno">6.4 </span>
-      <span>Interface <a href="#availablechangeevent"><code>AvailableChangeEvent</code></a></span>
-    </h3>
-    <pre class="idl"><span>[Constructor(DOMString type, optional <a href="#availablechangeeventinit">AvailableChangeEventInit</a> eventInitDict)]
-interface <dfn id="availablechangeevent">AvailableChangeEvent</dfn> : Event {
-  readonly attribute boolean available;
-};
-
-dictionary <dfn id="availablechangeeventinit">AvailableChangeEventInit</dfn> : EventInit {
-  boolean available;
-};
-</span>
-</pre>
-    <p>
-      An event named <code>availablechange</code> is fired during the execution
-      of the <span>monitoring presentation display availability</span>
-      algorithm when the <dfn id="presentation-display-availability">presentation display availability</dfn> changes.
-      It is fired at the <a href="#presentationsession"><code>PresentationSession</code></a> object,
-      using the <a href="#availablechangeevent"><code>AvailableChangeEvent</code></a> interface, with the
-      <code>available</code> attribute set to the boolean value that the
-      algorithm determined.
-    </p>
-    <h4 id="monitoring-presentation-display-availability"><span class="secno">6.4.1 </span>
-      Monitoring presentation display availability
+    <h4 id="the-onavailablechange-eventhandler"><span class="secno">6.3.4 </span>
+      The <a href="#onavailablechange"><code>onavailablechange</code></a> EventHandler
     </h4>
-    <p class="XXX">
-      Each <code>Document</code> object must have a <dfn id="list-of-available-presentation-displays">list of available
-      presentation displays</dfn>. Each display in this list is identified by a
-      tuple (U, I, S) as follows:
+    <p>
+      <span>The following are the event handlers (and their corresponding event
+      handler event types) that must be supported, as event handler IDL
+      attributes, by objects implementing the <a href="#presentationsession"><code>PresentationSession</code></a>
+      interface:</span>
     </p>
+    <table>
+      <thead>
+        <tr>
+          <th>
+            Event handler
+          </th>
+          <th>
+            Event handler event type
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            <dfn id="onavailablechange"><code>onavailablechange</code></dfn>
+          </td>
+          <td>
+            <code>availablechange</code>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+    <p>
+      In order to satisfy the <a href="#non-functional-requirements" title="non-functional-requirements">power
+      saving non-functionional requirements</a> the user agent must keep
+      track of the number of <code>EventHandler</code>s registered to the
+      <code>onavailable</code> event. Using this information, implementation
+      specific discovery of <span title="presentation-display">presentation
+      displays</span> can be resumed or suspended, in order to save power. In
+      the following, the user agent behavior, depending on the number of
+      registered <code>EventHandler</code>s, is described.
+    </p>
+    <h5 id="updating-the-list-of-available-presentation-displays"><span class="secno">6.3.4.1 </span>
+      Updating the list of available presentation displays
+    </h5>
+    <p>
+      The user agent must maintain a <dfn id="list-of-available-presentation-displays">list of available presentation
+      displays</dfn>. When the user agent is to <dfn title="algorithm-update-available" id="algorithm-update-available">update the list of available presentation
+      displays</dfn>, it must run the following steps:
+    </p>
+    <p>
+      While there are <a href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#event-handlers" data-anolis-spec="w3c-html" class="external">event handlers</a>
+      added to NavigatorPresentation.onavailablechange, the user agent must
+      continuously keep track of the available
+    </p><a href="#presentation-display">presentation displays</a> and repeat
+    the following steps:
+    <ol>
+      <li>
+        <a href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#queue-a-task" data-anolis-spec="w3c-html" class="external">Queue a task</a> to retrieve the
+        the list of curently available <a href="#presentation-display">presentation displays</a> and let <a id="newdisplays"><em>newDisplays</em></a> be this list.
+      </li>
+      <li>Wait for the completion of that task.
+      </li>
+      <li>If <a href="#availabledisplays">availableDisplays</a> is empty and
+      <a href="#newdisplays">newDisplays</a> is not empty, then
+        <ol>
+          <li>
+            <a href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#queue-a-task" data-anolis-spec="w3c-html" class="external">Queue a task</a> to
+            <a href="http://www.w3.org/html/wg/drafts/html/master/infrastructure.html#concept-event-fire" title="concept-event-fire" data-anolis-spec="w3c-html" class="external">fire
+            an event</a> named <code>availablechange</code> at <em>E</em>
+            (and only <em>E</em>) with the event's <code>available</code>
+            property set to <code>true</code>.
+          </li>
+        </ol>
+      </li>
+      <li>If <a href="#availabledisplays">availableDisplays</a> is not empty
+      and <a href="#newdisplays">newDisplays</a> is empty, then:
+        <div style="margin-left: 2em">
+          <a href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#queue-a-task" data-anolis-spec="w3c-html" class="external">Queue a task</a> to
+          <a href="http://www.w3.org/html/wg/drafts/html/master/infrastructure.html#concept-event-fire" title="concept-event-fire" data-anolis-spec="w3c-html" class="external">fire an
+          event</a> named <code>availablechange</code> at <em>E</em> (and
+          only <em>E</em>) with the event's <code>available</code> property set
+          to <code>false</code>.
+        </div>
+      </li>
+      <li>Set <a href="#availableDisplays">availableDisplays</a> to the value
+      of <a href="#newDisplays">newDisplays</a>.
+      </li>
+    </ol>
     <p>
       Let <em>D</em> be the set of presentations that are currently known to
       the user agent (regardles of their state). <em>D</em> is represented as a
@@ -1417,45 +1452,28 @@ dictionary <dfn id="availablechangeeventinit">AvailableChangeEventInit</dfn> : E
       When the user agent is required to <dfn id="monitor-presentation-display-availability">monitor presentation display
       availability</dfn>, it must run the following steps ...
     </p>
+    <h3 id="interface-availablechangeevent"><span class="secno">6.4 </span>
+      <span>Interface <a href="#availablechangeevent"><code>AvailableChangeEvent</code></a></span>
+    </h3>
+    <pre class="idl"><span>[Constructor(DOMString type, optional <a href="#availablechangeeventinit">AvailableChangeEventInit</a> eventInitDict)]
+interface <dfn id="availablechangeevent">AvailableChangeEvent</dfn> : Event {
+  readonly attribute boolean available;
+};
+
+dictionary <dfn id="availablechangeeventinit">AvailableChangeEventInit</dfn> : EventInit {
+  boolean available;
+};
+</span>
+</pre>
     <p>
-      While there are <a href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#event-handlers" data-anolis-spec="w3c-html" class="external">event handlers</a>
-      added to NavigatorPresentation.onavailablechange, the user agent must
-      continuously keep track of the available
-    </p><a href="#presentation-display">presentation displays</a> and repeat
-    the following steps:
-    <ol>
-      <li>
-        <a href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#queue-a-task" data-anolis-spec="w3c-html" class="external">Queue a task</a> to retrieve the
-        the list of curently available <a href="#presentation-display">presentation displays</a> and let <a id="newdisplays"><em>newDisplays</em></a> be this list.
-      </li>
-      <li>Wait for the completion of that task.
-      </li>
-      <li>If <a href="#availabledisplays">availableDisplays</a> is empty and
-      <a href="#newdisplays">newDisplays</a> is not empty, then
-        <ol>
-          <li>
-            <a href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#queue-a-task" data-anolis-spec="w3c-html" class="external">Queue a task</a> to
-            <a href="http://www.w3.org/html/wg/drafts/html/master/infrastructure.html#concept-event-fire" title="concept-event-fire" data-anolis-spec="w3c-html" class="external">fire
-            an event</a> named <code>availablechange</code> at <em>E</em>
-            (and only <em>E</em>) with the event's <code>available</code>
-            property set to <code>true</code>.
-          </li>
-        </ol>
-      </li>
-      <li>If <a href="#availabledisplays">availableDisplays</a> is not empty
-      and <a href="#newdisplays">newDisplays</a> is empty, then:
-        <div style="margin-left: 2em">
-          <a href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#queue-a-task" data-anolis-spec="w3c-html" class="external">Queue a task</a> to
-          <a href="http://www.w3.org/html/wg/drafts/html/master/infrastructure.html#concept-event-fire" title="concept-event-fire" data-anolis-spec="w3c-html" class="external">fire an
-          event</a> named <code>availablechange</code> at <em>E</em> (and
-          only <em>E</em>) with the event's <code>available</code> property set
-          to <code>false</code>.
-        </div>
-      </li>
-      <li>Set <a href="#availableDisplays">availableDisplays</a> to the value
-      of <a href="#newDisplays">newDisplays</a>.
-      </li>
-    </ol>
+      An event named <code>availablechange</code> is fired during the execution
+      of the <span>monitoring presentation display availability</span>
+      algorithm when the <dfn id="presentation-display-availability">presentation display availability</dfn> changes.
+      It is fired at the <a href="#presentationsession"><code>PresentationSession</code></a> object,
+      using the <a href="#availablechangeevent"><code>AvailableChangeEvent</code></a> interface, with the
+      <code>available</code> attribute set to the boolean value that the
+      algorithm determined.
+    </p>
     <h3 id="todo"><span class="secno">6.5 </span>
       TODO
     </h3>

--- a/index.html
+++ b/index.html
@@ -797,7 +797,7 @@ function setSession(theSession) {
     <p>
       For addressing the requirement of communication between originating page
       and presentation page/screen, the presenting page can now use the same
-      <a href="#session"><code>session</code></a> object. It accesses this object through the
+      <code>session</code> object. It accesses this object through the
       <code>navigator.presentation.session</code> property, which is only
       non-<code>null</code> for the page on the presentation screen.
     </p>
@@ -912,7 +912,11 @@ interface <dfn id="presentationsession">PresentationSession</dfn> : EventTarget 
       the following steps:
     </p>
     <p class="open-issue">
-      Need algorithm for send message
+      Needs algorithm for send message and more fine-grained definition of data
+      types for sending. Candidates, similar interfaces, are found in the
+      <a href="https://html.spec.whatwg.org/multipage/comms.html#the-messageevent-interfaces">
+      WHATWG HTML spec's <code>MessageEvent</code> section</a>, or the <a href="http://w3c.github.io/webrtc-pc/#rtcdatachannel">WebRTC's spec
+      <code>RPCDataChannel</code>.</a>
     </p>
     <h4 id="closing-a-presentationsession"><span class="secno">6.2.2 </span>
       Closing a <a href="#presentationsession"><code>PresentationSession</code></a>
@@ -1002,19 +1006,23 @@ interface <dfn id="presentationsession">PresentationSession</dfn> : EventTarget 
   readonly attribute <a href="#navigatorpresentation">NavigatorPresentation</a> <a href="#presentation">presentation</a>;
 };
 </pre>
-    <p class="XXX">
-      The <dfn id="presentation"><code>presentation</code></dfn> attribute must return the
-      <a href="#navigatorpresentation"><code>NavigatorPresentation</code></a> object.
+    <p>
+      The <dfn id="presentation"><code>presentation</code></dfn> attribute is used to retrieve an
+      instance of the <a href="#navigatorpresentation"><code>NavigatorPresentation</code></a> interface, the main
+      interface of Presentation API.
     </p>
     <pre class="idl">interface <dfn id="navigatorpresentation">NavigatorPresentation</dfn> : EventTarget {
-  readonly attribute <a href="#presentationsession">PresentationSession</a>? <a href="#session">session</a>;
+  readonly attribute <a href="#presentationsession">PresentationSession</a>? <span>session</span>;
   Promise&lt;<a href="#presentationsession">PresentationSession</a>&gt; <a href="#startsession">startSession</a>(DOMString url, DOMString? presentationId);
   Promise&lt;<a href="#presentationsession">PresentationSession</a>&gt; <a href="#joinsession">joinSession</a>(DOMString url, DOMString? presentationId);
   attribute <a href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#eventhandler" data-anolis-spec="w3c-html" class="external">EventHandler</a> <a href="#onavailablechange">onavailablechange</a>;
 };
 </pre>
-    <p class="XXX">
-      On getting, the <dfn id="session"><code>session</code></dfn> attribute must return ...
+    <p class="open-issue">
+      <i>(drott)</i> What would be a good definition of the
+      <code>session</code> attribute? Do we want to keep it? It's somewhat hard
+      to define, when it should contain a value, and when it should be empty -
+      and it's not compatible with multiple calls to startSession, for example.
     </p>
     <h4 id="starting-a-presentation-session"><span class="secno">6.3.1 </span>
       Starting a presentation session
@@ -1327,12 +1335,14 @@ dictionary <dfn id="availablechangeeventinit">AvailableChangeEventInit</dfn> : E
 };
 </span>
 </pre>
-    <p class="XXX">
-      When the <dfn id="presentation-display-availability">presentation display availability</dfn> changes, the user
-      agent must fire an event with the name <code>availablechange</code> at
-      the <a href="#presentationsession"><code>PresentationSession</code></a> object, using the
-      <a href="#availablechangeevent"><code>AvailableChangeEvent</code></a> interface, with the
-      <code>available</code> attribute initialized to ...
+    <p>
+      An event named <code>availablechange</code> is fired during the execution
+      of the <span>monitoring presentation display availability</span>
+      algorithm when the <dfn id="presentation-display-availability">presentation display availability</dfn> changes.
+      It is fired at the <a href="#presentationsession"><code>PresentationSession</code></a> object,
+      using the <a href="#availablechangeevent"><code>AvailableChangeEvent</code></a> interface, with the
+      <code>available</code> attribute set to the boolean value that the
+      algorithm determined.
     </p>
     <h4 id="monitoring-presentation-display-availability"><span class="secno">6.4.1 </span>
       Monitoring presentation display availability
@@ -1370,14 +1380,15 @@ dictionary <dfn id="availablechangeeventinit">AvailableChangeEventInit</dfn> : E
       When a new <a href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#event-handlers" title="event handlers" data-anolis-spec="w3c-html" class="external">event
       handler</a> <em>E</em> is added to
       <code><a href="#navigatorpresentation">NavigatorPresentation</a>.onavailablechange</code>, the
-      user agent must run the <a href="monitor-availability-algorithm">algorithm to monitor availability</a>.
-    </p>
+      user agent must run the
+    </p><a href="monitor-availability-algorithm">algorithm to monitor
+    availability</a>.
     <p class="note">
-      The mechanism used to monitor <a href="#presentation-display">presention
-      displays</a> availability is left to the user agent. The user agent may
-      choose search for screens at any time, not just when event handlers are
-      added to <code>NavigatorPresentation.onavailablechange</code>.
-    </p>
+      The mechanism used to monitor
+    </p><a href="#presentation-display">presention displays</a> availability is
+    left to the user agent. The user agent may choose search for screens at any
+    time, not just when event handlers are added to
+    <code>NavigatorPresentation.onavailablechange</code>.
     <p class="open-issue">
       Do we want to fire the event at all handlers, or only the newly added
       one?
@@ -1403,9 +1414,9 @@ dictionary <dfn id="availablechangeeventinit">AvailableChangeEventInit</dfn> : E
     <p>
       While there are <a href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#event-handlers" data-anolis-spec="w3c-html" class="external">event handlers</a>
       added to NavigatorPresentation.onavailablechange, the user agent must
-      continuously keep track of the available <a href="#presentation-display">presentation displays</a> and repeat the
-      following steps:
-    </p>
+      continuously keep track of the available
+    </p><a href="#presentation-display">presentation displays</a> and repeat
+    the following steps:
     <ol>
       <li>
         <a href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#queue-a-task" data-anolis-spec="w3c-html" class="external">Queue a task</a> to retrieve the

--- a/index.html
+++ b/index.html
@@ -62,6 +62,11 @@
     }
 
     code { color: orangered; }
+    .XXX { background: white; border: solid #78AB46; padding: 0.5em; margin: 1em 0; }
+    table { border-collapse: collapse; border-style: hidden hidden none hidden; }
+    table thead, table tbody { border-bottom: solid; }
+    table td, table th { border-left: solid; border-right: solid; border-bottom: solid thin; vertical-align: top; padding: 0.2em; }
+    dfn { font-weight: bolder; font-style: normal; }
     </style>
   </head>
   <body>
@@ -194,30 +199,30 @@
     </a>
   <ol>
    <li><a href="#use-cases"><span class="secno">1.1 </span>
-      Use Cases
+      Use cases
     </a>
     <ol>
      <li><a href="#presentations"><span class="secno">1.1.1 </span>
       Presentations
     </a></li>
      <li><a href="#video-and-image-sharing"><span class="secno">1.1.2 </span>
-      Video and Image Sharing
+      Video and image sharing
     </a></li>
      <li><a href="#gaming"><span class="secno">1.1.3 </span>
       Gaming
     </a></li>
      <li><a href="#media-flinging-to-multiple-screens"><span class="secno">1.1.4 </span>
-      Media Flinging to Multiple Screens
+      Media flinging to multiple screens
     </a></ol></ol></li>
  <li><a href="#requirements"><span class="secno">2 </span>
       Requirements
     </a>
   <ol>
    <li><a href="#functional-requirements"><span class="secno">2.1 </span>
-      Functional Requirements
+      Functional requirements
     </a></li>
    <li><a href="#non-functional-requirements"><span class="secno">2.2 </span>
-      <span>Non-Functional Requirements</span>
+      <span>Non-functional requirements</span>
     </a></ol></li>
  <li><a href="#conformance"><span class="secno">3 </span>
       Conformance
@@ -237,54 +242,42 @@
       Automatically reconnecting to existing presentations
     </a></li>
    <li><a href="#open-questions"><span class="secno">5.3 </span>
-      Open Questions
+      Open questions
     </a></li>
    <li><a href="#usage-on-remote-screen"><span class="secno">5.4 </span>
-      Usage on Remote Screen
+      Usage on remote screen
     </a></ol></li>
- <li><a href="#interfaces"><span class="secno">6 </span>
-      Interfaces
+ <li><a href="#apis-for-interacting-with-presentation-sessions"><span class="secno">6 </span>
+      APIs for interacting with presentation sessions
     </a>
   <ol>
-   <li><a href="#navigatorpresentation"><span class="secno">6.1 </span>
-      <code>NavigatorPresentation</code>
+   <li><a href="#introduction-0"><span class="secno">6.1 </span>
+      Introduction
     </a></li>
-   <li><a href="#availablechangeevent"><span class="secno">6.2 </span>
-      <code>AvailableChangeEvent</code>
+   <li><a href="#interface-presentationsession"><span class="secno">6.2 </span>
+      Interface <code>PresentationSession</code>
     </a></li>
-   <li><a href="#presentationsession"><span class="secno">6.3 </span>
-      <code>PresentationSession</code>
-    </a></ol></li>
- <li><a href="#algorithms"><span class="secno">7 </span>
-      Algorithms
-    </a>
-  <ol>
-   <li><a href="#presentation-display-availability"><span class="secno">7.1 </span>
-      Presentation Display Availability
+   <li><a href="#interface-navigatorpresentation"><span class="secno">6.3 </span>
+      Interface <code>NavigatorPresentation</code>
     </a>
     <ol>
-     <li><a href="#availability-listener-added"><span class="secno">7.1.1 </span>
-      Availability Listener Added
+     <li><a href="#starting-a-presentation-session"><span class="secno">6.3.1 </span>
+      Starting a presentation session
     </a></li>
-     <li><a href="#availability-listener-removed"><span class="secno">7.1.2 </span>
-      Availability Listener Removed
+     <li><a href="#joining-a-presentation-session"><span class="secno">6.3.2 </span>
+      Joining a presentation session
     </a></li>
-     <li><a href="#monitor-availability-algorithm"><span class="secno">7.1.3 </span>
-      Algorithm to Monitor Presentation Display Availability Change
+     <li><a href="#establishing-a-presentation-connection"><span class="secno">6.3.3 </span>
+      Establishing a presentation connection
     </a></ol></li>
-   <li><a href="#start-session"><span class="secno">7.2 </span>
-      Start Session
-    </a></li>
-   <li><a href="#join-session"><span class="secno">7.3 </span>
-      Join Session
-    </a></li>
-   <li><a href="#session-close"><span class="secno">7.4 </span>
-      Session Close
-    </a></li>
-   <li><a href="#presentation-connection"><span class="secno">7.5 </span>
-      Presentation Connection
-    </a></li>
-   <li><a href="#todo"><span class="secno">7.6 </span>
+   <li><a href="#interface-availablechangeevent"><span class="secno">6.4 </span>
+      <span>Interface <code>AvailableChangeEvent</code></span>
+    </a>
+    <ol>
+     <li><a href="#monitoring-presentation-display-availability"><span class="secno">6.4.1 </span>
+      Monitoring presentation display availability
+    </a></ol></li>
+   <li><a href="#todo"><span class="secno">6.5 </span>
       TODO
     </a></ol></li>
  <li><a class="no-num" href="#references">
@@ -343,7 +336,7 @@
       devices through any of the above means.
     </p>
     <h3 id="use-cases"><span class="secno">1.1 </span>
-      Use Cases
+      Use cases
     </h3>
     <h4 id="presentations"><span class="secno">1.1.1 </span>
       Presentations
@@ -363,7 +356,7 @@
       <b>Requirements:</b> R1, R3, R4, R5, R7
     </p>
     <h4 id="video-and-image-sharing"><span class="secno">1.1.2 </span>
-      <a id="video-sharing">Video and Image Sharing</a>
+      <a id="video-sharing">Video and image sharing</a>
     </h4>
     <p>
       Using an online video or image sharing service, a user would like to show
@@ -394,7 +387,7 @@
       <b>Requirements:</b> R1, R3, R4, R5, R7
     </p>
     <h4 id="media-flinging-to-multiple-screens"><span class="secno">1.1.4 </span>
-      Media Flinging to Multiple Screens
+      Media flinging to multiple screens
     </h4>Alice enters a video sharing site using a browser on her tablet. Next,
     Alice picks her favorite video from the site, and the video starts to play
     on her tablet. While the video is playing Alice clicks a button "Share on
@@ -420,7 +413,7 @@
       Requirements
     </h2>
     <h3 id="functional-requirements"><span class="secno">2.1 </span>
-      Functional Requirements
+      Functional requirements
     </h3>
     <ul>
       <li>
@@ -480,7 +473,7 @@
       </li>
     </ul>
     <h3 id="non-functional-requirements"><span class="secno">2.2 </span>
-      <span id="Non-Functional_Requirements">Non-Functional Requirements</span>
+      <span id="non-functional_requirements">Non-functional requirements</span>
     </h3>
     <ul>
       <li>
@@ -526,12 +519,6 @@
     <h2 id="terminology"><span class="secno">4 </span>
       Terminology
     </h2>
-    <p>
-      The term <dfn id="presentation-display" title="presentation display">presentation display</dfn>
-      refers to an external screen available to the opening user agent via an
-      implementation specific connection technology and compatible with the
-      Presentation API for the display content on it.
-    </p>
     <p>
       The terms <a class="external" data-anolis-spec="w3c-html" href="http://www.w3.org/html/wg/drafts/html/master/browsers.html#browsing-context">browsing context</a>,
       <a class="external" data-anolis-spec="w3c-html" href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#event-handlers">event handlers</a>, <a class="external" data-anolis-spec="w3c-html" href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#event-handler-event-type" title="event handler event type">event handler
@@ -647,7 +634,7 @@ function setSession(theSession) {
     <p class="open-issue">
       Do we want to fire an event immediately after the page registers for it?
       What's a best practice method for asynchronous notifications of this
-      kind? See below in the <a href="#open-questions">Open Questions</a>
+      kind? See below in the <a href="#open-questions">Open questions</a>
       section.
     </p>
     <p class="open-issue">
@@ -702,25 +689,25 @@ function setSession(theSession) {
       returns a <code>Promise</code> to the opener page. When the user selects
       a screen, the presentation page is shown and a communication channel has
       been established the <code>Promise</code> resolves to a
-      <code>PresentationSession</code> object, which acts as a handle to the
+      <a href="#presentationsession"><code>PresentationSession</code></a> object, which acts as a handle to the
       presentation for communication and state handling. Initially, the state
-      of the <code>PresentationSession</code> is <code>"connected"</code>. At
+      of the <a href="#presentationsession"><code>PresentationSession</code></a> is <code>"connected"</code>. At
       this point, the opener page can communicate with the presentation page
       using the session's <code>postMessage()</code> to send messages and its
-      <code>onmessage</code> event handler to receive messages. The
+      <a href="#onmessage"><code>onmessage</code></a> event handler to receive messages. The
       presentation page will also have access to
-      <code>PresentationSession</code> that it can use to send and receive
-      messages with the opener page (see <a href="#usage-on-remote-screen">Usage on Remote Screen</a>).
+      <a href="#presentationsession"><code>PresentationSession</code></a> that it can use to send and receive
+      messages with the opener page (see <a href="#usage-on-remote-screen">Usage on remote screen</a>).
     </p>
     <p>
       If the user cancels screen selection, the <code>Promise</code> returned
       by <code>startSession(url, presentationId)</code> remains unresolved.
     </p>
     <p>
-      While there is a pending call to <code>startSession</code> asking the
+      While there is a pending call to <a href="#startsession"><code>startSession</code></a> asking the
       user to select a screen (that the user has not yet accepted or canceled),
       the browser may choose to reject subsequent calls to
-      <code>startSession</code> from the same page, by returning a
+      <a href="#startsession"><code>startSession</code></a> from the same page, by returning a
       <code>Promise</code> that never resolves. This will prevent the browser
       from needing to 'queue up' requests to present to the user.
     </p>
@@ -735,15 +722,15 @@ function setSession(theSession) {
       that presentation. To reconnect automatically, the page may call
       <code>joinSession(url, presentationId)</code>, which returns a
       <code>Promise</code> that resolves to an existing
-      <code>PresentationSession</code> if one exists that is presenting the
+      <a href="#presentationsession"><code>PresentationSession</code></a> if one exists that is presenting the
       same <code>url</code> with the same <code>presentationId</code> as was
-      passed originally into <code>startSession</code>. The requesting page can
+      passed originally into <a href="#startsession"><code>startSession</code></a>. The requesting page can
       then communicate with the presentation as if the user had manually
-      connected to it via <code>startSession</code>.
+      connected to it via <a href="#startsession"><code>startSession</code></a>.
     </p>
     <p>
       At the time <code>joinSession(url, presentationId)</code> is called, if
-      the browser is not aware of any <code>PresentationSession</code> with a
+      the browser is not aware of any <a href="#presentationsession"><code>PresentationSession</code></a> with a
       matching <code>url</code> and <code>presentationId</code>, the
       <code>Promise</code> should remain unresolved. The browser may become
       aware of such a session at a later time (for example, by switching to a
@@ -766,12 +753,12 @@ function setSession(theSession) {
       there is a pending <code>Promise</code> from a call to
       <code>joinSession(url, presentationId)</code> (with the same
       <code>url</code> and <code>presentationId</code>, and the user selects a
-      screen in response to <code>startSession</code>, then the
-      <code>Promise</code> from <code>startSession</code> will be resolved and
-      the <code>Promise</code> from <code>joinSession</code> will not.
+      screen in response to <a href="#startsession"><code>startSession</code></a>, then the
+      <code>Promise</code> from <a href="#startsession"><code>startSession</code></a> will be resolved and
+      the <code>Promise</code> from <a href="#joinsession"><code>joinSession</code></a> will not.
     </p>
     <h4 id="open-questions"><span class="secno">5.3 </span>
-      Open Questions
+      Open questions
     </h4>
     <p class="open-issue">
       Do we need to insert into the description an additional permission prompt
@@ -780,7 +767,7 @@ function setSession(theSession) {
     </p>
     <p class="open-issue">
       If there are already connected screens when the page subscribes to the
-      <code>onavailablechange</code> event, we can handle this in two ways: We
+      <a href="#onavailablechange"><code>onavailablechange</code></a> event, we can handle this in two ways: We
       can synthesize one initial event to notify the page about available
       screens as soon as the first event handler is installed (as described).
       Or we can add another message like
@@ -795,12 +782,12 @@ function setSession(theSession) {
       <code>"new"</code> or <code>"resumed"</code>.
     </p>
     <h3 id="usage-on-remote-screen"><span class="secno">5.4 </span>
-      Usage on Remote Screen
+      Usage on remote screen
     </h3>
     <p>
       For addressing the requirement of communication between originating page
       and presentation page/screen, the presenting page can now use the same
-      <code>session</code> object. It accesses this object through the
+      <a href="#session"><code>session</code></a> object. It accesses this object through the
       <code>navigator.presentation.session</code> property, which is only
       non-<code>null</code> for the page on the presentation screen.
     </p>
@@ -826,7 +813,7 @@ function setSession(theSession) {
       This session is a similar object as in the first example. Here, its
       initial state is <code>"connected"</code>, which means we can use it to
       communicate with the opener page using <code>postMessage()</code> and
-      <code>onmessage</code>.
+      <a href="#onmessage"><code>onmessage</code></a>.
     </p>
     <p>
       The presentation page can also monitor the connection state by listening
@@ -842,164 +829,160 @@ function setSession(theSession) {
       page, we need to define how connection and disconnection of these pages
       is communicated to the presentation page (if at all).
     </p>
-    <h2 id="interfaces"><span class="secno">6 </span>
-      Interfaces
+    <h2 id="apis-for-interacting-with-presentation-sessions"><span class="secno">6 </span>
+      APIs for interacting with presentation sessions
     </h2>
-    <h3 id="navigatorpresentation"><span class="secno">6.1 </span>
-      <code>NavigatorPresentation</code>
+    <h3 id="introduction-0"><span class="secno">6.1 </span>
+      Introduction
     </h3>
-    <pre class="idl">interface NavigatorPresentation : EventTarget {
-  readonly attribute PresentationSession? session;
-  Promise&lt;PresentationSession&gt; startSession(DOMString url, DOMString? presentationId);
-  Promise&lt;PresentationSession&gt; joinSession(DOMString url, DOMString? presentationId);
-  attribute EventHandler onavailablechange;
-};
+    <p>
+      A <dfn id="presentation-display" title="presentation display">presentation display</dfn> refers to
+      an external screen available to the user agent via an implementation
+      specific connection technology.
+    </p>
+    <p class="XXX">
+      A <dfn id="concept-presentation-session" title="concept-presentation-session">presentation session</dfn> is
+      ... and its relationship to a <a href="#presentation-display">presentation display</a> is ...
+      Each <span>presentation session</span> has a <dfn id="presentation-session-identifier">presentation session
+      identifier</dfn> and a <dfn id="presentation-session-state">presentation session state</dfn>.
+    </p>
+    <h3 id="interface-presentationsession"><span class="secno">6.2 </span>
+      Interface <a href="#presentationsession"><code>PresentationSession</code></a>
+    </h3>
+    <p>
+      Each <a href="#concept-presentation-session" title="concept-presentation-session">presentation
+      session</a> is represented by a <a href="#presentationsession"><code>PresentationSession</code></a>
+      object.
+    </p>
+    <pre class="idl">enum <dfn id="presentationsessionstate">PresentationSessionState</dfn> { "connected", "disconnected" /*, "resumed" */ };
 
-partial interface Navigator {
-  readonly attribute NavigatorPresentation presentation;
+interface <dfn id="presentationsession">PresentationSession</dfn> : EventTarget {
+  readonly DOMString? <a href="#id">id</a>;
+  readonly attribute <a href="#presentationsessionstate">PresentationSessionState</a> <a href="#state">state</a>;
+  void <a href="#postmessage">postMessage</a>(DOMString message);
+  void <a href="#close">close</a>();
+  attribute <a class="external" data-anolis-spec="w3c-html" href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#eventhandler">EventHandler</a> <a href="#onmessage">onmessage</a>;
+  attribute <a class="external" data-anolis-spec="w3c-html" href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#eventhandler">EventHandler</a> <a href="#onstatechange">onstatechange</a>;
 };
 </pre>
-    <h3 id="availablechangeevent"><span class="secno">6.2 </span>
-      <code>AvailableChangeEvent</code>
-    </h3>
-    <p>
-      Fired at the primary screen's <code>NavigatorPresentation</code> object,
-      when screen availability changes.
+    <p class="XXX">
+      The <dfn id="id"><code>id</code></dfn> attribute, on getting, must return the
+      <a href="#presentation-session-identifier">presentation session identifier</a>.
     </p>
-    <pre class="idl">[Constructor(DOMString type, optional AvailableChangeEventInit eventInitDict)]
-interface AvailableChangeEvent : Event {
-  readonly attribute boolean available;
-};
-
-dictionary AvailableChangeEventInit : EventInit {
-  boolean available;
-};
-</pre>
-    <h3 id="presentationsession"><span class="secno">6.3 </span>
-      <code>PresentationSession</code>
-    </h3>
-    <p>
-      An object representing the established presentation session.
+    <p class="XXX">
+      The <dfn id="state"><code>state</code></dfn> attribute represents the
+      <span>presentation session</span>'s current state. On getting, it must
+      return one of the following values: ...
     </p>
-    <pre class="idl">enum PresentationSessionState { "connected", "disconnected" /*, "resumed" */ };
-
-interface PresentationSession : EventTarget {
-  readonly DOMString? id;
-  readonly attribute PresentationSessionState state;
-  void postMessage(DOMString message);
-  void close();
-  attribute EventHandler onmessage;
-  attribute EventHandler onstatechange;
-};
-</pre>
-    <h2 id="algorithms"><span class="secno">7 </span>
-      Algorithms
-    </h2>
-    <p>
-      These algorithms define the behavior of the
-      <code>NavigatorPresentation</code> and <code>PresentationSession</code>
-      interfaces declared in the <a href="#interfaces">Interfaces</a> section.
+    <p class="XXX">
+      The <dfn id="postmessage"><code>postMessage</code></dfn>() method, when invoked on a
+      <code>PresentationSesssion</code> object with an argument message, must
+      ...
     </p>
     <p>
-      Let <em>D</em> be the set of presentations that are currently known to
-      the user agent (regardles of their state). <em>D</em> is represented as a
-      set of tuples <em>(U, I, S)</em> where <em>U</em> is the URL that is
-      being presented; <em>I</em> is an alphanumeric identifier for the
-      presentation; and <em>S</em> is the user agent's
-      <code>PresentationSession</code> for the presentation. <em>U</em> and
-      <em>I</em> together uniquely identify the
-      <code>PresentationSession</code> of the corresponding presentation.
-    </p>
-    <p>
-      Let <a id="availabledisplays"><em>availableDisplays</em></a> be the list
-      of available <a href="presentation-display">presentation displays</a>
-      that are currently known to the user agent.
-    </p>
-    <h3 id="presentation-display-availability"><span class="secno">7.1 </span>
-      Presentation Display Availability
-    </h3>
-    <h4 id="availability-listener-added"><span class="secno">7.1.1 </span>
-      Availability Listener Added
-    </h4>
-    <p>
-      When a new <a class="external" data-anolis-spec="w3c-html" href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#event-handlers" title="event handlers">event
-      handler</a> <em>E</em> is added to
-      <code>NavigatorPresentation.onavailablechange</code>, the user agent must
-      run the <a href="monitor-availability-algorithm">algorithm to monitor
-      availability</a>.
-    </p>
-    <p class="note">
-      The mechanism used to monitor <a href="#presentation-display">presention
-      displays</a> availability is left to the user agent. The user agent may
-      choose search for screens at any time, not just when event handlers are
-      added to <code>NavigatorPresentation.onavailablechange</code>.
-    </p>
-    <p class="open-issue">
-      Do we want to fire the event at all handlers, or only the newly added
-      one?
-    </p>
-    <h4 id="availability-listener-removed"><span class="secno">7.1.2 </span>
-      Availability Listener Removed
-    </h4>
-    <p>
-      When the last <a class="external" data-anolis-spec="w3c-html" href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#event-handlers" title="event handlers">event handler</a> is removed from
-      <code>NavigatorPresentation.onavailablechange</code>, the user agent may
-      run the following steps:
-    </p>
-    <ol>
-      <li>Cancel the <a href="monitor-availability-algorithm">algorithm to
-      monitor availability change.</a>
-      </li>
-    </ol>
-    <h4 id="monitor-availability-algorithm"><span class="secno">7.1.3 </span>
-      Algorithm to Monitor Presentation Display Availability Change
-    </h4>
-    <p>
-      While there are <a class="external" data-anolis-spec="w3c-html" href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#event-handlers">event handlers</a>
-      added to NavigatorPresentation.onavailablechange, the user agent must
-      continuously keep track of the available <a href="#presentation-display">presentation displays</a> and repeat the
+      When the <dfn id="close"><code>close</code></dfn>() method is called on a
+      <a href="#presentationsession"><code>PresentationSession</code></a> <em>S</em>, the user agent must run the
       following steps:
     </p>
     <ol>
-      <li>
-        <a class="external" data-anolis-spec="w3c-html" href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#queue-a-task">Queue a task</a> to retrieve the
-        the list of curently available <a href="#presentation-display">presentation displays</a> and let <a id="newdisplays"><em>newDisplays</em></a> be this list.
-      </li>
-      <li>Wait for the completion of that task.
-      </li>
-      <li>If <a href="#availabledisplays">availableDisplays</a> is empty and
-      <a href="#newdisplays">newDisplays</a> is not empty, then
+      <li>If <em>S.state</em> is not <code>connected</code>, then:
         <ol>
-          <li>
-            <a class="external" data-anolis-spec="w3c-html" href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#queue-a-task">Queue a task</a> to
-            <a class="external" data-anolis-spec="w3c-html" href="http://www.w3.org/html/wg/drafts/html/master/infrastructure.html#concept-event-fire" title="concept-event-fire">fire
-            an event</a> named <code>availablechange</code> at <em>E</em>
-            (and only <em>E</em>) with the event's <code>available</code>
-            property set to <code>true</code>.
+          <li>Abort these steps.
           </li>
         </ol>
       </li>
-      <li>If <a href="#availabledisplays">availableDisplays</a> is not empty
-      and <a href="#newdisplays">newDisplays</a> is empty, then:
-        <div style="margin-left: 2em">
-          <a class="external" data-anolis-spec="w3c-html" href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#queue-a-task">Queue a task</a> to
-          <a class="external" data-anolis-spec="w3c-html" href="http://www.w3.org/html/wg/drafts/html/master/infrastructure.html#concept-event-fire" title="concept-event-fire">fire an
-          event</a> named <code>availablechange</code> at <em>E</em> (and
-          only <em>E</em>) with the event's <code>available</code> property set
-          to <code>false</code>.
-        </div>
+      <li>Set <em>S.state</em> to <code>disconnected</code>.
       </li>
-      <li>Set <a href="#availableDisplays">availableDisplays</a> to the value
-      of <a href="#newDisplays">newDisplays</a>.
+      <li>Let <em>D</em> be the set of presentations known by the user agent.
+      </li>
+      <li>
+        <a class="external" data-anolis-spec="w3c-html" href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#queue-a-task">Queue a task</a> <em>T</em> to run
+        the following steps in order:
+        <ol>
+          <li>For each presentation <em>(U, I, S')</em> in <em>D</em>,
+            <ol>
+              <li>Let <em>u</em> equal <em>U</em>, <em>i</em> equal <em>I</em>,
+              and <em>s</em> equal <em>S'</em>.
+              </li>
+              <li>If <em>u</em> is equal to <em>S.url</em> and <em>i</em> is
+              equal to <em>S.id</em>, run the following steps:
+                <ol>
+                  <li>
+                    <a class="external" data-anolis-spec="w3c-html" href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#queue-a-task">Queue a task</a> to
+                    <a class="external" data-anolis-spec="w3c-html" href="http://www.w3.org/html/wg/drafts/html/master/infrastructure.html#concept-event-fire" title="concept-event-fire">fire an event</a> named
+                    <code>statechange</code> at <em>s.onstatechange</em>.
+                  </li>
+                </ol>
+              </li>
+            </ol>
+          </li>
+        </ol>
       </li>
     </ol>
-    <h3 id="start-session"><span class="secno">7.2 </span>
-      Start Session
-    </h3>
     <p>
-      When <code>NavigatorPresentaton.startSession(presentationUrl,
+      The following are the event handlers (and their corresponding event
+      handler event types) that must be supported, as event handler IDL
+      attributes, by objects implementing the <a href="#presentationsession"><code>PresentationSession</code></a>
+      interface:
+    </p>
+    <table>
+      <thead>
+        <tr>
+          <th>
+            Event handler
+          </th>
+          <th>
+            Event handler event type
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            <dfn id="onmessage"><code>onmessage</code></dfn>
+          </td>
+          <td>
+            <code>message</code>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <dfn id="onstatechange"><code>onstatechange</code></dfn>
+          </td>
+          <td>
+            <code>statechange</code>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+    <h3 id="interface-navigatorpresentation"><span class="secno">6.3 </span>
+      Interface <a href="#navigatorpresentation"><code>NavigatorPresentation</code></a>
+    </h3>
+    <pre class="idl">partial interface <a class="external" data-anolis-spec="w3c-html" href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#navigator">Navigator</a> {
+  readonly attribute <a href="#navigatorpresentation">NavigatorPresentation</a> <a href="#presentation">presentation</a>;
+};
+</pre>
+    <p class="XXX">
+      The <dfn id="presentation"><code>presentation</code></dfn> attribute must return the
+      <a href="#navigatorpresentation"><code>NavigatorPresentation</code></a> object.
+    </p>
+    <pre class="idl">interface <dfn id="navigatorpresentation">NavigatorPresentation</dfn> : EventTarget {
+  readonly attribute <a href="#presentationsession">PresentationSession</a>? <a href="#session">session</a>;
+  Promise&lt;<a href="#presentationsession">PresentationSession</a>&gt; <a href="#startsession">startSession</a>(DOMString url, DOMString? presentationId);
+  Promise&lt;<a href="#presentationsession">PresentationSession</a>&gt; <a href="#joinsession">joinSession</a>(DOMString url, DOMString? presentationId);
+  attribute <a class="external" data-anolis-spec="w3c-html" href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#eventhandler">EventHandler</a> <a href="#onavailablechange">onavailablechange</a>;
+};
+</pre>
+    <p class="XXX">
+      On getting, the <dfn id="session"><code>session</code></dfn> attribute must return ...
+    </p>
+    <h4 id="starting-a-presentation-session"><span class="secno">6.3.1 </span>
+      Starting a presentation session
+    </h4>
+    <p>
+      When <code><dfn id="startsession">startSession</dfn>(presentationUrl,
       presentationId)</code> is called, the user agent must run the following
-      steps.
+      steps:
     </p>
     <dl>
       <dt>
@@ -1024,10 +1007,11 @@ interface PresentationSession : EventTarget {
       </li>
       <li>Return <em>P</em>.
       </li>
-      <li>If the user agent is currently not running the <a href="#monitor-availability-algorithm">presentation display availability
-      monitoring algorithm</a>:
+      <li>If the user agent does not <a href="#monitor-presentation-display-availability">monitor presentation display
+      availability</a>, run the following steps:
         <ol>
-          <li>Start the algorithm.
+          <li>
+            <a href="#monitor-presentation-display-availability">Monitor presentation display availability</a>.
           </li>
           <li>Wait until the algorithm completes.
           </li>
@@ -1058,7 +1042,7 @@ interface PresentationSession : EventTarget {
               <em>I</em> be a random alphanumeric value of at least 16
               characters drawn from the characters <code>[A-Za-z0-9]</code>.
               </li>
-              <li>Create a new <code>PresentationSession</code> <em>S</em>.
+              <li>Create a new <a href="#presentationsession"><code>PresentationSession</code></a> <em>S</em>.
               </li>
               <li>Set <code>S.url</code> to <code>presentationUrl</code>, set
               <code>S.id</code> to <em>I</em>, and set <code>S.state</code> to
@@ -1080,8 +1064,9 @@ interface PresentationSession : EventTarget {
                         <a class="external" data-anolis-spec="promguide" href="http://www.w3.org/2001/tag/doc/promises-guide#shorthand-manipulating" title="resolve-reject">Resolve</a> <em>P</em> with
                         <em>S</em>.
                       </li>
-                      <li>Initiate the <a href="#presentation-connection">Presentation Connection</a>
-                      algorithm for <em>S</em>.
+                      <li>
+                        <a href="#establish-a-presentation-connection">Establish a presentation connection</a> with
+                        <em>S</em>.
                       </li>
                     </ol>
                   </li>
@@ -1118,15 +1103,14 @@ interface PresentationSession : EventTarget {
     <p class="open-issue">
       Do we want to distinguish the permission-denied outcome from the
       no-screens-available outcome? Developers would be able to infer it anyway
-      from <code>onavailablechange</code>.
+      from <a href="#onavailablechange"><code>onavailablechange</code></a>.
     </p>
-    <h3 id="join-session"><span class="secno">7.3 </span>
-      Join Session
-    </h3>
+    <h4 id="joining-a-presentation-session"><span class="secno">6.3.2 </span>
+      Joining a presentation session
+    </h4>
     <p>
-      When <code>NavigatorPresentation.joinSession(presentationUrl,
-      presentationId)</code> is called, the user agent must run the following
-      steps:
+      When <code><dfn id="joinsession">joinSession</dfn>(presentationUrl, presentationId)</code>
+      is called, the user agent must run the following steps:
     </p>
     <dl>
       <dt>
@@ -1168,8 +1152,9 @@ interface PresentationSession : EventTarget {
                   <li>
                     <a class="external" data-anolis-spec="promguide" href="http://www.w3.org/2001/tag/doc/promises-guide#shorthand-manipulating" title="resolve-reject">Resolve</a> <em>P</em> with <em>S</em>.
                   </li>
-                  <li>Initiate the <a href="#presentation-connection">Presentation Connection</a>
-                  algorithm for <em>S</em>.
+                  <li>
+                    <a href="#establish-a-presentation-connection">Establish a presentation connection</a> with
+                    <em>S</em>.
                   </li>
                   <li>Abort the remaining steps of <em>T</em>.
                   </li>
@@ -1188,58 +1173,41 @@ interface PresentationSession : EventTarget {
       If no matching presentation is found, we could leave the Promise pending
       in case a matching presentation is started in the future.
     </p>
-    <h3 id="session-close"><span class="secno">7.4 </span>
-      Session Close
-    </h3>
     <p>
-      When <code>PresentationSession.close()</code> is called on a
-      <code>PresentationSession</code> <em>S</em>, the user agent must run the
-      following steps:
+      <span>The following are the event handlers (and their corresponding event
+      handler event types) that must be supported, as event handler IDL
+      attributes, by objects implementing the <a href="#presentationsession"><code>PresentationSession</code></a>
+      interface:</span>
     </p>
-    <ol>
-      <li>If <em>S.state</em> is not <code>connected</code>, then:
-        <ol>
-          <li>Abort these steps.
-          </li>
-        </ol>
-      </li>
-      <li>Set <em>S.state</em> to <code>disconnected</code>.
-      </li>
-      <li>Let <em>D</em> be the set of presentations known by the user agent.
-      </li>
-      <li>
-        <a class="external" data-anolis-spec="w3c-html" href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#queue-a-task">Queue a task</a> <em>T</em> to run
-        the following steps in order:
-        <ol>
-          <li>For each presentation <em>(U, I, S')</em> in <em>D</em>,
-            <ol>
-              <li>Let <em>u</em> equal <em>U</em>, <em>i</em> equal <em>I</em>,
-              and <em>s</em> equal <em>S'</em>.
-              </li>
-              <li>If <em>u</em> is equal to <em>S.url</em> and <em>i</em> is
-              equal to <em>S.id</em>, run the following steps:
-                <ol>
-                  <li>
-                    <a class="external" data-anolis-spec="w3c-html" href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#queue-a-task">Queue a task</a> to
-                    <a class="external" data-anolis-spec="w3c-html" href="http://www.w3.org/html/wg/drafts/html/master/infrastructure.html#concept-event-fire" title="concept-event-fire">fire an event</a> named
-                    <code>statechange</code> at <em>s.onstatechange</em>.
-                  </li>
-                </ol>
-              </li>
-            </ol>
-          </li>
-        </ol>
-      </li>
-    </ol>
-    <h3 id="presentation-connection"><span class="secno">7.5 </span>
-      Presentation Connection
-    </h3>
-    <p>
-      When the user agent has created a <code>PresentationSession</code>
-      <em>S</em> to resolve a promise returned from
-      <code>NavigatorPresentation.startSession</code>, or resolved a promise
-      returned from to <code>NavigatorPresentation.joinSession</code> with
-      <em>S</em>, it must run the following steps:
+    <table>
+      <thead>
+        <tr>
+          <th>
+            Event handler
+          </th>
+          <th>
+            Event handler event type
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            <dfn id="onavailablechange"><code>onavailablechange</code></dfn>
+          </td>
+          <td>
+            <code>availablechange</code>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+    <h4 id="establishing-a-presentation-connection"><span class="secno">6.3.3 </span>
+      Establishing a presentation connection
+    </h4>
+    <p class="XXX">
+      When the user agent is to <dfn id="establish-a-presentation-connection">establish a presentation connection</dfn>
+      using a <span>presentation session</span> <em>S</em>, it must run the
+      following steps:
     </p>
     <ol>
       <li>If <em>S.state</em> is <code>connected</code>, then:
@@ -1306,7 +1274,132 @@ interface PresentationSession : EventTarget {
       Need to further specify the semantics of the messaging channel (using
       WebSockets or MessagePort as a reference).
     </p>
-    <h3 id="todo"><span class="secno">7.6 </span>
+    <h3 id="interface-availablechangeevent"><span class="secno">6.4 </span>
+      <span>Interface <a href="#availablechangeevent"><code>AvailableChangeEvent</code></a></span>
+    </h3>
+    <pre class="idl"><span>[Constructor(DOMString type, optional <a href="#availablechangeeventinit">AvailableChangeEventInit</a> eventInitDict)]
+interface <dfn id="availablechangeevent">AvailableChangeEvent</dfn> : Event {
+  readonly attribute boolean available;
+};
+
+dictionary <dfn id="availablechangeeventinit">AvailableChangeEventInit</dfn> : EventInit {
+  boolean available;
+};
+</span>
+</pre>
+    <p class="XXX">
+      When the <dfn id="presentation-display-availability">presentation display availability</dfn> changes, the user
+      agent must fire an event with the name <code>availablechange</code> at
+      the <a href="#presentationsession"><code>PresentationSession</code></a> object, using the
+      <a href="#availablechangeevent"><code>AvailableChangeEvent</code></a> interface, with the
+      <code>available</code> attribute initialized to ...
+    </p>
+    <h4 id="monitoring-presentation-display-availability"><span class="secno">6.4.1 </span>
+      Monitoring presentation display availability
+    </h4>
+    <p class="XXX">
+      Each <code>Document</code> object must have a <dfn id="list-of-available-presentation-displays">list of available
+      presentation displays</dfn>. Each display in this list is identified by a
+      tuple (U, I, S) as follows:
+    </p>
+    <p>
+      Let <em>D</em> be the set of presentations that are currently known to
+      the user agent (regardles of their state). <em>D</em> is represented as a
+      set of tuples <em>(U, I, S)</em> where <em>U</em> is the URL that is
+      being presented; <em>I</em> is an alphanumeric identifier for the
+      presentation; and <em>S</em> is the user agent's
+      <a href="#presentationsession"><code>PresentationSession</code></a> for the presentation. <em>U</em> and
+      <em>I</em> together uniquely identify the
+      <a href="#presentationsession"><code>PresentationSession</code></a> of the corresponding presentation.
+    </p>
+    <p class="XXX">
+      When the user agent is to <dfn id="update-the-list-of-available-presentation-displays">update the list of available presentation
+      displays</dfn>, it must run the following steps:
+    </p>
+    <ol>
+      <li>Let <a id="availabledisplays"><em>availableDisplays</em></a> be the
+      <a href="#list-of-available-presentation-displays">list of available presentation displays</a> that are currently
+      known to the user agent.
+      </li>
+    </ol>
+    <p class="XXX">
+      When the user agent is to <dfn id="start-monitoring-for-changes-to-presentation-display-availability">start monitoring for changes to
+      presentation display availability</dfn>, it must run the following steps:
+    </p>
+    <p>
+      When a new <a class="external" data-anolis-spec="w3c-html" href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#event-handlers" title="event handlers">event
+      handler</a> <em>E</em> is added to
+      <code><a href="#navigatorpresentation">NavigatorPresentation</a>.onavailablechange</code>, the
+      user agent must run the <a href="monitor-availability-algorithm">algorithm to monitor availability</a>.
+    </p>
+    <p class="note">
+      The mechanism used to monitor <a href="#presentation-display">presention
+      displays</a> availability is left to the user agent. The user agent may
+      choose search for screens at any time, not just when event handlers are
+      added to <code>NavigatorPresentation.onavailablechange</code>.
+    </p>
+    <p class="open-issue">
+      Do we want to fire the event at all handlers, or only the newly added
+      one?
+    </p>
+    <p class="XXX">
+      When the user agent is to <dfn id="stop-monitoring-for-changes-to-presentation-display-availability">stop monitoring for changes to
+      presentation display availability</dfn>, it must run the following steps:
+    </p>
+    <p>
+      When the last <a class="external" data-anolis-spec="w3c-html" href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#event-handlers" title="event handlers">event handler</a> is removed from
+      <code>NavigatorPresentation.onavailablechange</code>, the user agent may
+      run the following steps:
+    </p>
+    <ol>
+      <li>Cancel the <a href="monitor-availability-algorithm">algorithm to
+      monitor availability change.</a>
+      </li>
+    </ol>
+    <p class="XXX">
+      When the user agent is required to <dfn id="monitor-presentation-display-availability">monitor presentation display
+      availability</dfn>, it must run the following steps ...
+    </p>
+    <p>
+      While there are <a class="external" data-anolis-spec="w3c-html" href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#event-handlers">event handlers</a>
+      added to NavigatorPresentation.onavailablechange, the user agent must
+      continuously keep track of the available <a href="#presentation-display">presentation displays</a> and repeat the
+      following steps:
+    </p>
+    <ol>
+      <li>
+        <a class="external" data-anolis-spec="w3c-html" href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#queue-a-task">Queue a task</a> to retrieve the
+        the list of curently available <a href="#presentation-display">presentation displays</a> and let <a id="newdisplays"><em>newDisplays</em></a> be this list.
+      </li>
+      <li>Wait for the completion of that task.
+      </li>
+      <li>If <a href="#availabledisplays">availableDisplays</a> is empty and
+      <a href="#newdisplays">newDisplays</a> is not empty, then
+        <ol>
+          <li>
+            <a class="external" data-anolis-spec="w3c-html" href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#queue-a-task">Queue a task</a> to
+            <a class="external" data-anolis-spec="w3c-html" href="http://www.w3.org/html/wg/drafts/html/master/infrastructure.html#concept-event-fire" title="concept-event-fire">fire
+            an event</a> named <code>availablechange</code> at <em>E</em>
+            (and only <em>E</em>) with the event's <code>available</code>
+            property set to <code>true</code>.
+          </li>
+        </ol>
+      </li>
+      <li>If <a href="#availabledisplays">availableDisplays</a> is not empty
+      and <a href="#newdisplays">newDisplays</a> is empty, then:
+        <div style="margin-left: 2em">
+          <a class="external" data-anolis-spec="w3c-html" href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#queue-a-task">Queue a task</a> to
+          <a class="external" data-anolis-spec="w3c-html" href="http://www.w3.org/html/wg/drafts/html/master/infrastructure.html#concept-event-fire" title="concept-event-fire">fire an
+          event</a> named <code>availablechange</code> at <em>E</em> (and
+          only <em>E</em>) with the event's <code>available</code> property set
+          to <code>false</code>.
+        </div>
+      </li>
+      <li>Set <a href="#availableDisplays">availableDisplays</a> to the value
+      of <a href="#newDisplays">newDisplays</a>.
+      </li>
+    </ol>
+    <h3 id="todo"><span class="secno">6.5 </span>
       TODO
     </h3>
     <p class="open-issue">

--- a/xrefs/presentation.json
+++ b/xrefs/presentation.json
@@ -1,6 +1,7 @@
 {
   "definitions": {
     "algorithm-post-message": "algorithm-post-message",
+    "algorithm-update-available": "algorithm-update-available",
     "availablechangeevent": "availablechangeevent",
     "availablechangeeventinit": "availablechangeeventinit",
     "close": "close",
@@ -13,6 +14,7 @@
     "list of available presentation displays": "list-of-available-presentation-displays",
     "monitor presentation display availability": "monitor-presentation-display-availability",
     "navigatorpresentation": "navigatorpresentation",
+    "non-functional-requirements": "non-functional-requirements",
     "onavailablechange": "onavailablechange",
     "onmessage": "onmessage",
     "onstatechange": "onstatechange",

--- a/xrefs/presentation.json
+++ b/xrefs/presentation.json
@@ -12,7 +12,6 @@
     "establish a presentation connection": "establish-a-presentation-connection",
     "id": "id",
     "joinsession": "joinsession",
-    "list of available presentation displays": "list-of-available-presentation-displays",
     "navigatorpresentation": "navigatorpresentation",
     "non-functional-requirements": "non-functional-requirements",
     "onavailablechange": "onavailablechange",

--- a/xrefs/presentation.json
+++ b/xrefs/presentation.json
@@ -5,6 +5,7 @@
     "availablechangeeventinit": "availablechangeeventinit",
     "close": "close",
     "close-algorithm": "close-algorithm",
+    "concept-presentation": "concept-presentation",
     "concept-presentation-session": "concept-presentation-session",
     "establish a presentation connection": "establish-a-presentation-connection",
     "id": "id",

--- a/xrefs/presentation.json
+++ b/xrefs/presentation.json
@@ -1,6 +1,32 @@
 {
   "definitions": {
-    "presentation display": "presentation-display"
+    "availablechangeevent": "availablechangeevent",
+    "availablechangeeventinit": "availablechangeeventinit",
+    "close": "close",
+    "concept-presentation-session": "concept-presentation-session",
+    "establish a presentation connection": "establish-a-presentation-connection",
+    "id": "id",
+    "joinsession": "joinsession",
+    "list of available presentation displays": "list-of-available-presentation-displays",
+    "monitor presentation display availability": "monitor-presentation-display-availability",
+    "navigatorpresentation": "navigatorpresentation",
+    "onavailablechange": "onavailablechange",
+    "onmessage": "onmessage",
+    "onstatechange": "onstatechange",
+    "postmessage": "postmessage",
+    "presentation": "presentation",
+    "presentation display": "presentation-display",
+    "presentation display availability": "presentation-display-availability",
+    "presentation session identifier": "presentation-session-identifier",
+    "presentation session state": "presentation-session-state",
+    "presentationsession": "presentationsession",
+    "presentationsessionstate": "presentationsessionstate",
+    "session": "session",
+    "start monitoring for changes to presentation display availability": "start-monitoring-for-changes-to-presentation-display-availability",
+    "startsession": "startsession",
+    "state": "state",
+    "stop monitoring for changes to presentation display availability": "stop-monitoring-for-changes-to-presentation-display-availability",
+    "update the list of available presentation displays": "update-the-list-of-available-presentation-displays"
   },
   "url": "https://w3c.github.io/presentation-api"
 }

--- a/xrefs/presentation.json
+++ b/xrefs/presentation.json
@@ -1,8 +1,10 @@
 {
   "definitions": {
+    "algorithm-post-message": "algorithm-post-message",
     "availablechangeevent": "availablechangeevent",
     "availablechangeeventinit": "availablechangeeventinit",
     "close": "close",
+    "close-algorithm": "close-algorithm",
     "concept-presentation-session": "concept-presentation-session",
     "establish a presentation connection": "establish-a-presentation-connection",
     "id": "id",
@@ -13,6 +15,7 @@
     "onavailablechange": "onavailablechange",
     "onmessage": "onmessage",
     "onstatechange": "onstatechange",
+    "opening browsing context": "opening-browsing-context",
     "postmessage": "postmessage",
     "presentation": "presentation",
     "presentation display": "presentation-display",

--- a/xrefs/presentation.json
+++ b/xrefs/presentation.json
@@ -1,9 +1,10 @@
 {
   "definitions": {
+    "algorithm-monitor-available": "algorithm-monitor-available",
     "algorithm-post-message": "algorithm-post-message",
-    "algorithm-update-available": "algorithm-update-available",
     "availablechangeevent": "availablechangeevent",
     "availablechangeeventinit": "availablechangeeventinit",
+    "cancel monitoring the list of available presentation displays": "cancel-monitoring-the-list-of-available-presentation-displays",
     "close": "close",
     "close-algorithm": "close-algorithm",
     "concept-presentation": "concept-presentation",
@@ -12,7 +13,6 @@
     "id": "id",
     "joinsession": "joinsession",
     "list of available presentation displays": "list-of-available-presentation-displays",
-    "monitor presentation display availability": "monitor-presentation-display-availability",
     "navigatorpresentation": "navigatorpresentation",
     "non-functional-requirements": "non-functional-requirements",
     "onavailablechange": "onavailablechange",
@@ -27,11 +27,8 @@
     "presentation session state": "presentation-session-state",
     "presentationsession": "presentationsession",
     "presentationsessionstate": "presentationsessionstate",
-    "start monitoring for changes to presentation display availability": "start-monitoring-for-changes-to-presentation-display-availability",
     "startsession": "startsession",
-    "state": "state",
-    "stop monitoring for changes to presentation display availability": "stop-monitoring-for-changes-to-presentation-display-availability",
-    "update the list of available presentation displays": "update-the-list-of-available-presentation-displays"
+    "state": "state"
   },
   "url": "https://w3c.github.io/presentation-api"
 }

--- a/xrefs/presentation.json
+++ b/xrefs/presentation.json
@@ -24,7 +24,6 @@
     "presentation session state": "presentation-session-state",
     "presentationsession": "presentationsession",
     "presentationsessionstate": "presentationsessionstate",
-    "session": "session",
     "start monitoring for changes to presentation display availability": "start-monitoring-for-changes-to-presentation-display-availability",
     "startsession": "startsession",
     "state": "state",


### PR DESCRIPTION
* APIs for interacting with Presentation.. => "API"
* opening browsing context
* close, send => own algorithms
* send TODO moved
* session property open-issue, still required?
* AvailableChange event reorg'ed
* Idioms => uppercase
* Definition of "presentation"
* session identifier => add "alphanumeric"
* Availability updating algorithm isolated

* Organizing section of onavailable change
** Define monitoring algorithm
** Define when to start and cancel monitoring

* Event handlers wording
* Replace "opener page" => opening browsing context
* removed .XXX style
* Padding before headings
