### PR TITLE
[publication] Updated URL passed to Echidna to use right Git branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ branches:
 
 env:
   global:
-    - URL="https://w3c.github.io/presentation-api/ECHIDNA"
+    - URL="https://rawgit.com/w3c/presentation-api/TR/ECHIDNA"
     - DECISION="https://lists.w3.org/Archives/Public/public-secondscreen/2015Jun/0096.html"
     - secure: "nJ8QtGEN8dzi2syMLFDpK8AAfTtvR/6QXe+H/rymwXHyD0LuoBGtH8NxZ6uyV1TfqTC3YcjuM0pFqtO+9gNi1L2uYeJH808cb6QjM9+qhuL9E0xE6qcoud7jqMeMY/K6HsSDqjEDJdTKNBOygMIzg69TASBoe9V/yGmpGZzGDZg="
  


### PR DESCRIPTION
Travis configuration meant that the editor's draft in the default "gh-pages" is being published to /TR/. However, it should rather be the editor's draft in the "TR" branch.

In other words, the URL to give to Echidna should not be:
https://w3c.github.io/presentation-api/ECHIDNA

... but rather:
https://rawgit.com/w3c/presentation-api/TR/ECHIDNA

This commit updates the URL in the Travis configuration. Note that I also updated the information associated with the publication token stored on W3C servers to expect "https://rawgit.com/w3c/presentation-api/TR/" source URLs