### PR TITLE
Use「Living Document」convention for auto-publishing

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,6 +13,7 @@
         specStatus: 'ED',
         edDraftURI: 'http://w3c.github.io/presentation-api/',
         shortName:  'presentation-api',
+        subtitle:  'Living Document',
         editors: [
           {
             w3cid: 68454,


### PR DESCRIPTION
Use **Living Document** subtitle to indicate in the TR/WD version that it’s up-to-date with the latest repo sources (auto-published).

I think @marcoscaceres introduced this convention with the https://github.com/w3c/manifest spec, but regardless it seems like a useful convention to adopt for specs that are using the auto-publishing system.