### PR TITLE
getAvailability() should return true if the list of displays isn't empty.

### DIFF
--- a/index.html
+++ b/index.html
@@ -822,7 +822,7 @@
             when there are available displays. However, the user agent may not
             support continuous availability monitoring; for example, because of
             platform or power consumption restrictions. In this case the
-            <a>Promise</a> returned by <code>getAvailability()</code> is
+            <a>Promise</a> returned by <code>getAvailability()</code> MUST be
             <a title="reject">rejected</a> and the algorithm to <a>monitor the
             list of available presentation displays</a> will only run as part
             of the <a for="PresentationRequest" title="start">start a
@@ -1302,9 +1302,10 @@
                 </li>
               </ol>
             </li>
-            <li>Otherwise, let <em>A</em> be a new
-            <code>PresentationAvailability</code> object with its
-            <code>value</code> property set to <code>false</code>.
+            <li>Let <em>A</em> be a new <code>PresentationAvailability</code>
+            object with its <code>value</code> property set to <code>false</code>
+            if the <a>list of available presentation displays</a> is empty and
+            <code>true</code> otherwise.
             </li>
             <li>Create a tuple <em>(A, presentationUrl, P)</em> and add it to
             the <a>set of availability objects</a>.


### PR DESCRIPTION
In other words, if there is a discovery happening which already found a device, getAvailability() should be resolved with true.

Fixes #161