### PR TITLE
Rolled back Copyright notice to the usual one

### DIFF
--- a/Overview.src.html
+++ b/Overview.src.html
@@ -131,34 +131,21 @@
       <p class="copyright">
         <a href=
         "http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a>
-        © 2014 <a href="http://www.w3.org/"><abbr title=
+        © 2015 <a href="http://www.w3.org/"><abbr title=
         "World Wide Web Consortium">W3C</abbr></a><sup>®</sup> (<a href=
         "http://www.csail.mit.edu/"><abbr title=
         "Massachusetts Institute of Technology">MIT</abbr></a>, <a href=
         "http://www.ercim.eu/"><abbr title=
         "European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>,
         <a href="http://www.keio.ac.jp/">Keio</a>, <a href=
-        "http://ev.buaa.edu.cn/">Beihang</a>), All Rights Reserved. W3C
-        <a href="http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">
-        liability</a>, <a href=
+        "http://ev.buaa.edu.cn/">Beihang</a>). W3C <a href=
+        "http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>,
+        <a href=
         "http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a>
         and <a href=
         "http://www.w3.org/Consortium/Legal/copyright-documents">document
-        use</a> rules apply. Additionally, all Code Components, as defined
-        below, are made available under the <a href=
-        "https://www.w3.org/Consortium/Legal/copyright-software">W3C Software
-        License and Notice</a>.
+        use</a> rules apply.
       </p>
-      <ul class="copyright">
-        <li style="list-style: none">For the purpose of this license, Code
-        Components are:
-        </li>
-        <li>Web IDL in sections clearly marked as Web IDL; and
-        </li>
-        <li>W3C defined markup (HTML, CSS, etc.) and computer programming
-        language code clearly marked as code examples.
-        </li>
-      </ul>
       <hr>
     </div>
     <section>

--- a/index.html
+++ b/index.html
@@ -78,8 +78,8 @@
       <h1>
         Presentation API
       </h1>
-      <h2 class="no-num no-toc" id="editor's-draft-12-february-2015">
-        Editor's Draft 12 February 2015
+      <h2 class="no-num no-toc" id="editor's-draft-13-february-2015">
+        Editor's Draft 13 February 2015
       </h2>
       <dl>
         <dt>
@@ -132,25 +132,12 @@
       </dl>
       <p class="copyright">
         <a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a>
-        © 2014 <a href="http://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>®</sup> (<a href="http://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>, <a href="http://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>,
-        <a href="http://www.keio.ac.jp/">Keio</a>, <a href="http://ev.buaa.edu.cn/">Beihang</a>), All Rights Reserved. W3C
-        <a href="http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">
-        liability</a>, <a href="http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a>
+        © 2015 <a href="http://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>®</sup> (<a href="http://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>, <a href="http://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>,
+        <a href="http://www.keio.ac.jp/">Keio</a>, <a href="http://ev.buaa.edu.cn/">Beihang</a>). W3C <a href="http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>,
+        <a href="http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a>
         and <a href="http://www.w3.org/Consortium/Legal/copyright-documents">document
-        use</a> rules apply. Additionally, all Code Components, as defined
-        below, are made available under the <a href="https://www.w3.org/Consortium/Legal/copyright-software">W3C Software
-        License and Notice</a>.
+        use</a> rules apply.
       </p>
-      <ul class="copyright">
-        <li style="list-style: none">For the purpose of this license, Code
-        Components are:
-        </li>
-        <li>Web IDL in sections clearly marked as Web IDL; and
-        </li>
-        <li>W3C defined markup (HTML, CSS, etc.) and computer programming
-        language code clearly marked as code examples.
-        </li>
-      </ul>
       <hr>
     </div>
     <section>

--- a/releases/FPWD.html
+++ b/releases/FPWD.html
@@ -78,8 +78,8 @@
       <h1>
         Presentation API
       </h1>
-      <h2 class="no-num no-toc" id="w3c-working-draft-12-february-2015">
-        W3C First Public Working Draft 12 February 2015
+      <h2 class="no-num no-toc" id="w3c-working-draft-13-february-2015">
+        W3C First Public Working Draft 13 February 2015
       </h2>
       <dl>
         <dt>
@@ -132,25 +132,12 @@
       </dl>
       <p class="copyright">
         <a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">Copyright</a>
-        © 2014 <a href="http://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>®</sup> (<a href="http://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>, <a href="http://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>,
-        <a href="http://www.keio.ac.jp/">Keio</a>, <a href="http://ev.buaa.edu.cn/">Beihang</a>), All Rights Reserved. W3C
-        <a href="http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">
-        liability</a>, <a href="http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a>
+        © 2015 <a href="http://www.w3.org/"><abbr title="World Wide Web Consortium">W3C</abbr></a><sup>®</sup> (<a href="http://www.csail.mit.edu/"><abbr title="Massachusetts Institute of Technology">MIT</abbr></a>, <a href="http://www.ercim.eu/"><abbr title="European Research Consortium for Informatics and Mathematics">ERCIM</abbr></a>,
+        <a href="http://www.keio.ac.jp/">Keio</a>, <a href="http://ev.buaa.edu.cn/">Beihang</a>). W3C <a href="http://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>,
+        <a href="http://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a>
         and <a href="http://www.w3.org/Consortium/Legal/copyright-documents">document
-        use</a> rules apply. Additionally, all Code Components, as defined
-        below, are made available under the <a href="https://www.w3.org/Consortium/Legal/copyright-software">W3C Software
-        License and Notice</a>.
+        use</a> rules apply.
       </p>
-      <ul class="copyright">
-        <li style="list-style: none">For the purpose of this license, Code
-        Components are:
-        </li>
-        <li>Web IDL in sections clearly marked as Web IDL; and
-        </li>
-        <li>W3C defined markup (HTML, CSS, etc.) and computer programming
-        language code clearly marked as code examples.
-        </li>
-      </ul>
       <hr>
     </div>
     <section>


### PR DESCRIPTION
Note the commit also changes the copyright date to 2015.

The custom copyright notice noted in the charter of the working group is no longer useful now that the W3C Document License has been updated to license code components under a W3C Software License. The group may thus roll back to the regular pub-rule compliant copyright notice, which will achieve the same effect.

Addresses #55.