### PR TITLE
Use the custom W3C Document License defined in the Charter

### DIFF
--- a/Overview.src.html
+++ b/Overview.src.html
@@ -69,6 +69,7 @@
     table td, table th { border-left: solid; border-right: solid; border-bottom: solid thin; vertical-align: top; padding: 0.2em; }
     dfn { font-weight: bolder; font-style: normal; }
     #use-cases-and-requirements dd { margin-top: 0.5em; margin-bottom: 1em; }
+    .copyright { font-size: small; }
     </style>
   </head>
   <body>
@@ -137,14 +138,27 @@
         "http://www.ercim.eu/"><abbr title=
         "European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>,
         <a href="http://www.keio.ac.jp/">Keio</a>, <a href=
-        "http://ev.buaa.edu.cn/">Beihang</a>). W3C <a href=
-        "http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>,
-        <a href=
+        "http://ev.buaa.edu.cn/">Beihang</a>), All Rights Reserved. W3C
+        <a href="http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">
+        liability</a>, <a href=
         "http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a>
         and <a href=
         "http://www.w3.org/Consortium/Legal/copyright-documents">document
-        use</a> rules apply.
+        use</a> rules apply. Additionally, all Code Components, as defined
+        below, are made available under the <a href=
+        "https://www.w3.org/Consortium/Legal/copyright-software">W3C Software
+        License and Notice</a>.
       </p>
+      <ul class="copyright">
+        <li style="list-style: none">For the purpose of this license, Code
+        Components are:
+        </li>
+        <li>Web IDL in sections clearly marked as Web IDL; and
+        </li>
+        <li>W3C defined markup (HTML, CSS, etc.) and computer programming
+        language code clearly marked as code examples.
+        </li>
+      </ul>
       <hr>
     </div>
     <section>

--- a/Overview.src.html
+++ b/Overview.src.html
@@ -68,10 +68,6 @@
     table thead, table tbody { border-bottom: solid; }
     table td, table th { border-left: solid; border-right: solid; border-bottom: solid thin; vertical-align: top; padding: 0.2em; }
     dfn { font-weight: bolder; font-style: normal; }
-
-    h2, h3 { padding-top: 1.3em; }
-    h4 { padding-top: 1.2em; }
-
     #use-cases-and-requirements dd { margin-top: 0.5em; margin-bottom: 1em; }
     </style>
   </head>

--- a/index.html
+++ b/index.html
@@ -66,6 +66,7 @@
     table td, table th { border-left: solid; border-right: solid; border-bottom: solid thin; vertical-align: top; padding: 0.2em; }
     dfn { font-weight: bolder; font-style: normal; }
     #use-cases-and-requirements dd { margin-top: 0.5em; margin-bottom: 1em; }
+    .copyright { font-size: small; }
     </style>
   </head>
   <body>
@@ -132,11 +133,24 @@
       <p class="copyright">
         <a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a>
         © 2014 <a href="http://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>®</sup> (<a href="http://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>, <a href="http://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>,
-        <a href="http://www.keio.ac.jp/">Keio</a>, <a href="http://ev.buaa.edu.cn/">Beihang</a>). W3C <a href="http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>,
-        <a href="http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a>
+        <a href="http://www.keio.ac.jp/">Keio</a>, <a href="http://ev.buaa.edu.cn/">Beihang</a>), All Rights Reserved. W3C
+        <a href="http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">
+        liability</a>, <a href="http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a>
         and <a href="http://www.w3.org/Consortium/Legal/copyright-documents">document
-        use</a> rules apply.
+        use</a> rules apply. Additionally, all Code Components, as defined
+        below, are made available under the <a href="https://www.w3.org/Consortium/Legal/copyright-software">W3C Software
+        License and Notice</a>.
       </p>
+      <ul class="copyright">
+        <li style="list-style: none">For the purpose of this license, Code
+        Components are:
+        </li>
+        <li>Web IDL in sections clearly marked as Web IDL; and
+        </li>
+        <li>W3C defined markup (HTML, CSS, etc.) and computer programming
+        language code clearly marked as code examples.
+        </li>
+      </ul>
       <hr>
     </div>
     <section>

--- a/index.html
+++ b/index.html
@@ -65,10 +65,6 @@
     table thead, table tbody { border-bottom: solid; }
     table td, table th { border-left: solid; border-right: solid; border-bottom: solid thin; vertical-align: top; padding: 0.2em; }
     dfn { font-weight: bolder; font-style: normal; }
-
-    h2, h3 { padding-top: 1.3em; }
-    h4 { padding-top: 1.2em; }
-
     #use-cases-and-requirements dd { margin-top: 0.5em; margin-bottom: 1em; }
     </style>
   </head>
@@ -81,8 +77,8 @@
       <h1>
         Presentation API
       </h1>
-      <h2 class="no-num no-toc" id="editor's-draft-11-february-2015">
-        Editor's Draft 11 February 2015
+      <h2 class="no-num no-toc" id="editor's-draft-12-february-2015">
+        Editor's Draft 12 February 2015
       </h2>
       <dl>
         <dt>

--- a/releases/FPWD.html
+++ b/releases/FPWD.html
@@ -66,6 +66,7 @@
     table td, table th { border-left: solid; border-right: solid; border-bottom: solid thin; vertical-align: top; padding: 0.2em; }
     dfn { font-weight: bolder; font-style: normal; }
     #use-cases-and-requirements dd { margin-top: 0.5em; margin-bottom: 1em; }
+    .copyright { font-size: small; }
     </style>
   </head>
   <body>
@@ -132,11 +133,24 @@
       <p class="copyright">
         <a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a>
         © 2014 <a href="http://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>®</sup> (<a href="http://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>, <a href="http://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>,
-        <a href="http://www.keio.ac.jp/">Keio</a>, <a href="http://ev.buaa.edu.cn/">Beihang</a>). W3C <a href="http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>,
-        <a href="http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a>
+        <a href="http://www.keio.ac.jp/">Keio</a>, <a href="http://ev.buaa.edu.cn/">Beihang</a>), All Rights Reserved. W3C
+        <a href="http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">
+        liability</a>, <a href="http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a>
         and <a href="http://www.w3.org/Consortium/Legal/copyright-documents">document
-        use</a> rules apply.
+        use</a> rules apply. Additionally, all Code Components, as defined
+        below, are made available under the <a href="https://www.w3.org/Consortium/Legal/copyright-software">W3C Software
+        License and Notice</a>.
       </p>
+      <ul class="copyright">
+        <li style="list-style: none">For the purpose of this license, Code
+        Components are:
+        </li>
+        <li>Web IDL in sections clearly marked as Web IDL; and
+        </li>
+        <li>W3C defined markup (HTML, CSS, etc.) and computer programming
+        language code clearly marked as code examples.
+        </li>
+      </ul>
       <hr>
     </div>
     <section>

--- a/releases/FPWD.html
+++ b/releases/FPWD.html
@@ -65,10 +65,6 @@
     table thead, table tbody { border-bottom: solid; }
     table td, table th { border-left: solid; border-right: solid; border-bottom: solid thin; vertical-align: top; padding: 0.2em; }
     dfn { font-weight: bolder; font-style: normal; }
-
-    h2, h3 { padding-top: 1.3em; }
-    h4 { padding-top: 1.2em; }
-
     #use-cases-and-requirements dd { margin-top: 0.5em; margin-bottom: 1em; }
     </style>
   </head>
@@ -81,8 +77,8 @@
       <h1>
         Presentation API
       </h1>
-      <h2 class="no-num no-toc" id="w3c-working-draft-11-february-2015">
-        W3C First Public Working Draft 11 February 2015
+      <h2 class="no-num no-toc" id="w3c-working-draft-12-february-2015">
+        W3C First Public Working Draft 12 February 2015
       </h2>
       <dl>
         <dt>


### PR DESCRIPTION
The group's Charter defines a custom Document License [1] the documents produced by this group should use. To that end, I updated the Editor's Draft as well as the FPWD snapshot in staging accordingly.

@tidoust Pubrules checker naturally does not understand this custom Document License, so this needs to be checked manually.

[1] http://www.w3.org/2014/secondscreen/charter.html#doclicense