### PR TITLE
A link to WG's charter

### DIFF
--- a/Overview.src.html
+++ b/Overview.src.html
@@ -175,7 +175,10 @@
       <p>
         This document was published by the <a href=
         "http://www.w3.org/2014/secondscreen/">Second Screen Presentation
-        Working Group</a> as an Editor's Draft. If you wish to make comments
+        Working Group</a> as an Editor's Draft. The Working Group actively
+        pursues its activities within the bounds of the <a href=
+        "http://www.w3.org/2014/secondscreen/charter.html">W3C Second Screen
+        Presentation Working Group charter</a>. If you wish to make comments
         regarding this document, please send them to <a href=
         "mailto:public-secondscreen@w3.org">public-secondscreen@w3.org</a>
         (<a href=

--- a/index.html
+++ b/index.html
@@ -78,8 +78,8 @@
       <h1>
         Presentation API
       </h1>
-      <h2 class="no-num no-toc" id="editor's-draft-6-april-2015">
-        Editor's Draft 6 April 2015
+      <h2 class="no-num no-toc" id="editor's-draft-9-april-2015">
+        Editor's Draft 9 April 2015
       </h2>
       <dl>
         <dt>
@@ -166,7 +166,9 @@
       </p>
       <p>
         This document was published by the <a href="http://www.w3.org/2014/secondscreen/">Second Screen Presentation
-        Working Group</a> as an Editor's Draft. If you wish to make comments
+        Working Group</a> as an Editor's Draft. The Working Group actively
+        pursues its activities within the bounds of the <a href="http://www.w3.org/2014/secondscreen/charter.html">W3C Second Screen
+        Presentation Working Group charter</a>. If you wish to make comments
         regarding this document, please send them to <a href="mailto:public-secondscreen@w3.org">public-secondscreen@w3.org</a>
         (<a href="mailto:public-secondscreen-request@w3.org?subject=subscribe">subscribe</a>,
         <a href="http://lists.w3.org/Archives/Public/public-secondscreen/">archives</a>).


### PR DESCRIPTION
Hi, all. At the **Status of This Document** Section, I specified our WG’s [charter](http://www.w3.org/2014/secondscreen/charter.html). <br>A WG's charter is the first document when a non-member gets to read before joining a WG. I’m aware that our charter is well-specified in the Work Mode. For non-members, however, I believe that the fastest and easiest way to access the WG charter is to add it in the beginning of the working document. (just like they did for HTML5 recommendation)
Thank you for your consideration.