### PR TITLE
Set tidy "preserve-entitites" config flag to preserve &amp; escaping

### DIFF
--- a/build/tidyconfig.txt
+++ b/build/tidyconfig.txt
@@ -1,6 +1,7 @@
 char-encoding: utf8
 drop-proprietary-attributes: no
 indent: yes
+preserve-entities: yes
 wrap: 80
 tidy-mark: no
 quiet: yes


### PR DESCRIPTION
Recent version 5.0.0 of tidy seems to treat ampersands a bit differently. It drops the escaping of non-ambiguous ampersands in particular.

That is technically correct in HTML5, see the relevant spec definition:
http://www.w3.org/TR/html5/syntax.html#syntax-ambiguous-ampersand

I would personally prefer tidy not to update entitites that we chose to escape though. The "preserve-entities" setting does just that.

This was initially raised in #164:
https://github.com/w3c/presentation-api/issues/164#issuecomment-133460718

FWIW, the change in Tidy may be due to:
https://github.com/htacg/tidy-html5/issues/207