### PR TITLE
Spec pubrules and Echidna compliant, WD generation semi-automated

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: node_js
+
+branches:
+  only:
+    - TR
+
+env:
+  global:
+    - URL="https://raw.githubusercontent.com/w3c/presentation-api/TR/releases/WD.html"
+    - DECISION="https://lists.w3.org/Archives/Public/public-secondscreen/2015Jun/0096.html"
+    - secure: "nJ8QtGEN8dzi2syMLFDpK8AAfTtvR/6QXe+H/rymwXHyD0LuoBGtH8NxZ6uyV1TfqTC3YcjuM0pFqtO+9gNi1L2uYeJH808cb6QjM9+qhuL9E0xE6qcoud7jqMeMY/K6HsSDqjEDJdTKNBOygMIzg69TASBoe9V/yGmpGZzGDZg="
+ 
+script:
+  - echo "ok"
+
+after_success:
+  - curl "https://labs.w3.org/echidna/api/request" --data "url=$URL" --data "decision=$DECISION" --data "token=$TOKEN"

--- a/ECHIDNA
+++ b/ECHIDNA
@@ -1,0 +1,1 @@
+releases/WD.html

--- a/Makefile
+++ b/Makefile
@@ -15,39 +15,40 @@ PUBLISHED-URL=$(shell curl -s http://www.w3.org/TR/presentation-api/ \
 
 
 # Default rule generates the Editor's Draft
-all: tidy index.html xrefs/presentation.json
+all: index.html
 
 # Rule to generate the First Public Working Draft
-fpwd: tidy xrefs/presentation.json releases/FPWD.html
+fpwd: releases/FPWD.html
 
 # Rule to generate a new Working Draft release
-wd: tidy xrefs/presentation.json releases/WD.html
+wd: releases/WD.html
 
 
-releases/FPWD.html: Overview.src.html ../xref Makefile
+releases/FPWD.html: tidy ../xref xrefs/presentation.json
 	$(ANOLIS) --w3c-status=WD --w3c-compat-substitutions \
 	--w3c-compat-crazy-substitutions --w3c-shortname="presentation-api" \
 	--omit-optional-tags --quote-attr-values --enable=xspecxref \
-	--xref="../xref" --enable=refs $< $@
+	--xref="../xref" --enable=refs Overview.src.html $@
 
 
-releases/WD.html: Overview.src.html ../xref Makefile
+releases/WD.html: tidy ../xref xrefs/presentation.json
 	# Generate the Working Draft release from the source spec
 	$(ANOLIS) --w3c-status=WD --w3c-compat-substitutions \
 	--w3c-compat-crazy-substitutions --w3c-shortname="presentation-api" \
 	--omit-optional-tags --quote-attr-values --enable=xspecxref \
-	--xref="../xref" --enable=refs $< $@
+	--xref="../xref" --enable=refs Overview.src.html $@
 
 	# Generate the "Previous version" link
 	sed -i "s|<!--previous-version-->|\n        <dt>Previous version:</dt>\n        <dd><a href=\"$(PUBLISHED-URL)\">$(PUBLISHED-URL)</a></dd>|" $@
 
 
-index.html: Overview.src.html ../xref Makefile
+index.html: tidy ../xref xrefs/presentation.json
 	# Make a temp copy of the source spec, replacing [VERSION] used in the
 	# "This version" link with the right GitHub page address
 	# (Anolis would generate a URL in /TR/ space otherwise, which is good
 	# for Working Draft releases but not for Editor's Drafts)
-	sed "s|\[VERSION\]|http://w3c.github.io/presentation-api/|" $< > tmp.html
+	sed "s|\[VERSION\]|http://w3c.github.io/presentation-api/|" \
+		Overview.src.html > tmp.html
 
 	# Generate the Editor's Draft from the temp copy
 	$(ANOLIS) --w3c-status=ED --w3c-compat-substitutions \
@@ -58,7 +59,7 @@ index.html: Overview.src.html ../xref Makefile
 	rm tmp.html
 
 
-xrefs/presentation.json: Overview.src.html Makefile
+xrefs/presentation.json: Overview.src.html
 	$(ANOLIS) --dump-xrefs=$@ $< /tmp/spec
 
 

--- a/Overview.src.html
+++ b/Overview.src.html
@@ -85,16 +85,14 @@
           This version:
         </dt>
         <dd>
-          <!--begin-link-->http://w3c.github.io/presentation-api/ 
-          <!--end-link-->
+          <!--begin-link-->[VERSION]<!--end-link-->
         </dd>
         <dt>
           Latest published version:
         </dt>
         <dd>
-          <!--begin-link-->http://www.w3.org/TR/presentation-api/ 
-          <!--end-link-->
-        </dd>
+          <!--begin-link-->[LATEST]<!--end-link-->
+        </dd><!--previous-version-->
         <dt>
           Latest editor's draft:
         </dt>
@@ -122,10 +120,10 @@
         <dt>
           Editors:
         </dt>
-        <dd>
+        <dd data-editor-id="68454">
           <a href="mailto:mfoltz@google.com">Mark Foltz</a>, Google
         </dd>
-        <dd>
+        <dd data-editor-id="63802">
           Dominik Röttsches, Intel (until April 2015)
         </dd>
       </dl>
@@ -173,7 +171,7 @@
       <p>
         This document was published by the <a href=
         "http://www.w3.org/2014/secondscreen/">Second Screen Presentation
-        Working Group</a> as an Editor's Draft. If you wish to make comments
+        Working Group</a> as a Working Draft. If you wish to make comments
         regarding this document, please send them to <a href=
         "mailto:public-secondscreen@w3.org">public-secondscreen@w3.org</a>
         (<a href=
@@ -183,43 +181,36 @@
         All comments are welcome.
       </p>
       <p>
-        This document is a <b>work in progress</b> and is subject to change. It
-        builds on the <a href=
-        "http://www.w3.org/2014/secondscreen/presentation-api/20141118/" title=
-        "Presentation API W3C Community Group Final Report">final report</a>
-        (dated 18 November 2014) produced by the Second Screen Presentation
-        Community Group. Algorithms have been drafted in particular. Most
-        sections are still incomplete or underspecified. Privacy and security
-        considerations are missing. A few open issues are noted inline. Please
-        check the group's <a href=
-        "https://github.com/w3c/presentation-api/issues">issue tracker</a> on
-        GitHub for an accurate list. Feedback from early experimentations is
-        encouraged to allow the Second Screen Presentation Working Group to
-        evolve the specification based on implementation issues.
+        This document is a <b>work in progress</b> and is subject to change.
+        Some sections are still incomplete or underspecified. Privacy and
+        security considerations need to be adjusted based on feedback and
+        experience. Open issues are noted inline. Please check the group's
+        <a href="https://github.com/w3c/presentation-api/issues">issue
+        tracker</a> on GitHub for an accurate list. Feedback from early
+        experimentations is encouraged to allow the Second Screen Presentation
+        Working Group to evolve the specification based on implementation
+        issues.
       </p>
       <p>
-        Publication as a First Public Working Draft does not imply endorsement
-        by the <abbr title="World Wide Web Consortium">W3C</abbr> Membership.
-        This draft document may be updated, replaced or obsoleted by other
-        documents at any time. It is inappropriate to cite this document as
-        other than work in progress.
+        Publication as a Working Draft does not imply endorsement by the W3C
+        Membership. This is a draft document and may be updated, replaced or
+        obsoleted by other documents at any time. It is inappropriate to cite
+        this document as other than work in progress.
       </p>
       <p>
         This document was produced by a group operating under the <a id=
         "sotd_patent" rel="w3p:patentRules" href=
         "http://www.w3.org/Consortium/Patent-Policy-20040205/">5 February 2004
-        <abbr title="World Wide Web Consortium">W3C</abbr> Patent Policy</a>.
-        <abbr title="World Wide Web Consortium">W3C</abbr> maintains a <a href=
+        W3C Patent Policy</a>. W3C maintains a <a href=
         "http://www.w3.org/2004/01/pp-impl/74168/status" rel=
         "disclosure">public list of any patent disclosures</a> made in
         connection with the deliverables of the group; that page also includes
         instructions for disclosing a patent. An individual who has actual
-        knowledge of a patent that the individual believes contains <a href=
+        knowledge of a patent which the individual believes contains <a href=
         "http://www.w3.org/Consortium/Patent-Policy-20040205/#def-essential">Essential
         Claim(s)</a> must disclose the information in accordance with <a href=
         "http://www.w3.org/Consortium/Patent-Policy-20040205/#sec-Disclosure">section
-        6 of the <abbr title="World Wide Web Consortium">W3C</abbr> Patent
-        Policy</a>.
+        6 of the W3C Patent Policy</a>.
       </p>
       <p>
         This document is governed by the <a id="w3c_process_revision" href=

--- a/index.html
+++ b/index.html
@@ -85,18 +85,14 @@
           This version:
         </dt>
         <dd>
-          <!--begin-link--><a href="http://w3c.github.io/presentation-api/ 
-          ">http://w3c.github.io/presentation-api/ 
-          </a><!--end-link-->
+          <!--begin-link--><a href="http://w3c.github.io/presentation-api/">http://w3c.github.io/presentation-api/</a><!--end-link-->
         </dd>
         <dt>
           Latest published version:
         </dt>
         <dd>
-          <!--begin-link--><a href="http://www.w3.org/TR/presentation-api/ 
-          ">http://www.w3.org/TR/presentation-api/ 
-          </a><!--end-link-->
-        </dd>
+          <!--begin-link--><a href="http://www.w3.org/TR/presentation-api/">http://www.w3.org/TR/presentation-api/</a><!--end-link-->
+        </dd><!--previous-version-->
         <dt>
           Latest editor's draft:
         </dt>
@@ -124,10 +120,10 @@
         <dt>
           Editors:
         </dt>
-        <dd>
+        <dd data-editor-id="68454">
           <a href="mailto:mfoltz@google.com">Mark Foltz</a>, Google
         </dd>
-        <dd>
+        <dd data-editor-id="63802">
           Dominik Röttsches, Intel (until April 2015)
         </dd>
       </dl>
@@ -164,41 +160,37 @@
       </p>
       <p>
         This document was published by the <a href="http://www.w3.org/2014/secondscreen/">Second Screen Presentation
-        Working Group</a> as an Editor's Draft. If you wish to make comments
+        Working Group</a> as a Working Draft. If you wish to make comments
         regarding this document, please send them to <a href="mailto:public-secondscreen@w3.org">public-secondscreen@w3.org</a>
         (<a href="mailto:public-secondscreen-request@w3.org?subject=subscribe">subscribe</a>,
         <a href="http://lists.w3.org/Archives/Public/public-secondscreen/">archives</a>).
         All comments are welcome.
       </p>
       <p>
-        This document is a <b>work in progress</b> and is subject to change. It
-        builds on the <a href="http://www.w3.org/2014/secondscreen/presentation-api/20141118/" title="Presentation API W3C Community Group Final Report">final report</a>
-        (dated 18 November 2014) produced by the Second Screen Presentation
-        Community Group. Algorithms have been drafted in particular. Most
-        sections are still incomplete or underspecified. Privacy and security
-        considerations are missing. A few open issues are noted inline. Please
-        check the group's <a href="https://github.com/w3c/presentation-api/issues">issue tracker</a> on
-        GitHub for an accurate list. Feedback from early experimentations is
-        encouraged to allow the Second Screen Presentation Working Group to
-        evolve the specification based on implementation issues.
+        This document is a <b>work in progress</b> and is subject to change.
+        Some sections are still incomplete or underspecified. Privacy and
+        security considerations need to be adjusted based on feedback and
+        experience. Open issues are noted inline. Please check the group's
+        <a href="https://github.com/w3c/presentation-api/issues">issue
+        tracker</a> on GitHub for an accurate list. Feedback from early
+        experimentations is encouraged to allow the Second Screen Presentation
+        Working Group to evolve the specification based on implementation
+        issues.
       </p>
       <p>
-        Publication as a First Public Working Draft does not imply endorsement
-        by the <abbr title="World Wide Web Consortium">W3C</abbr> Membership.
-        This draft document may be updated, replaced or obsoleted by other
-        documents at any time. It is inappropriate to cite this document as
-        other than work in progress.
+        Publication as a Working Draft does not imply endorsement by the W3C
+        Membership. This is a draft document and may be updated, replaced or
+        obsoleted by other documents at any time. It is inappropriate to cite
+        this document as other than work in progress.
       </p>
       <p>
         This document was produced by a group operating under the <a href="http://www.w3.org/Consortium/Patent-Policy-20040205/" id="sotd_patent" rel="w3p:patentRules">5 February 2004
-        <abbr title="World Wide Web Consortium">W3C</abbr> Patent Policy</a>.
-        <abbr title="World Wide Web Consortium">W3C</abbr> maintains a <a href="http://www.w3.org/2004/01/pp-impl/74168/status" rel="disclosure">public list of any patent disclosures</a> made in
+        W3C Patent Policy</a>. W3C maintains a <a href="http://www.w3.org/2004/01/pp-impl/74168/status" rel="disclosure">public list of any patent disclosures</a> made in
         connection with the deliverables of the group; that page also includes
         instructions for disclosing a patent. An individual who has actual
-        knowledge of a patent that the individual believes contains <a href="http://www.w3.org/Consortium/Patent-Policy-20040205/#def-essential">Essential
+        knowledge of a patent which the individual believes contains <a href="http://www.w3.org/Consortium/Patent-Policy-20040205/#def-essential">Essential
         Claim(s)</a> must disclose the information in accordance with <a href="http://www.w3.org/Consortium/Patent-Policy-20040205/#sec-Disclosure">section
-        6 of the <abbr title="World Wide Web Consortium">W3C</abbr> Patent
-        Policy</a>.
+        6 of the W3C Patent Policy</a>.
       </p>
       <p>
         This document is governed by the <a href="http://www.w3.org/2014/Process-20140801/" id="w3c_process_revision">1 August 2014 <abbr title="World Wide Web Consortium">W3C</abbr> Process Document</a>.


### PR DESCRIPTION
This commit should contain all updates needed to be able to publish working
drafts to /TR/ space at W3C on a semi-automated basis.

The basic principle is to use a dedicated "TR" branch where we generate the
Working Draft to publish. Any push to that branch will trigger Travis CI
(provided it is enabled on the repository, obviously) that will, in turn,
send a publication request to Echidna at W3C with the right parameters.

Actually publishing the spec from a local checkout of the gh-pages branch
should look like:

git checkout TR
git merge gh-pages
make wd
git add releases/WD.html
git commit
git push w3c TR

Using a separate branch is not stricto senso necessary. I chose that option:
1. to have Working Drafts remain somewhat hidden on GitHub, the gh-pages
branch will only contain the Editor's Draft and that sounds a good idea
2. because it is easy to trigger Travis CI on a specific branch but not when
a when a specific file is updated.

In terms of changes, I updated the raw spec to be publication rules and
Echidna compliant, adding the editors IDs, updating the way version links
are managed, and the Status of This Document section so that it might be used
without modification in a published Working Draft.

I also created a "wd" Makefile rule to generate the releases/WD.html file that
can be provided to Echidna for immediate publication. The generated WD.html
file is not part of this commit but has been checked with success against
Specberus, the new pubrules checker.

Note that the Makefile now uses "curl", "grep" and "sed" to extract the URL of
the latest published WD, used to compute the Previous Version link in the
generated Working Draft. This is all a bit hacky but should work fine in most
cases, except when publishing the spec more than once in a given day. The
"previous version" link can be manually checked and overwritten by some editor
before committing the working draft in any case.

Also note that Specberus does not like trailing spaces in "href" in the
"This version" and other similar links. We have them because of a combinaison
of us using Tidy to enforce 80-character-long lines and Anolis that uses a
specific syntax based on comments for these links ("<!--begin-link-->" and
"<!--end-link-->"). I worked around that using Anolis "[VERSION]" and
"[LATEST]" substitution strings that do not get truncated in the source spec
and thus do not generate spaces in the end. The issue has been reported to
Specberus folks:
 https://github.com/w3c/specberus/issues/207

I also added what I believe would be the right ECHIDNA manifest file and the
right .travis.yml configuration file to automate the publication. This will
perhaps need to be adjusted when we try to publish the first working draft.