### PR TITLE
Reference WebIDL for DOMException instead of DOM

### DIFF
--- a/Overview.src.html
+++ b/Overview.src.html
@@ -325,13 +325,9 @@
         <span data-anolis-ref="">HTML5</span>.
       </p>
       <p>
-        The term <span data-anolis-spec="dom" title=
-        "domexception">DOMException</span> is defined in <span data-anolis-ref=
-        "dom">DOM</span>.
-      </p>
-      <p>
         This document provides interface definitions using the
         <span data-anolis-ref="webidl">WEBIDL</span> standard. The terms
+        <span data-anolis-spec="webidl">DOMException</span>,
         <span data-anolis-spec="webidl">Promise</span>, <span data-anolis-spec=
         "webidl">ArrayBuffer</span>, and <span data-anolis-spec=
         "webidl">ArrayBufferView</span> are defined in <span data-anolis-ref=
@@ -1087,8 +1083,7 @@ interface <dfn>NavigatorPresentation</dfn> : EventTarget {
                 <li>
                   <span data-anolis-spec="promguide" title=
                   "resolve-reject">Reject</span> <em>P</em> with a
-                  <span data-anolis-spec="dom" title=
-                  "domexception">DOMException</span> named
+                  <span data-anolis-spec="webidl">DOMException</span> named
                   <code>"NotFoundError"</code>.
                 </li>
                 <li>Abort all remaining steps.
@@ -1146,8 +1141,7 @@ interface <dfn>NavigatorPresentation</dfn> : EventTarget {
                             <li>
                               <span data-anolis-spec="promguide" title=
                               "resolve-reject">Reject</span> P with a
-                              <span data-anolis-spec="dom" title=
-                              "domexception">DOMException</span> named
+                              <span data-anolis-spec="webidl">DOMException</span> named
                               <code>"OperationError"</code>.
                             </li>
                           </ol>
@@ -1162,8 +1156,7 @@ interface <dfn>NavigatorPresentation</dfn> : EventTarget {
                     <li>
                       <span data-anolis-spec="promguide" title=
                       "resolve-reject">Reject</span> <em>P</em> with a
-                      <span data-anolis-spec="dom" title=
-                      "domexception">DOMException</span> named
+                      <span data-anolis-spec="webidl">DOMException</span> named
                       <code>"AbortError"</code>.
                     </li>
                   </ol>
@@ -1258,8 +1251,7 @@ interface <dfn>NavigatorPresentation</dfn> : EventTarget {
                 <li>
                   <span data-anolis-spec="promguide" title=
                   "resolve-reject">Reject</span> <em>P</em> with a
-                  <span data-anolis-spec="dom" title=
-                  "domexception">DOMException</span> named
+                  <span data-anolis-spec="webidl">DOMException</span> named
                   <code>"NotFoundError"</code>.
                 </li>
               </ol>


### PR DESCRIPTION
DOM now defers to WebIDL for DOMException
(I'm not sure what's the right way to make the cross-ref work right on Anolis; let me know if it needs further tweaking)