### PR TITLE
Use syntax highlighting in the examples

### DIFF
--- a/index.html
+++ b/index.html
@@ -311,7 +311,7 @@
         <h3>
           Monitor availability of presentation displays example
         </h3>
-        <pre class="example">
+        <pre class="example highlight">
 &lt;!-- controller.html --&gt;
 &lt;button id="castBtn" style="display: none;"&gt;Cast&lt;/button&gt;
 &lt;script&gt;
@@ -345,7 +345,7 @@
         <h3>
           Starting a new presentation session example
         </h3>
-        <pre class="example">
+        <pre class="example highlight">
 &lt;!-- controller.html --&gt;
 &lt;script&gt;
   // Start new session.
@@ -361,7 +361,7 @@
         <h3>
           Joining a presentation session example
         </h3>
-        <pre class="example">
+        <pre class="example highlight">
 &lt;!-- controller.html --&gt;
 &lt;script&gt;
   // read presId from localStorage if exists
@@ -381,7 +381,7 @@
         <h3>
           Handling an event for a UA initiated presentation session example
         </h3>
-        <pre class="example">
+        <pre class="example highlight">
 &lt;!-- controller.html --&gt;
 &lt;head&gt;
   &lt;!-- Setting presentation.defaultRequest allows the page to specify the
@@ -400,7 +400,7 @@
         <h3>
           Monitor session's state and exchange data example
         </h3>
-        <pre class="example">
+        <pre class="example highlight">
 &lt;!-- controller.html --&gt;
 &lt;script&gt;
   var session;
@@ -434,7 +434,7 @@
 &lt;/script&gt;
 
 </pre>
-        <pre class="example">
+        <pre class="example highlight">
 &lt;!-- presentation.html --&gt;
 &lt;script&gt;
   var addSession = function(session) {


### PR DESCRIPTION
Make use of the [syntax highlighter][1] of ReSpec.

[1]: https://www.w3.org/respec/ref.html#highlight