### PR TITLE
Editorial

### DIFF
--- a/index.html
+++ b/index.html
@@ -190,8 +190,9 @@
         "presenting browsing context">presentation</a> run on the same UA and
         the operating system is used to route the <a>presentation display</a>
         output to the <a>presentation display</a>. This is commonly referred to
-        as the <b>1-UA</b> case. This specification imposes no requirements on
-        the <a>presentation display</a> devices connected in such a manner.
+        as the <b id="1-ua">1-UA</b> case. This specification imposes no
+        requirements on the <a>presentation display</a> devices connected in
+        such a manner.
       </p>
       <p>
         If the <a>presentation display</a> is able to render HTML documents and
@@ -200,10 +201,10 @@
         "presenting browsing context">presentation</a>. In this case, the UA
         acts as a proxy that requests the <a>presentation display</a> to show
         and render the <a title="presenting browsing context">presentation</a>
-        itself. This is commonly referred to as the <b>2-UA</b> case. This way
-        of attaching to displays could be enhanced in the future by defining a
-        standard protocol for delivering these types of messages that display
-        devices could choose to implement.
+        itself. This is commonly referred to as the <b id="2-ua">2-UA</b> case.
+        This way of attaching to displays could be enhanced in the future by
+        defining a standard protocol for delivering these types of messages
+        that display devices could choose to implement.
       </p>
       <p>
         The API defined here is intended to be used with UAs that attach to

--- a/index.html
+++ b/index.html
@@ -1303,9 +1303,9 @@
               </ol>
             </li>
             <li>Let <em>A</em> be a new <code>PresentationAvailability</code>
-            object with its <code>value</code> property set to <code>false</code>
-            if the <a>list of available presentation displays</a> is empty and
-            <code>true</code> otherwise.
+            object with its <code>value</code> property set to
+            <code>false</code> if the <a>list of available presentation
+            displays</a> is empty and <code>true</code> otherwise.
             </li>
             <li>Create a tuple <em>(A, presentationUrl, P)</em> and add it to
             the <a>set of availability objects</a>.


### PR DESCRIPTION
Add anchors for 1-UA and 2-UA terms to allow cross-referencing from interoperability.md that is being baked in https://github.com/w3c/presentation-api/pull/175.