### PR TITLE
Added a custom paragraph in Status of This Document section (#47)

### DIFF
--- a/Overview.src.html
+++ b/Overview.src.html
@@ -190,7 +190,7 @@
       Community Group. Algorithms have been drafted in particular. Most
       sections are still incomplete or underspecified. Privacy and security
       considerations are missing. A few open issues are noted inline. Please
-      check the goup's <a href=
+      check the group's <a href=
       "https://github.com/w3c/presentation-api/issues">issue tracker</a> on
       GitHub for an accurate list. Feedback from early experimentations is
       encouraged to allow the Second Screen Presentation Working Group to

--- a/Overview.src.html
+++ b/Overview.src.html
@@ -182,6 +182,21 @@
       All comments are welcome.
     </p>
     <p>
+      This document is a <b>work in progress</b> and is subject to change. It
+      builds on the <a href=
+      "http://www.w3.org/2014/secondscreen/presentation-api/20141118/" title=
+      "Presentation API W3C Community Group Final Report">final report</a>
+      (dated 18 November 2014) produced by the Second Screen Presentation
+      Community Group. Algorithms have been drafted in particular. Most
+      sections are still incomplete or underspecified. Privacy and security
+      considerations are missing. A few open issues are noted inline. Please
+      check the goup's <a href=
+      "https://github.com/w3c/presentation-api/issues">issue tracker</a> on
+      GitHub for an accurate list. Feedback from early experimentations is
+      encouraged to allow the Second Screen Presentation Working Group to
+      evolve the specification based on implementation issues.
+    </p>
+    <p>
       Publication as an Editor's Draft does not imply endorsement by the
       <abbr title="World Wide Web Consortium">W3C</abbr> Membership. This is a
       draft document and may be updated, replaced or obsoleted by other

--- a/index.html
+++ b/index.html
@@ -176,7 +176,7 @@
       Community Group. Algorithms have been drafted in particular. Most
       sections are still incomplete or underspecified. Privacy and security
       considerations are missing. A few open issues are noted inline. Please
-      check the goup's <a href="https://github.com/w3c/presentation-api/issues">issue tracker</a> on
+      check the group's <a href="https://github.com/w3c/presentation-api/issues">issue tracker</a> on
       GitHub for an accurate list. Feedback from early experimentations is
       encouraged to allow the Second Screen Presentation Working Group to
       evolve the specification based on implementation issues.

--- a/index.html
+++ b/index.html
@@ -170,6 +170,18 @@
       All comments are welcome.
     </p>
     <p>
+      This document is a <b>work in progress</b> and is subject to change. It
+      builds on the <a href="http://www.w3.org/2014/secondscreen/presentation-api/20141118/" title="Presentation API W3C Community Group Final Report">final report</a>
+      (dated 18 November 2014) produced by the Second Screen Presentation
+      Community Group. Algorithms have been drafted in particular. Most
+      sections are still incomplete or underspecified. Privacy and security
+      considerations are missing. A few open issues are noted inline. Please
+      check the goup's <a href="https://github.com/w3c/presentation-api/issues">issue tracker</a> on
+      GitHub for an accurate list. Feedback from early experimentations is
+      encouraged to allow the Second Screen Presentation Working Group to
+      evolve the specification based on implementation issues.
+    </p>
+    <p>
       Publication as an Editor's Draft does not imply endorsement by the
       <abbr title="World Wide Web Consortium">W3C</abbr> Membership. This is a
       draft document and may be updated, replaced or obsoleted by other


### PR DESCRIPTION
This new paragraph mentions the provenance of the spec, most important change
since publication by the CG, alerts users about missing or incomplete parts,
and invites them to check the list of issues on GitHub.

It builds on the text proposed by @anssiko.

Notes:
- the need for a custom paragraph comes from PubRules [1].
The Manual of Style [2] gives useful examples of points to address in this
custom paragraph, which I followed to some extent.

- a few other changes will be needed to convert the document into a "First
Public Working Draft". This will be the last changes made to the spec, when
the spec right before publication, when the spec is copied over to W3C space.

[1] http://www.w3.org/2005/07/pubrules?year=2015&uimode=filter&filter=Filter+pubrules&filterValues=form&docstatus=fpwd-wd-tr&patpol=w3c&rectrack=yes&normative=yes&procrev=2014&prevrec=none#document-status
[2] http://www.w3.org/2001/06/manual/#Status