### PR TITLE
Update the canonical link relation to help search engines find the latest

### DIFF
--- a/releases/FPWD.html
+++ b/releases/FPWD.html
@@ -5,7 +5,7 @@
     <meta http-equiv="refresh" content=
     "0; url=http://www.w3.org/TR/2015/WD-presentation-api-20150217/" />
     <link rel="canonical" href=
-    "http://www.w3.org/TR/2015/WD-presentation-api-20150217/" />
+    "http://w3c.github.io/presentation-api/" />
     <title>
       Presentation API
     </title>


### PR DESCRIPTION
We should update the canonical link relationship to point to the latest spec (aka Editor's Draft) to make sure search engines prefer the latest spec over the dated snapshot(s). It is a known problem that people who search for the specifications using their favourite search engine will often end up reading old snapshot releases rather than the latest.

We fix this for the FPWD in staging (now published) by changing the canonical link relation to point to the latest.

A generic solution to this problem is to adopt the new publication workflow at W3C which allows the group to automatise its TR publications and release as often as needed to keep the TR releases fresh. The group may want to consider adopting the new workflow when the initial kinks are gone (see the alpha release announcement at [1]).

Thanks @marcoscaceres for reporting the issue [2].

[1] https://lists.w3.org/Archives/Public/spec-prod/2015JanMar/0005.html
[2] https://github.com/w3c/presentation-api/pull/59#discussion_r25050065