### PR TITLE
Initial description of session creation and monitoring in presenting …

### DIFF
--- a/Overview.src.html
+++ b/Overview.src.html
@@ -965,7 +965,8 @@ partial interface <span data-anolis-spec="w3c-html">Navigator</span> {
         </p>
         <pre class="idl">
 interface <dfn>NavigatorPresentation</dfn> : EventTarget {
-  readonly attribute <span>PresentationSession</span>? <span>session</span>;
+  Promise&lt;<span>PresentationSession</span>&gt; <span>getSession</span>();
+  Promise&lt;<span>PresentationSession[]</span>&gt; <span>getSessions</span>();
   Promise&lt;<span>PresentationSession</span>&gt; <span>startSession</span>(DOMString url);
   Promise&lt;<span>PresentationSession</span>&gt; <span>joinSession</span>(DOMString url, DOMString presentationId);
   Promise&lt;<span>Availability</span>&gt; <span>getAvailability</span>();
@@ -973,11 +974,6 @@ interface <dfn>NavigatorPresentation</dfn> : EventTarget {
 "w3c-html">EventHandler</span> <span>ondefaultsessionstart</span>;
 };
 </pre>
-        <p class="open-issue">
-          <a href="https://github.com/w3c/presentation-api/issues/52">ISSUE 52:
-          Specify the NavigatorPresentation.session attribute and its related
-          algorithms</a>
-        </p>
         <section>
           <h4>
             Starting a presentation session
@@ -1210,7 +1206,8 @@ interface <dfn>NavigatorPresentation</dfn> : EventTarget {
         </section>
         <section>
           <h4>
-            Establishing a presentation connection
+            Establishing a presentation connection in controlling browsing
+            context
           </h4>
           <p>
             When the user agent is to <dfn>establish a presentation
@@ -1339,6 +1336,163 @@ interface <dfn>NavigatorPresentation</dfn> : EventTarget {
             presentation display availability</span> as long as the returned
             <span title="Availability">Availability</span> object is kept
             alive.
+            </li>
+          </ol>
+        </section>
+        <section>
+          <h4>
+            Establishing a presentation connection in the presenting browsing
+            context
+          </h4>
+          <p>
+            When a new <span>presenting browsing context</span> has been
+            created and navigated to the <code>presentationUrl</code> on a
+            user-selected <span>presentation display</span>, the user agent has
+            to:
+          </p>
+          <ol>
+            <li>
+              <span data-anolis-spec="w3c-html" title="queue a task">Queue a
+              task</span> to start <span>monitoring of incoming presentation
+              sessions</span> from <span>controlling browsing context</span>s.
+            </li>
+          </ol>
+        </section>
+        <section>
+          <h4>
+            Monitoring incoming presentation sessions in presenting browsing
+            context
+          </h4>
+          <p>
+            When the user agent is to start <dfn>monitoring incoming
+            presentation sessions</dfn> in <span>presenting browsing
+            context</span> from <span>controlling browsing context</span>s, it
+            must run the following steps:
+          </p>
+          <ol>
+            <li>
+              <span data-anolis-spec="w3c-html" title="queue a task">Queue a
+              task</span> <var>T</var> to wait for and accept incoming sessions
+              from <span>controlling browsing context</span>s using
+              implementation specific mechanism.
+              <ol>
+                <li>On every new session request from <span>controlling
+                browsing context</span>, run the following steps:
+                  <ol>
+                    <li>Create new <code>PresentationSession</code>
+                    <var>S</var>.
+                    </li>
+                    <li>Let <var>I</var> be a new <span>valid presentation
+                    session identifier</span> unique among all
+                    <span>presentation session identifier</span>s for known
+                    sessions in the <span>set of presentations</span>.
+                    </li>
+                    <li>Set the <span>presentation session identifier</span> of
+                    <var>S</var> to <var>I</var>.
+                    </li>
+                    <li>Establish the session connection using implementation
+                    specific mechanism.
+                    </li>
+                    <li>Set the <span>presentation session state</span> of
+                    <var>S</var> to <code>connected</code>.
+                    </li>
+                    <li>Add a tuple {<code>undefined</code>, <span>presentation
+                    session identifier</span> of <var>S</var>, <var>S</var>} to
+                    the <span>set of presentations</span>.
+                    </li>
+                    <li>
+                      <span data-anolis-spec="w3c-html" title=
+                      "queue a task">Queue a task</span> to
+                      <span data-anolis-spec="w3c-html" title=
+                      "concept-event-fire">fire an event</span> named
+                      <code>sessionavailable</code> at
+                      <code>NavigatorPresentation</code>.
+                    </li>
+                  </ol>
+                </li>
+              </ol>
+            </li>
+          </ol>
+        </section>
+        <section>
+          <h4>
+            Getting presentation session created on the startup of presenting
+            browsing context
+          </h4>
+          <p>
+            When the <code>getSession()</code> method is called, the user agent
+            must run the following steps:
+          </p>
+          <ol>
+            <li>Let <var>P</var> be a new <span data-anolis-spec=
+            "webidl">Promise</span>.
+            </li>
+            <li>Return <var>P</var>.
+            </li>
+            <li>
+              <span data-anolis-spec="w3c-html" title="queue a task">Queue a
+              task</span> <var>T</var> to run the following steps in order:
+              <ol>
+                <li>If the <span>set of presentations</span> is empty then wait
+                until at least one element is added to the <span>set of
+                presentations</span>.
+                </li>
+                <li>Let <var>S</var> be the first <span>presentation
+                session</span> added to the <span>set of presentations</span>.
+                </li>
+                <li>
+                  <span data-anolis-spec="promguide" title=
+                  "resolve-reject">Resolve</span> <var>P</var> with
+                  <var>S</var>.
+                </li>
+              </ol>
+            </li>
+          </ol>
+          <p class="note">
+            If the <span>set of presentations</span> is empty, we leave the
+            <span data-anolis-spec="webidl">Promise</span> pending until
+            connecting request arrives from the <span>controlling browsing
+            context</span>. If the first <span>controlling browsing
+            context</span> disconnects after initial connection, then promise
+            returned to subsequent calls to <code>getSession()</code> will
+            resolve with <span>presentation session</span> that has it
+            <span>presentation session state</span> set to
+            <code>disconnected</code>.
+          </p>
+        </section>
+        <section>
+          <h4>
+            Getting all connected presentation sessions in presenting browsing
+            context
+          </h4>
+          <p>
+            When the <code>getSessions()</code> method is called, the user
+            agent must run the following steps:
+          </p>
+          <ol>
+            <li>Let <var>P</var> be a new <span data-anolis-spec=
+            "webidl">Promise</span>.
+            </li>
+            <li>Return <var>P</var>.
+            </li>
+            <li>
+              <span data-anolis-spec="w3c-html" title="queue a task">Queue a
+              task</span> to run the following steps in order:
+              <ol>
+                <li>Let array be an empty array.
+                </li>
+                <li>For each known session in the <span>set of
+                presentations</span>
+                  <ol>
+                    <li>Add known session to the array.
+                    </li>
+                  </ol>
+                </li>
+                <li>
+                  <span data-anolis-spec="promguide" title=
+                  "resolve-reject">Resolve</span> <var>P</var> with array.
+                </li>
+              </ol>
             </li>
           </ol>
         </section>

--- a/index.html
+++ b/index.html
@@ -77,8 +77,8 @@
       <h1>
         Presentation API
       </h1>
-      <h2 class="no-num no-toc" id="editor's-draft-12-june-2015">
-        Editor's Draft 12 June 2015
+      <h2 class="no-num no-toc" id="editor's-draft-17-june-2015">
+        Editor's Draft 17 June 2015
       </h2>
       <dl>
         <dt>
@@ -273,14 +273,31 @@
      <li><a href="#joining-a-presentation-session"><span class="secno">6.4.2 </span>
             Joining a presentation session
           </a></li>
-     <li><a href="#establishing-a-presentation-connection"><span class="secno">6.4.3 </span>
-            Establishing a presentation connection
+     <li><a href="#establishing-a-presentation-connection-in-controlling-browsing-context"><span class="secno">6.4.3 </span>
+            Establishing a presentation connection in controlling browsing
+            context
           </a></li>
      <li><a href="#getting-the-presentation-displays-availability-information"><span class="secno">6.4.4 </span>
             Getting the <span>presentation displays</span> availability
             information
           </a></li>
-     <li><a href="#event-handlers-0"><span class="secno">6.4.5 </span>
+     <li><a href="#establishing-a-presentation-connection-in-the-presenting-browsing-context"><span class="secno">6.4.5 </span>
+            Establishing a presentation connection in the presenting browsing
+            context
+          </a></li>
+     <li><a href="#monitoring-incoming-presentation-sessions-in-presenting-browsing-context"><span class="secno">6.4.6 </span>
+            Monitoring incoming presentation sessions in presenting browsing
+            context
+          </a></li>
+     <li><a href="#getting-presentation-session-created-on-the-startup-of-presenting-browsing-context"><span class="secno">6.4.7 </span>
+            Getting presentation session created on the startup of presenting
+            browsing context
+          </a></li>
+     <li><a href="#getting-all-connected-presentation-sessions-in-presenting-browsing-context"><span class="secno">6.4.8 </span>
+            Getting all connected presentation sessions in presenting browsing
+            context
+          </a></li>
+     <li><a href="#event-handlers-0"><span class="secno">6.4.9 </span>
             Event Handlers
           </a></ol></li>
    <li><a href="#interface-defaultsessionstart"><span class="secno">6.5 </span>
@@ -1018,18 +1035,14 @@ interface <dfn id="presentationsession">PresentationSession</dfn> : EventTarget 
           interface, the main interface of Presentation API.
         </p>
         <pre class="idl">interface <dfn id="navigatorpresentation">NavigatorPresentation</dfn> : EventTarget {
-  readonly attribute <a href="#presentationsession">PresentationSession</a>? <span>session</span>;
+  Promise&lt;<a href="#presentationsession">PresentationSession</a>&gt; <span>getSession</span>();
+  Promise&lt;<span>PresentationSession[]</span>&gt; <span>getSessions</span>();
   Promise&lt;<a href="#presentationsession">PresentationSession</a>&gt; <a href="#startsession">startSession</a>(DOMString url);
   Promise&lt;<a href="#presentationsession">PresentationSession</a>&gt; <a href="#joinsession">joinSession</a>(DOMString url, DOMString presentationId);
   Promise&lt;<a href="#availability">Availability</a>&gt; <a href="#getavailability">getAvailability</a>();
   attribute <a class="external" data-anolis-spec="w3c-html" href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#eventhandler">EventHandler</a> <a href="#ondefaultsessionstart">ondefaultsessionstart</a>;
 };
 </pre>
-        <p class="open-issue">
-          <a href="https://github.com/w3c/presentation-api/issues/52">ISSUE 52:
-          Specify the NavigatorPresentation.session attribute and its related
-          algorithms</a>
-        </p>
         <section>
           <h4 id="starting-a-presentation-session"><span class="secno">6.4.1 </span>
             Starting a presentation session
@@ -1248,8 +1261,9 @@ interface <dfn id="presentationsession">PresentationSession</dfn> : EventTarget 
           </p>
         </section>
         <section>
-          <h4 id="establishing-a-presentation-connection"><span class="secno">6.4.3 </span>
-            Establishing a presentation connection
+          <h4 id="establishing-a-presentation-connection-in-controlling-browsing-context"><span class="secno">6.4.3 </span>
+            Establishing a presentation connection in controlling browsing
+            context
           </h4>
           <p>
             When the user agent is to <dfn id="establish-a-presentation-connection">establish a presentation
@@ -1377,7 +1391,158 @@ interface <dfn id="presentationsession">PresentationSession</dfn> : EventTarget 
           </ol>
         </section>
         <section>
-          <h4 id="event-handlers-0"><span class="secno">6.4.5 </span>
+          <h4 id="establishing-a-presentation-connection-in-the-presenting-browsing-context"><span class="secno">6.4.5 </span>
+            Establishing a presentation connection in the presenting browsing
+            context
+          </h4>
+          <p>
+            When a new <a href="#presenting-browsing-context">presenting browsing context</a> has been
+            created and navigated to the <code>presentationUrl</code> on a
+            user-selected <a href="#presentation-display">presentation display</a>, the user agent has
+            to:
+          </p>
+          <ol>
+            <li>
+              <a class="external" data-anolis-spec="w3c-html" href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#queue-a-task" title="queue a task">Queue a
+              task</a> to start <span>monitoring of incoming presentation
+              sessions</span> from <a href="#controlling-browsing-context">controlling browsing context</a>s.
+            </li>
+          </ol>
+        </section>
+        <section>
+          <h4 id="monitoring-incoming-presentation-sessions-in-presenting-browsing-context"><span class="secno">6.4.6 </span>
+            Monitoring incoming presentation sessions in presenting browsing
+            context
+          </h4>
+          <p>
+            When the user agent is to start <dfn id="monitoring-incoming-presentation-sessions">monitoring incoming
+            presentation sessions</dfn> in <a href="#presenting-browsing-context">presenting browsing
+            context</a> from <a href="#controlling-browsing-context">controlling browsing context</a>s, it
+            must run the following steps:
+          </p>
+          <ol>
+            <li>
+              <a class="external" data-anolis-spec="w3c-html" href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#queue-a-task" title="queue a task">Queue a
+              task</a> <var>T</var> to wait for and accept incoming sessions
+              from <a href="#controlling-browsing-context">controlling browsing context</a>s using
+              implementation specific mechanism.
+              <ol>
+                <li>On every new session request from <a href="#controlling-browsing-context">controlling
+                browsing context</a>, run the following steps:
+                  <ol>
+                    <li>Create new <a href="#presentationsession"><code>PresentationSession</code></a>
+                    <var>S</var>.
+                    </li>
+                    <li>Let <var>I</var> be a new <a href="#valid-presentation-session-identifier">valid presentation
+                    session identifier</a> unique among all
+                    <a href="#presentation-session-identifier">presentation session identifier</a>s for known
+                    sessions in the <a href="#set-of-presentations">set of presentations</a>.
+                    </li>
+                    <li>Set the <a href="#presentation-session-identifier">presentation session identifier</a> of
+                    <var>S</var> to <var>I</var>.
+                    </li>
+                    <li>Establish the session connection using implementation
+                    specific mechanism.
+                    </li>
+                    <li>Set the <a href="#presentation-session-state">presentation session state</a> of
+                    <var>S</var> to <code>connected</code>.
+                    </li>
+                    <li>Add a tuple {<code>undefined</code>, <a href="#presentation-session-identifier">presentation
+                    session identifier</a> of <var>S</var>, <var>S</var>} to
+                    the <a href="#set-of-presentations">set of presentations</a>.
+                    </li>
+                    <li>
+                      <a class="external" data-anolis-spec="w3c-html" href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#queue-a-task" title="queue a task">Queue a task</a> to
+                      <a class="external" data-anolis-spec="w3c-html" href="http://www.w3.org/html/wg/drafts/html/master/infrastructure.html#concept-event-fire" title="concept-event-fire">fire an event</a> named
+                      <code>sessionavailable</code> at
+                      <a href="#navigatorpresentation"><code>NavigatorPresentation</code></a>.
+                    </li>
+                  </ol>
+                </li>
+              </ol>
+            </li>
+          </ol>
+        </section>
+        <section>
+          <h4 id="getting-presentation-session-created-on-the-startup-of-presenting-browsing-context"><span class="secno">6.4.7 </span>
+            Getting presentation session created on the startup of presenting
+            browsing context
+          </h4>
+          <p>
+            When the <code>getSession()</code> method is called, the user agent
+            must run the following steps:
+          </p>
+          <ol>
+            <li>Let <var>P</var> be a new <a class="external" data-anolis-spec="webidl" href="https://heycam.github.io/webidl/#idl-promise">Promise</a>.
+            </li>
+            <li>Return <var>P</var>.
+            </li>
+            <li>
+              <a class="external" data-anolis-spec="w3c-html" href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#queue-a-task" title="queue a task">Queue a
+              task</a> <var>T</var> to run the following steps in order:
+              <ol>
+                <li>If the <a href="#set-of-presentations">set of presentations</a> is empty then wait
+                until at least one element is added to the <a href="#set-of-presentations">set of
+                presentations</a>.
+                </li>
+                <li>Let <var>S</var> be the first <a href="#presentation-session">presentation
+                session</a> added to the <a href="#set-of-presentations">set of presentations</a>.
+                </li>
+                <li>
+                  <a class="external" data-anolis-spec="promguide" href="http://www.w3.org/2001/tag/doc/promises-guide#shorthand-manipulating" title="resolve-reject">Resolve</a> <var>P</var> with
+                  <var>S</var>.
+                </li>
+              </ol>
+            </li>
+          </ol>
+          <p class="note">
+            If the <a href="#set-of-presentations">set of presentations</a> is empty, we leave the
+            <a class="external" data-anolis-spec="webidl" href="https://heycam.github.io/webidl/#idl-promise">Promise</a> pending until
+            connecting request arrives from the <a href="#controlling-browsing-context">controlling browsing
+            context</a>. If the first <a href="#controlling-browsing-context">controlling browsing
+            context</a> disconnects after initial connection, then promise
+            returned to subsequent calls to <code>getSession()</code> will
+            resolve with <a href="#presentation-session">presentation session</a> that has it
+            <a href="#presentation-session-state">presentation session state</a> set to
+            <code>disconnected</code>.
+          </p>
+        </section>
+        <section>
+          <h4 id="getting-all-connected-presentation-sessions-in-presenting-browsing-context"><span class="secno">6.4.8 </span>
+            Getting all connected presentation sessions in presenting browsing
+            context
+          </h4>
+          <p>
+            When the <code>getSessions()</code> method is called, the user
+            agent must run the following steps:
+          </p>
+          <ol>
+            <li>Let <var>P</var> be a new <a class="external" data-anolis-spec="webidl" href="https://heycam.github.io/webidl/#idl-promise">Promise</a>.
+            </li>
+            <li>Return <var>P</var>.
+            </li>
+            <li>
+              <a class="external" data-anolis-spec="w3c-html" href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#queue-a-task" title="queue a task">Queue a
+              task</a> to run the following steps in order:
+              <ol>
+                <li>Let array be an empty array.
+                </li>
+                <li>For each known session in the <a href="#set-of-presentations">set of
+                presentations</a>
+                  <ol>
+                    <li>Add known session to the array.
+                    </li>
+                  </ol>
+                </li>
+                <li>
+                  <a class="external" data-anolis-spec="promguide" href="http://www.w3.org/2001/tag/doc/promises-guide#shorthand-manipulating" title="resolve-reject">Resolve</a> <var>P</var> with array.
+                </li>
+              </ol>
+            </li>
+          </ol>
+        </section>
+        <section>
+          <h4 id="event-handlers-0"><span class="secno">6.4.9 </span>
             Event Handlers
           </h4>
           <p>


### PR DESCRIPTION
Initial description of session creation and monitoring in presenting browsing context. Methods `getSession()` and `getSessions()` added to `NavigatorPresentation` interface as agreed at F2F http://www.w3.org/2015/05/19-webscreens-minutes.html#action12. 
Interface still might change since discussion is ongoing in https://github.com/w3c/presentation-api/issues/19. This PR is a starting point for future modifications coming from https://github.com/w3c/presentation-api/issues/91 as well.