### PR TITLE
Fix syntax error in examples

### DIFF
--- a/Overview.src.html
+++ b/Overview.src.html
@@ -611,7 +611,7 @@
     session = theSession;
     if (session) {
       // save presId in localStorage
-      localStorage &amp;&amp; localStorage["presId"] = session.id;
+      localStorage &amp;&amp; (localStorage["presId"] = session.id);
       // monitor session's state
       session.onstatechange = function () {
         if (this == session &amp;&amp; this.state == "disconnected")

--- a/index.html
+++ b/index.html
@@ -683,7 +683,7 @@
     session = theSession;
     if (session) {
       // save presId in localStorage
-      localStorage &amp;&amp; localStorage["presId"] = session.id;
+      localStorage &amp;&amp; (localStorage["presId"] = session.id);
       // monitor session's state
       session.onstatechange = function () {
         if (this == session &amp;&amp; this.state == "disconnected")


### PR DESCRIPTION
missing "(" and ")" added to line:
localStorage && (localStorage["presId"] = session.id);