### PR TITLE
Rename Availability interface to PresentationAvailability.

### DIFF
--- a/Overview.src.html
+++ b/Overview.src.html
@@ -838,10 +838,10 @@ interface <dfn>PresentationSession</dfn> : EventTarget {
       </section>
       <section>
         <h3>
-          Interface <code>Availability</code>
+          Interface <code>PresentationAvailability</code>
         </h3>
         <pre class="idl">
-interface <dfn>Availability</dfn> : EventTarget {
+interface <dfn>PresentationAvailability</dfn> : EventTarget {
   readonly attribute boolean value;
   attribute <span data-anolis-spec=
 "w3c-html">EventHandler</span> <span>onchange</span>;  
@@ -849,7 +849,7 @@ interface <dfn>Availability</dfn> : EventTarget {
         
 </pre>
         <p>
-          An <code>Availability</code> object is associated with a
+          An <code>PresentationAvailability</code> object is associated with a
           <span>presentation display</span> and represents its
           <dfn>presentation display availability</dfn>.
         </p>
@@ -890,7 +890,8 @@ interface <dfn>Availability</dfn> : EventTarget {
           </p>
           <ol>
             <li>
-              <em>A</em> is a live <code>Availability</code> object;
+              <em>A</em> is a live <code>PresentationAvailability</code>
+              object;
             </li>
             <li>
               <em>availabilityUrl</em> is the <code>availabilityUrl</code>
@@ -916,32 +917,33 @@ interface <dfn>Availability</dfn> : EventTarget {
             <span>monitor the list of available presentation displays</span>.
           </p>
           <p>
-            While there are live <code>Availability</code> objects, the user
-            agent may <span>monitor the list of available presentation
+            While there are live <code>PresentationAvailability</code> objects,
+            the user agent may <span>monitor the list of available presentation
             displays</span> continuously, so that pages can use the
-            <code>value</code> property of an <code>Availability</code> object
-            to offer presentation only when there are available displays.
-            However, the user agent may not support continuous availability
-            monitoring; for example, because of platform or power consumption
-            restrictions. In this case the <span>Promise</span> returned by
-            <code>getAvailability()</code> is <span data-anolis-spec=
-            "promguide" title="resolve-reject">rejected</span> and the
-            algorithm to <span>monitor the list of available presentation
-            displays</span> will only run as part of the <span title=
-            "startSession">session start</span> algorithm.
+            <code>value</code> property of an
+            <code>PresentationAvailability</code> object to offer presentation
+            only when there are available displays. However, the user agent may
+            not support continuous availability monitoring; for example,
+            because of platform or power consumption restrictions. In this case
+            the <span>Promise</span> returned by <code>getAvailability()</code>
+            is <span data-anolis-spec="promguide" title=
+            "resolve-reject">rejected</span> and the algorithm to <span>monitor
+            the list of available presentation displays</span> will only run as
+            part of the <span title="startSession">session start</span>
+            algorithm.
           </p>
           <p>
-            When there are no live <code>Availability</code> objects (that is,
-            the <span>set of availability objects</span> is empty), user agents
-            should not <span>monitor the list of available presentation
-            displays</span> to satisfy the <a href=
+            When there are no live <code>PresentationAvailability</code>
+            objects (that is, the <span>set of availability objects</span> is
+            empty), user agents should not <span>monitor the list of available
+            presentation displays</span> to satisfy the <a href=
             "https://github.com/w3c/presentation-api/blob/gh-pages/uc-req.md#nf-req01-power-saving-friendly">
             power saving non-functional requirement</a>. To further save power,
             the UA may also keep track of whether the page holding an
-            <code>Availability</code> object is in the foreground. Using this
-            information, implementation specific discovery of <span title=
-            "presentation-display">presentation displays</span> can be resumed
-            or suspended.
+            <code>PresentationAvailability</code> object is in the foreground.
+            Using this information, implementation specific discovery of
+            <span title="presentation-display">presentation displays</span> can
+            be resumed or suspended.
           </p>
           <p>
             Some <span>presentation displays</span> may only be able to display
@@ -1004,9 +1006,9 @@ interface <dfn>Availability</dfn> : EventTarget {
             </li>
           </ol>
           <p>
-            When an <code>Availability</code> object is no longer alive (i.e.,
-            is eligible for garbage collection), the user agent should run the
-            following steps:
+            When an <code>PresentationAvailability</code> object is no longer
+            alive (i.e., is eligible for garbage collection), the user agent
+            should run the following steps:
           </p>
           <ol>
             <li>Find and remove any entry <em>(A, availabilityUrl, P)</em> in
@@ -1048,7 +1050,7 @@ interface <dfn>NavigatorPresentation</dfn> : EventTarget {
   // This API used by controlling browsing context.
   Promise&lt;<span>PresentationSession</span>&gt; <span>startSession</span>(DOMString url);
   Promise&lt;<span>PresentationSession</span>&gt; <span>joinSession</span>(DOMString url, DOMString presentationId);
-  Promise&lt;<span>Availability</span>&gt; <span>getAvailability</span>(DOMString url);
+  Promise&lt;<span>PresentationAvailability</span>&gt; <span>getAvailability</span>(DOMString url);
   attribute <span data-anolis-spec=
 "w3c-html">EventHandler</span> <span>ondefaultsessionstart</span>;
 
@@ -1418,9 +1420,9 @@ interface <dfn>NavigatorPresentation</dfn> : EventTarget {
                 </li>
               </ol>
             </li>
-            <li>Otherwise, let <em>A</em> be a new <code>Availability</code>
-            object with its <code>value</code> property set to
-            <code>false</code>.
+            <li>Otherwise, let <em>A</em> be a new
+            <code>PresentationAvailability</code> object with its
+            <code>value</code> property set to <code>false</code>.
             </li>
             <li>Create a tuple <em>(A, availabilityUrl, P)</em> and add it to
             the <span>set of availability objects</span>.
@@ -1673,13 +1675,14 @@ dictionary <dfn>DefaultSessionStartEventInit</dfn> : EventInit {
         Personally identifiable information
       </h3>
       <p>
-        The <code>change</code> event fired on the <code>Availability</code>
-        object reveals one bit of information about the presence (or
-        non-presence) of a <span>presentation screen</span> typically
-        discovered through the local area network. This could be used in
-        conjunction with other information for fingerprinting the user.
-        However, this information is also dependent on the user's local network
-        context, so the risk is minimized.
+        The <code>change</code> event fired on the
+        <code>PresentationAvailability</code> object reveals one bit of
+        information about the presence (or non-presence) of a
+        <span>presentation screen</span> typically discovered through the local
+        area network. This could be used in conjunction with other information
+        for fingerprinting the user. However, this information is also
+        dependent on the user's local network context, so the risk is
+        minimized.
       </p>
       <p class="open-issue">
         If we allow the page to filter the set of presentation screens based on

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     </title>
     <link href="https://www.w3.org/StyleSheets/TR/W3C-ED" rel="stylesheet">
     <style>
-    /* Note formatting taken from HTML5 spec */
+/* Note formatting taken from HTML5 spec */
     .note { border-left-style: solid; border-left-width: 0.25em; background: none repeat scroll 0 0 #E9FBE9; border-color: #52E052; }
     .note em, .warning em, .note i, .warning i { font-style: normal; }
     p.note, div.note { padding: 0.5em 2em; }
@@ -72,8 +72,8 @@
       <h1>
         Presentation API
       </h1>
-      <h2 class="no-num no-toc" id="editor's-draft-1-july-2015">
-        Editor's Draft 1 July 2015
+      <h2 class="no-num no-toc" id="editor's-draft-3-july-2015">
+        Editor's Draft 3 July 2015
       </h2>
       <dl>
         <dt>
@@ -252,8 +252,8 @@
      <li><a href="#event-handlers"><span class="secno">6.2.4 </span>
             Event Handlers
           </a></ol></li>
-   <li><a href="#interface-availability"><span class="secno">6.3 </span>
-          Interface <code>Availability</code>
+   <li><a href="#interface-presentationavailability"><span class="secno">6.3 </span>
+          Interface <code>PresentationAvailability</code>
         </a>
     <ol>
      <li><a href="#the-set-of-availability-objects"><span class="secno">6.3.1 </span>
@@ -918,17 +918,17 @@ interface <dfn id="presentationsession">PresentationSession</dfn> : EventTarget 
         </section>
       </section>
       <section>
-        <h3 id="interface-availability"><span class="secno">6.3 </span>
-          Interface <a href="#availability"><code>Availability</code></a>
+        <h3 id="interface-presentationavailability"><span class="secno">6.3 </span>
+          Interface <a href="#presentationavailability"><code>PresentationAvailability</code></a>
         </h3>
-        <pre class="idl">interface <dfn id="availability">Availability</dfn> : EventTarget {
+        <pre class="idl">interface <dfn id="presentationavailability">PresentationAvailability</dfn> : EventTarget {
   readonly attribute boolean value;
   attribute <a class="external" data-anolis-spec="w3c-html" href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#eventhandler">EventHandler</a> <span>onchange</span>;  
 };
         
 </pre>
         <p>
-          An <a href="#availability"><code>Availability</code></a> object is associated with a
+          An <a href="#presentationavailability"><code>PresentationAvailability</code></a> object is associated with a
           <a href="#presentation-display">presentation display</a> and represents its
           <dfn id="presentation-display-availability">presentation display availability</dfn>.
         </p>
@@ -968,7 +968,8 @@ interface <dfn id="presentationsession">PresentationSession</dfn> : EventTarget 
           </p>
           <ol>
             <li>
-              <em>A</em> is a live <a href="#availability"><code>Availability</code></a> object;
+              <em>A</em> is a live <a href="#presentationavailability"><code>PresentationAvailability</code></a>
+              object;
             </li>
             <li>
               <em>availabilityUrl</em> is the <code>availabilityUrl</code>
@@ -994,28 +995,31 @@ interface <dfn id="presentationsession">PresentationSession</dfn> : EventTarget 
             <a href="#monitor-the-list-of-available-presentation-displays-0">monitor the list of available presentation displays</a>.
           </p>
           <p>
-            While there are live <a href="#availability"><code>Availability</code></a> objects, the user
-            agent may <a href="#monitor-the-list-of-available-presentation-displays-0">monitor the list of available presentation
+            While there are live <a href="#presentationavailability"><code>PresentationAvailability</code></a> objects,
+            the user agent may <a href="#monitor-the-list-of-available-presentation-displays-0">monitor the list of available presentation
             displays</a> continuously, so that pages can use the
-            <code>value</code> property of an <a href="#availability"><code>Availability</code></a> object
-            to offer presentation only when there are available displays.
-            However, the user agent may not support continuous availability
-            monitoring; for example, because of platform or power consumption
-            restrictions. In this case the <span>Promise</span> returned by
-            <code>getAvailability()</code> is <a class="external" data-anolis-spec="promguide" href="http://www.w3.org/2001/tag/doc/promises-guide#shorthand-manipulating" title="resolve-reject">rejected</a> and the
-            algorithm to <a href="#monitor-the-list-of-available-presentation-displays-0">monitor the list of available presentation
-            displays</a> will only run as part of the <a href="#startsession" title="startSession">session start</a> algorithm.
+            <code>value</code> property of an
+            <a href="#presentationavailability"><code>PresentationAvailability</code></a> object to offer presentation
+            only when there are available displays. However, the user agent may
+            not support continuous availability monitoring; for example,
+            because of platform or power consumption restrictions. In this case
+            the <span>Promise</span> returned by <code>getAvailability()</code>
+            is <a class="external" data-anolis-spec="promguide" href="http://www.w3.org/2001/tag/doc/promises-guide#shorthand-manipulating" title="resolve-reject">rejected</a> and the algorithm to <a href="#monitor-the-list-of-available-presentation-displays-0">monitor
+            the list of available presentation displays</a> will only run as
+            part of the <a href="#startsession" title="startSession">session start</a>
+            algorithm.
           </p>
           <p>
-            When there are no live <a href="#availability"><code>Availability</code></a> objects (that is,
-            the <a href="#set-of-availability-objects">set of availability objects</a> is empty), user agents
-            should not <a href="#monitor-the-list-of-available-presentation-displays-0">monitor the list of available presentation
-            displays</a> to satisfy the <a href="https://github.com/w3c/presentation-api/blob/gh-pages/uc-req.md#nf-req01-power-saving-friendly">
+            When there are no live <a href="#presentationavailability"><code>PresentationAvailability</code></a>
+            objects (that is, the <a href="#set-of-availability-objects">set of availability objects</a> is
+            empty), user agents should not <a href="#monitor-the-list-of-available-presentation-displays-0">monitor the list of available
+            presentation displays</a> to satisfy the <a href="https://github.com/w3c/presentation-api/blob/gh-pages/uc-req.md#nf-req01-power-saving-friendly">
             power saving non-functional requirement</a>. To further save power,
             the UA may also keep track of whether the page holding an
-            <a href="#availability"><code>Availability</code></a> object is in the foreground. Using this
-            information, implementation specific discovery of <span title="presentation-display">presentation displays</span> can be resumed
-            or suspended.
+            <a href="#presentationavailability"><code>PresentationAvailability</code></a> object is in the foreground.
+            Using this information, implementation specific discovery of
+            <span title="presentation-display">presentation displays</span> can
+            be resumed or suspended.
           </p>
           <p>
             Some <span>presentation displays</span> may only be able to display
@@ -1077,9 +1081,9 @@ interface <dfn id="presentationsession">PresentationSession</dfn> : EventTarget 
             </li>
           </ol>
           <p>
-            When an <a href="#availability"><code>Availability</code></a> object is no longer alive (i.e.,
-            is eligible for garbage collection), the user agent should run the
-            following steps:
+            When an <a href="#presentationavailability"><code>PresentationAvailability</code></a> object is no longer
+            alive (i.e., is eligible for garbage collection), the user agent
+            should run the following steps:
           </p>
           <ol>
             <li>Find and remove any entry <em>(A, availabilityUrl, P)</em> in
@@ -1117,7 +1121,7 @@ interface <dfn id="presentationsession">PresentationSession</dfn> : EventTarget 
   // This API used by controlling browsing context.
   Promise&lt;<a href="#presentationsession">PresentationSession</a>&gt; <a href="#startsession">startSession</a>(DOMString url);
   Promise&lt;<a href="#presentationsession">PresentationSession</a>&gt; <a href="#joinsession">joinSession</a>(DOMString url, DOMString presentationId);
-  Promise&lt;<a href="#availability">Availability</a>&gt; <a href="#getavailability">getAvailability</a>(DOMString url);
+  Promise&lt;<a href="#presentationavailability">PresentationAvailability</a>&gt; <a href="#getavailability">getAvailability</a>(DOMString url);
   attribute <a class="external" data-anolis-spec="w3c-html" href="http://www.w3.org/html/wg/drafts/html/master/webappapis.html#eventhandler">EventHandler</a> <a href="#ondefaultsessionstart">ondefaultsessionstart</a>;
 
   // This API used by presenting browsing context.                  
@@ -1469,9 +1473,9 @@ interface <dfn id="presentationsession">PresentationSession</dfn> : EventTarget 
                 </li>
               </ol>
             </li>
-            <li>Otherwise, let <em>A</em> be a new <a href="#availability"><code>Availability</code></a>
-            object with its <code>value</code> property set to
-            <code>false</code>.
+            <li>Otherwise, let <em>A</em> be a new
+            <a href="#presentationavailability"><code>PresentationAvailability</code></a> object with its
+            <code>value</code> property set to <code>false</code>.
             </li>
             <li>Create a tuple <em>(A, availabilityUrl, P)</em> and add it to
             the <a href="#set-of-availability-objects">set of availability objects</a>.
@@ -1716,13 +1720,14 @@ dictionary <dfn id="defaultsessionstarteventinit">DefaultSessionStartEventInit</
         Personally identifiable information
       </h3>
       <p>
-        The <code>change</code> event fired on the <a href="#availability"><code>Availability</code></a>
-        object reveals one bit of information about the presence (or
-        non-presence) of a <span>presentation screen</span> typically
-        discovered through the local area network. This could be used in
-        conjunction with other information for fingerprinting the user.
-        However, this information is also dependent on the user's local network
-        context, so the risk is minimized.
+        The <code>change</code> event fired on the
+        <a href="#presentationavailability"><code>PresentationAvailability</code></a> object reveals one bit of
+        information about the presence (or non-presence) of a
+        <span>presentation screen</span> typically discovered through the local
+        area network. This could be used in conjunction with other information
+        for fingerprinting the user. However, this information is also
+        dependent on the user's local network context, so the risk is
+        minimized.
       </p>
       <p class="open-issue">
         If we allow the page to filter the set of presentation screens based on

--- a/xrefs/presentation.json
+++ b/xrefs/presentation.json
@@ -1,7 +1,6 @@
 {
   "definitions": {
     "algorithm-send": "algorithm-send",
-    "availability": "availability",
     "binarytype": "binarytype",
     "binarytype-attribute": "binarytype-attribute",
     "close": "close",
@@ -36,6 +35,7 @@
     "presentation session state": "presentation-session-state",
     "presentation session url": "presentation-session-url",
     "presentation-onmessage": "presentation-onmessage",
+    "presentationavailability": "presentationavailability",
     "presentationsession": "presentationsession",
     "presentationsessionstate": "presentationsessionstate",
     "presenting browsing context": "presenting-browsing-context",


### PR DESCRIPTION
The interface name is exposed in the global object so having it prefixed
with Presentation is probably safer. Also, it prevents the Presentation
API from taking ownership of the generic 'Availability' interface name.