### PR TITLE
Make session a required argument when constructing a PresentationSessionConnect.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1396,13 +1396,13 @@
             Interface <code>PresentationSessionConnectEvent</code>
           </h3>
           <pre class="idl">
-            [Constructor(DOMString type, optional PresentationSessionConnectEventInit eventInitDict)]
+            [Constructor(DOMString type, PresentationSessionConnectEventInit eventInitDict)]
             interface PresentationSessionConnectEvent : Event {
               [SameObject] readonly attribute PresentationSession session;
             };
 
             dictionary PresentationSessionConnectEventInit : EventInit {
-              PresentationSession session;
+              required PresentationSession session;
             };
 
 </pre>


### PR DESCRIPTION
Fixes #184.