### PR TITLE
Fixed typos and removed the 'origin' extraction step from the send() algorithm

### DIFF
--- a/Overview.src.html
+++ b/Overview.src.html
@@ -872,17 +872,6 @@ interface <dfn>PresentationSession</dfn> : EventTarget {
             <code>message</code>, which does not bubble, is not cancelable, and
             has no default action.
             </li>
-            <li>Initialize <em>event's</em> <code>origin</code> attribute to
-            the Unicode serialization of the URL that the <span>opening
-            browsing context</span> and the <span>presenting browsing
-            context</span> have in common.
-              <p class="open-issue">
-                <a href=
-                "https://github.com/w3c/presentation-api/issues/63">ISSUE 63:
-                Define (cross) origin relationship between opener and
-                presenting page</a>
-              </p>
-            </li>
             <li>Initialize the <em>event's</em> data attribute as follows:
               <ol>
                 <li>If the <span>presentation message type</span> is
@@ -914,6 +903,11 @@ interface <dfn>PresentationSession</dfn> : EventTarget {
               <span><code>PresentationSession</code></span>.
             </li>
           </ol>
+          <p class="open-issue">
+            <a href="https://github.com/w3c/presentation-api/issues/63">ISSUE
+            63: Define (cross) origin relationship between opener and
+            presenting page</a>
+          </p>
         </section>
         <section>
           <h4>
@@ -1355,7 +1349,7 @@ interface <dfn>NavigatorPresentation</dfn> : EventTarget {
             <span>The following are the event handlers (and their corresponding
             event handler event types) that must be supported, as event handler
             IDL attributes, by objects implementing the
-            <code>PresentationSession</code> interface:</span>
+            <code>NavigatorPresentation</code> interface:</span>
           </p>
           <table>
             <thead>
@@ -1384,7 +1378,7 @@ interface <dfn>NavigatorPresentation</dfn> : EventTarget {
             "non-functional-requirements">power saving non-functionional
             requirements</span> the user agent must keep track of the number of
             <code>EventHandler</code>s registered to the
-            <code>onavailable</code> event. Using this information,
+            <code>onavailablechange</code> event. Using this information,
             implementation specific discovery of <span title=
             "presentation-display">presentation displays</span> can be resumed
             or suspended, in order to save power.
@@ -1529,7 +1523,7 @@ dictionary <dfn>AvailableChangeEventInit</dfn> : EventInit {
           execution of the <span>monitoring presentation display
           availability</span> algorithm when the <dfn>presentation display
           availability</dfn> changes. It is fired at the
-          <span><code>PresentationSession</code></span> object, using the
+          <span><code>NavigatorPresentation</code></span> object, using the
           <code>AvailableChangeEvent</code> interface, with the
           <code>available</code> attribute set to the boolean value that the
           algorithm determined.

--- a/index.html
+++ b/index.html
@@ -78,8 +78,8 @@
       <h1>
         Presentation API
       </h1>
-      <h2 class="no-num no-toc" id="editor's-draft-14-may-2015">
-        Editor's Draft 14 May 2015
+      <h2 class="no-num no-toc" id="editor's-draft-19-may-2015">
+        Editor's Draft 19 May 2015
       </h2>
       <dl>
         <dt>
@@ -937,16 +937,6 @@ interface <dfn id="presentationsession">PresentationSession</dfn> : EventTarget 
             <code>message</code>, which does not bubble, is not cancelable, and
             has no default action.
             </li>
-            <li>Initialize <em>event's</em> <code>origin</code> attribute to
-            the Unicode serialization of the URL that the <a href="#opening-browsing-context">opening
-            browsing context</a> and the <a href="#presenting-browsing-context">presenting browsing
-            context</a> have in common.
-              <p class="open-issue">
-                <a href="https://github.com/w3c/presentation-api/issues/63">ISSUE 63:
-                Define (cross) origin relationship between opener and
-                presenting page</a>
-              </p>
-            </li>
             <li>Initialize the <em>event's</em> data attribute as follows:
               <ol>
                 <li>If the <a href="#presentation-message-type">presentation message type</a> is
@@ -978,6 +968,11 @@ interface <dfn id="presentationsession">PresentationSession</dfn> : EventTarget 
               <a href="#presentationsession"><code>PresentationSession</code></a>.
             </li>
           </ol>
+          <p class="open-issue">
+            <a href="https://github.com/w3c/presentation-api/issues/63">ISSUE
+            63: Define (cross) origin relationship between opener and
+            presenting page</a>
+          </p>
         </section>
         <section>
           <h4 id="closing-a-presentationsession"><span class="secno">6.3.3 </span>
@@ -1396,7 +1391,7 @@ interface <dfn id="presentationsession">PresentationSession</dfn> : EventTarget 
             <span>The following are the event handlers (and their corresponding
             event handler event types) that must be supported, as event handler
             IDL attributes, by objects implementing the
-            <a href="#presentationsession"><code>PresentationSession</code></a> interface:</span>
+            <a href="#navigatorpresentation"><code>NavigatorPresentation</code></a> interface:</span>
           </p>
           <table>
             <thead>
@@ -1424,7 +1419,7 @@ interface <dfn id="presentationsession">PresentationSession</dfn> : EventTarget 
             In order to satisfy the <span title="non-functional-requirements">power saving non-functionional
             requirements</span> the user agent must keep track of the number of
             <code>EventHandler</code>s registered to the
-            <code>onavailable</code> event. Using this information,
+            <a href="#onavailablechange"><code>onavailablechange</code></a> event. Using this information,
             implementation specific discovery of <span title="presentation-display">presentation displays</span> can be resumed
             or suspended, in order to save power.
           </p>The user agent must keep a <dfn id="list-of-available-presentation-displays">list of available presentation
@@ -1559,7 +1554,7 @@ dictionary <dfn id="availablechangeeventinit">AvailableChangeEventInit</dfn> : E
           execution of the <span>monitoring presentation display
           availability</span> algorithm when the <dfn id="presentation-display-availability">presentation display
           availability</dfn> changes. It is fired at the
-          <a href="#presentationsession"><code>PresentationSession</code></a> object, using the
+          <a href="#navigatorpresentation"><code>NavigatorPresentation</code></a> object, using the
           <a href="#availablechangeevent"><code>AvailableChangeEvent</code></a> interface, with the
           <code>available</code> attribute set to the boolean value that the
           algorithm determined.


### PR DESCRIPTION
A demo link is at http://avayvod.github.io/nits.html
The removal of the unused 'origin' step from the PresentationSession.send() was discussed at the F2F as part of the Issue #63 