### PR TITLE
Use TIDY instead of TIDY-HTML5 to make it settable in from ENV.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-TIDY-HTML5 ?= tidy-html5
+TIDY ?= tidy-html5
 
 tidy: index.html build/tidyconfig.txt
-	$(TIDY-HTML5) -config build/tidyconfig.txt -o $< $<
+	$(TIDY) -config build/tidyconfig.txt -o $< $<


### PR DESCRIPTION
This said, I'm not entirely sure why we use ```tidy-html5``` as the name of the binary while ```tidy``` is the output of building the tool from the repository. Am I doing something wrong?