### PR TITLE
Hide issue summaries pulled from GH

### DIFF
--- a/index.html
+++ b/index.html
@@ -130,6 +130,7 @@
     table td, table th { border-left: solid; border-right: solid; border-bottom: solid thin; vertical-align: top; padding: 0.2em; }
     dfn { font-weight: bolder; font-style: normal; }
     .copyright { font-size: small; }
+    .issue[id^='issue-'] > *:not([role='heading']) { display: none; }
     </style>
   </head>
   <body>


### PR DESCRIPTION
@mfoltzgoogle This is a workaround to hide the (currently too verbose) issue summaries pulled from GH. If this feature is liked by others we should bake this into ReSpec as a configuration option. In the interim, this CSS should do.