### PR TITLE
Example code conventions, factor our endSession() from setSession()

### DIFF
--- a/Overview.src.html
+++ b/Overview.src.html
@@ -542,15 +542,15 @@
         </h3>
         <pre class="example">
 &lt;!-- controller.html --&gt;
-&lt;button id="castBtn" style="display: none;"&gt;  &lt;/button&gt;
+&lt;button id="castBtn" style="display: none;"&gt;Cast&lt;/button&gt;
 &lt;script&gt;
   // the cast button is visible if at least one presentation display is available
   var castBtn = document.getElementById("castBtn");
   // availablechange event is fired when the presentation display availability changes
-  navigator.presentation.onavailablechange = function(evt){
+  navigator.presentation.onavailablechange = function (evt) {
     // show or hide cast button depending on display availability
-    castBtn.style.display = evt.available? "inline" : "none";
-  }
+    castBtn.style.display = evt.available ? "inline" : "none";
+  };
 &lt;/script&gt;
         
 </pre>
@@ -567,11 +567,11 @@
   // create random presId 
   var presId = Math.random().toFixed(6).substr(2);
   // Start new session. presId is optional.
-  // the new started session will be passed to setSession on success or null on error
-  navigator.presentation.startSession(presUrl, presId).then(setSession).catch(function(e){
+  navigator.presentation.startSession(presUrl, presId)
+    // the new started session will be passed to setSession on success
+    .then(setSession)
     // user cancels the selection dialog or an error is occurred
-    setSession(null);
-  });
+    .catch(function () { setSession(null); });
 &lt;/script&gt;
 </pre>
       </section>
@@ -585,11 +585,11 @@
   // read presId from localStorage if exists 
   var presId = localStorage &amp;&amp; localStorage["presId"] || null;
   // presId is mandatory for joinSession.
-  // The joined session will be passed to setSession on success or null on error
-  presId &amp;&amp; navigator.presentation.joinSession(presUrl, presId).then(setSession).catch(function(e){
+  presId &amp;&amp; navigator.presentation.joinSession(presUrl, presId)
+    // The joined session will be passed to setSession on success
+    .then(setSession)
     // no session found for presUrl and presId or an error is occurred
-    setSession(null);
-  });
+    .catch(function () { setSession(null); });
 &lt;/script&gt;
 </pre>
       </section>
@@ -601,23 +601,23 @@
 &lt;!-- controller.html --&gt;
 &lt;script&gt;
   var session;
-  var setSession = function(theSession){
+  var setSession = function (theSession) {
     // close old session if exists
     session &amp;&amp; session.close();
     // remove old presId from localStorage if exists
     localStorage &amp;&amp; delete localStorage["presId"];
     // set the new session
     session = theSession;
-    if(session){
+    if (session) {
       // save presId in localStorage
       localStorage &amp;&amp; localStorage["presId"] = session.id;
       // monitor session's state
-      session.onstatechange = function(){
-        if(this == session &amp;&amp; this.state == "disconnected")
+      session.onstatechange = function () {
+        if (this == session &amp;&amp; this.state == "disconnected")
           setSession(null);
       };
       // register message handler
-      session.onmessage = function(msg){
+      session.onmessage = function (msg) {
         console.log("receive message",msg);
       };
       // send message to presentation page
@@ -630,12 +630,12 @@
 &lt;!-- presentation.html --&gt;
 &lt;script&gt;
   var session = navigator.presentation.session;
-  session.onstatechange = function(){
+  session.onstatechange = function () {
     // session.state is either 'connected' or 'disconnected'
     console.log("session's state is now", session.state);
   };
-  session.onmessage = function(msg){
-    if(msg == "say hello")
+  session.onmessage = function (msg) {
+    if (msg == "say hello")
       session.postMessage("hello");
   };
 &lt;/script&gt;

--- a/Overview.src.html
+++ b/Overview.src.html
@@ -571,7 +571,7 @@
     // the new started session will be passed to setSession on success
     .then(setSession)
     // user cancels the selection dialog or an error is occurred
-    .catch(function () { setSession(null); });
+    .catch(endSession);
 &lt;/script&gt;
 </pre>
       </section>
@@ -589,7 +589,7 @@
     // The joined session will be passed to setSession on success
     .then(setSession)
     // no session found for presUrl and presId or an error is occurred
-    .catch(function () { setSession(null); });
+    .catch(endSession);
 &lt;/script&gt;
 </pre>
       </section>
@@ -602,10 +602,8 @@
 &lt;script&gt;
   var session;
   var setSession = function (theSession) {
-    // close old session if exists
-    session &amp;&amp; session.close();
-    // remove old presId from localStorage if exists
-    localStorage &amp;&amp; delete localStorage["presId"];
+    // end existing session, if any
+    endSession();
     // set the new session
     session = theSession;
     if (session) {
@@ -614,7 +612,7 @@
       // monitor session's state
       session.onstatechange = function () {
         if (this == session &amp;&amp; this.state == "disconnected")
-          setSession(null);
+          endSession();
       };
       // register message handler
       session.onmessage = function (msg) {
@@ -623,6 +621,12 @@
       // send message to presentation page
       session.postMessage("say hello");
     }
+  };
+  var endSession = function () {
+    // close old session if exists
+    session &amp;&amp; session.close();
+    // remove old presId from localStorage if exists
+    localStorage &amp;&amp; delete localStorage["presId"];
   };
 &lt;/script&gt;
 </pre>

--- a/index.html
+++ b/index.html
@@ -645,7 +645,7 @@
     // the new started session will be passed to setSession on success
     .then(setSession)
     // user cancels the selection dialog or an error is occurred
-    .catch(function () { setSession(null); });
+    .catch(endSession);
 &lt;/script&gt;
 </pre>
       </section>
@@ -662,7 +662,7 @@
     // The joined session will be passed to setSession on success
     .then(setSession)
     // no session found for presUrl and presId or an error is occurred
-    .catch(function () { setSession(null); });
+    .catch(endSession);
 &lt;/script&gt;
 </pre>
       </section>
@@ -674,10 +674,8 @@
 &lt;script&gt;
   var session;
   var setSession = function (theSession) {
-    // close old session if exists
-    session &amp;&amp; session.close();
-    // remove old presId from localStorage if exists
-    localStorage &amp;&amp; delete localStorage["presId"];
+    // end existing session, if any
+    endSession();
     // set the new session
     session = theSession;
     if (session) {
@@ -686,7 +684,7 @@
       // monitor session's state
       session.onstatechange = function () {
         if (this == session &amp;&amp; this.state == "disconnected")
-          setSession(null);
+          endSession();
       };
       // register message handler
       session.onmessage = function (msg) {
@@ -695,6 +693,12 @@
       // send message to presentation page
       session.postMessage("say hello");
     }
+  };
+  var endSession = function () {
+    // close old session if exists
+    session &amp;&amp; session.close();
+    // remove old presId from localStorage if exists
+    localStorage &amp;&amp; delete localStorage["presId"];
   };
 &lt;/script&gt;
 </pre>

--- a/index.html
+++ b/index.html
@@ -617,15 +617,15 @@
           Monitor availability of presentation displays example
         </h3>
         <pre class="example">&lt;!-- controller.html --&gt;
-&lt;button id="castBtn" style="display: none;"&gt;  &lt;/button&gt;
+&lt;button id="castBtn" style="display: none;"&gt;Cast&lt;/button&gt;
 &lt;script&gt;
   // the cast button is visible if at least one presentation display is available
   var castBtn = document.getElementById("castBtn");
   // availablechange event is fired when the presentation display availability changes
-  navigator.presentation.onavailablechange = function(evt){
+  navigator.presentation.onavailablechange = function (evt) {
     // show or hide cast button depending on display availability
-    castBtn.style.display = evt.available? "inline" : "none";
-  }
+    castBtn.style.display = evt.available ? "inline" : "none";
+  };
 &lt;/script&gt;
         
 </pre>
@@ -641,11 +641,11 @@
   // create random presId 
   var presId = Math.random().toFixed(6).substr(2);
   // Start new session. presId is optional.
-  // the new started session will be passed to setSession on success or null on error
-  navigator.presentation.startSession(presUrl, presId).then(setSession).catch(function(e){
+  navigator.presentation.startSession(presUrl, presId)
+    // the new started session will be passed to setSession on success
+    .then(setSession)
     // user cancels the selection dialog or an error is occurred
-    setSession(null);
-  });
+    .catch(function () { setSession(null); });
 &lt;/script&gt;
 </pre>
       </section>
@@ -658,11 +658,11 @@
   // read presId from localStorage if exists 
   var presId = localStorage &amp;&amp; localStorage["presId"] || null;
   // presId is mandatory for joinSession.
-  // The joined session will be passed to setSession on success or null on error
-  presId &amp;&amp; navigator.presentation.joinSession(presUrl, presId).then(setSession).catch(function(e){
+  presId &amp;&amp; navigator.presentation.joinSession(presUrl, presId)
+    // The joined session will be passed to setSession on success
+    .then(setSession)
     // no session found for presUrl and presId or an error is occurred
-    setSession(null);
-  });
+    .catch(function () { setSession(null); });
 &lt;/script&gt;
 </pre>
       </section>
@@ -673,23 +673,23 @@
         <pre class="example">&lt;!-- controller.html --&gt;
 &lt;script&gt;
   var session;
-  var setSession = function(theSession){
+  var setSession = function (theSession) {
     // close old session if exists
     session &amp;&amp; session.close();
     // remove old presId from localStorage if exists
     localStorage &amp;&amp; delete localStorage["presId"];
     // set the new session
     session = theSession;
-    if(session){
+    if (session) {
       // save presId in localStorage
       localStorage &amp;&amp; localStorage["presId"] = session.id;
       // monitor session's state
-      session.onstatechange = function(){
-        if(this == session &amp;&amp; this.state == "disconnected")
+      session.onstatechange = function () {
+        if (this == session &amp;&amp; this.state == "disconnected")
           setSession(null);
       };
       // register message handler
-      session.onmessage = function(msg){
+      session.onmessage = function (msg) {
         console.log("receive message",msg);
       };
       // send message to presentation page
@@ -701,12 +701,12 @@
         <pre class="example">&lt;!-- presentation.html --&gt;
 &lt;script&gt;
   var session = navigator.presentation.session;
-  session.onstatechange = function(){
+  session.onstatechange = function () {
     // session.state is either 'connected' or 'disconnected'
     console.log("session's state is now", session.state);
   };
-  session.onmessage = function(msg){
-    if(msg == "say hello")
+  session.onmessage = function (msg) {
+    if (msg == "say hello")
       session.postMessage("hello");
   };
 &lt;/script&gt;


### PR DESCRIPTION
* Code conventions per Douglas Crockford (http://javascript.crockford.com/code.html). I know this is a matter of taste, but Crockford has a good taste as he knows The [JavaScript] Good Parts ;-)

* Factor out `endSession()` from `setSession()` to make the `.then(setSession).catch(endSession)` even more concise.

@drott @louaybassbouss Please review, and feel free to merge if this does not introduce any bugs and the style is digestible to you.

Related: https://github.com/w3c/presentation-api/pull/64