### PR TITLE
Defines two conformance classes for the specification

### DIFF
--- a/index.html
+++ b/index.html
@@ -800,8 +800,7 @@
             Terminating a presentation
           </h4>
           <p>
-            When a <a>controlling user agent</a> is to <dfn data-lt=
-            "terminate-algorithm-controller">terminate a presentation</dfn>
+            When a <a>controlling user agent</a> is to terminate a presentation
             using <em>connection</em>, it MUST run the following steps:
           </p>
           <ol>
@@ -832,17 +831,15 @@
                     </li>
                   </ol>
                 </li>
-                <li>Signal the <a>receiving user agent</a> to <a data-lt=
-                "terminate-algorithm-receiver">terminate the presentation</a>
-                using an implementation specific mechanism.
+                <li>Signal the <a>receiving user agent</a> to terminate the
+                presentation using an implementation specific mechanism.
                 </li>
               </ol>
             </li>
           </ol>
           <p>
-            When a <a>receiving user agent</a> is to <dfn data-lt=
-            "terminate-algorithm-receiver">terminate a presentation</dfn> using
-            <em>connection</em>, it MUST close the <a>receiving browsing
+            When a <a>receiving user agent</a> is to terminate a presentation
+            using <em>connection</em>, it MUST close the <a>receiving browsing
             context</a> (equivalent to calling <code>window.close()</code>).
           </p>
           <p>
@@ -1654,7 +1651,7 @@
                 <li>
                   <a>Queue a task</a> to <a>fire</a> an event named
                   <code>connectionavailable</code> at <a for=
-                  "Navigator"><code>presentation.receiver</code></a>.
+                  "PresentationReceiver"><code>presentation.receiver</code></a>.
                 </li>
               </ol>
             </li>

--- a/index.html
+++ b/index.html
@@ -203,9 +203,9 @@
         <a data-lt="receiving browsing context">presentation</a> run on the
         same UA and the operating system is used to route the <a>presentation
         display</a> output to the <a>presentation display</a>. This is commonly
-        referred to as the <b id="1-ua">1-UA</b> case. This specification
-        imposes no requirements on the <a>presentation display</a> devices
-        connected in such a manner.
+        referred to as the <dfn><b id="1-ua">1-UA</b></dfn> case. This
+        specification imposes no requirements on the <a>presentation
+        display</a> devices connected in such a manner.
       </p>
       <p>
         If the <a>presentation display</a> is able to render HTML documents and
@@ -247,6 +247,54 @@
         particular, the algorithms defined in this specification are intended
         to be easy to follow, and not intended to be performant.)
       </p>
+      <section>
+        <h3>
+          Conformance Classes
+        </h3>
+        <p>
+          This specification describes the conformance criteria for two classes
+          of user agents.
+        </p>
+        <dl>
+          <dt>
+            <dfn>Controlling user agent</dfn>
+          </dt>
+          <dd>
+            <p>
+              Web browsers that conform to the specifications of a
+              <a>controlling user agent</a> must be able to start and control
+              presentations by providing a <a>controlling browsing context</a>
+              as described in this specification. This context MUST implement
+              the <code>PresentationConnection</code>,
+              <code>PresentationConnectionAvailable</code>, and
+              <code>PresentationRequest</code> interfaces.
+            </p>
+          </dd>
+          <dt>
+            <dfn>Receiving user agent</dfn>
+          </dt>
+          <dd>
+            <p>
+              Web browsers that conform to the specifications of a <a>receiving
+              user agent</a> must be able to render presentations by providing
+              a <a>receiving browsing context</a> as described in this
+              specification. This context must implement the
+              <code>PresentationConnection</code>,
+              <code>PresentationConnectionAvailable</code>, and
+              <code>PresentationReceiver</code> interfaces.
+            </p>
+          </dd>
+        </dl>
+        <p>
+          One user agent may act both as an <a>controlling user agent</a> and
+          as a <a>receiving user agent</a>, if it provides both browsing
+          contexts and implements all of their required interfaces. This can
+          happen when the the same user agent is able to host the
+          <a>controlling browsing context</a> and the <a>receiving browsing
+          context</a> for a presentation, as in the <a>1-UA</a> implementation
+          of the API.
+        </p>
+      </section>
     </section>
     <section>
       <h2>
@@ -339,16 +387,16 @@
   // Promise is resolved as soon as the presentation display availability is known.
   var request = new PresentationRequest(presUrl);
   request.getAvailability().then(function(availability) {
-    // availability.value may be kept up-to-date by the UA as long as the availability
-    // object is alive. It is advised for the web developers to discard the object
-    // as soon as it's not needed.
+    // availability.value may be kept up-to-date by the controlling UA as long
+    // as the availability object is alive. It is advised for the web developers
+    // to discard the object as soon as it's not needed.
     handleAvailabilityChange(availability.value);
     availability.onchange = function() { handleAvailabilityChange(this.value); };
   }).catch(function() {
-    // Availability monitoring is not supported by the platform, so discovery of presentation
-    // displays will happen only after request.start() is called.  Pretend the
-    // devices are available for simplicity; or, one could implement a third state for the
-    // button.
+    // Availability monitoring is not supported by the platform, so discovery of
+    // presentation displays will happen only after request.start() is called.
+    // Pretend the devices are available for simplicity; or, one could implement
+    // a third state for the button.
     handleAvailabilityChange(true);
   });
 &lt;/script&gt;
@@ -392,13 +440,13 @@
       </section>
       <section>
         <h3>
-          Handling an event for a UA initiated presentation example
+          Handling an event for a controlling UA initiated presentation example
         </h3>
         <pre class="example highlight">
 &lt;!-- controller.html --&gt;
 &lt;head&gt;
   &lt;!-- Setting presentation.defaultRequest allows the page to specify the
-       PresentationRequest to use when the UA initiates a presentation. --&gt;
+       PresentationRequest to use when the controlling UA initiates a presentation. --&gt;
 &lt;/head&gt;
 &lt;script&gt;
   navigator.presentation.defaultRequest = new PresentationRequest(defaultUrl);
@@ -536,12 +584,12 @@
         <p>
           The <dfn>set of presentations</dfn>, initially empty, contains the
           <a>presentation</a>s created by the <a>controlling browsing
-          contexts</a> for the user agent (or a specific user profile within
-          the user agent). The <a>set of presentations</a> is represented by a
-          list of tuples, where each tuple consists of a <a>presentation
-          URL</a>, a <a>presentation identifier</a>, and the <a>presentation
-          connection</a> itself. The <a>presentation URL</a> and
-          <a>presentation identifier</a> uniquely identify the
+          contexts</a> for the controlling user agent (or a specific user
+          profile within that user agent). The <a>set of presentations</a> is
+          represented by a list of tuples, where each tuple consists of a
+          <a>presentation URL</a>, a <a>presentation identifier</a>, and the
+          <a>presentation connection</a> itself. The <a>presentation URL</a>
+          and <a>presentation identifier</a> uniquely identify the
           <a>presentation</a>.
         </p>
       </section>
@@ -551,7 +599,9 @@
         </h3>
         <p>
           Each <a>presentation connection</a> is represented by a
-          <a>PresentationConnection</a> object.
+          <a>PresentationConnection</a> object. Both the <a>controlling user
+          agent</a> and <a>receiving user agent</a> must implement
+          <a>PresentationConnection</a>.
         </p>
         <pre class="idl">
           enum PresentationConnectionState { "connected", "closed", "terminated" };
@@ -750,7 +800,7 @@
             Terminating a presentation
           </h4>
           <p>
-            When the user agent is to <dfn data-lt=
+            When a user agent is to <dfn data-lt=
             "terminate-algorithm">terminate a presentation</dfn> using
             <em>connection</em>, it MUST run the following steps:
           </p>
@@ -826,6 +876,12 @@
               </ol>
             </li>
           </ol>
+          <p class="note">
+            This algorithm needs to be refined with different implementations
+            on the controlling browsing context and the receiving browsing
+            context. Alternatively, <code>terminate</code> needs to move to a
+            controller-only interface.
+          </p>
         </section>
         <section>
           <h4>
@@ -876,14 +932,20 @@
         <pre class="idl">
           interface PresentationAvailability : EventTarget {
             readonly attribute boolean value;
+
             attribute EventHandler onchange;
           };
-
-</pre>
+        </pre>
         <p>
           A <a><code>PresentationAvailability</code></a> object is associated
-          with a <a>presentation display</a> and represents its
-          <dfn>presentation display availability</dfn>.
+          with available <a>presentation displays</a> and represents the
+          <dfn>presentation display availability</dfn> for a presentation
+          request. The <a><code>PresentationAvailability</code></a> object
+          SHOULD be implemented in a <a>controlling browsing context</a> by a
+          <a>controlling user agent</a>, but may be omitted if the
+          <a>controlling user agent</a> cannot <a>monitor the list of available
+          presentation displays</a> without a pending request to <a>start a
+          presentation connection</a>.
         </p>
         <p>
           The <dfn for="PresentationAvailability">value</dfn> attribute MUST
@@ -1055,7 +1117,15 @@
             attribute EventHandler onconnectionavailable;
           };
 
-</pre>
+        </pre>
+        <p>
+          A <a><code>PresentationRequest</code></a> object is associated with a
+          request to initiate or reconnect to a presentation made by a
+          <a>controlling browsing context</a>. The
+          <a><code>PresentationRequest</code></a> object MUST be implemented in
+          a <a>controlling browsing context</a> provided by a <a>controlling
+          user agent</a>.
+        </p>
         <p>
           When a <a><code>PresentationRequest</code></a> is constructed, the
           given <code>url</code> MUST be used as the <dfn>presentation request
@@ -1501,7 +1571,7 @@
               required PresentationConnection connection;
             };
 
-</pre>
+          </pre>
           <p>
             An event named <code>connectionavailable</code> is fired on a
             <a>PresentationRequest</a> when a connection associated with the
@@ -1512,14 +1582,19 @@
             to the <a><code>PresentationConnection</code></a> object that was
             created. The event is fired for all connections that are created
             for the <a>controller</a>, either by the <a>controller</a> calling
-            <code>start()</code> or <code>reconnect()</code>, or by the UA
-            creating a connection on the controller's behalf via <a for=
+            <code>start()</code> or <code>reconnect()</code>, or by the
+            <a>controlling user agent</a> creating a connection on the
+            controller's behalf via <a for=
             "Presentation"><code>defaultRequest</code></a>.
           </p>
           <p>
-            The UA MUST fire the event as soon as it can create the
-            <a><code>PresentationConnection</code></a> associated with the
-            event.
+            The <a>controlling user agent</a> MUST fire the event as soon as it
+            can create the <a><code>PresentationConnection</code></a>
+            associated with the event.
+          </p>
+          <p class="note">
+            This section needs to be split and written from the point of view
+            of both the controlling user agent and the presenting user agent.
           </p>
         </section>
       </section>
@@ -1534,12 +1609,14 @@
             attribute EventHandler onconnectionavailable;
           };
 
-</pre>
+        </pre>
         <p>
           The <a>PresentationReceiver</a> object is available to a <a>receiving
           browsing context</a> in order to access the <a data-lt=
           "controlling browsing context">controlling browsing context</a> and
-          communicate with them.
+          communicate with it. The <a><code>PresentationReceiver</code></a>
+          object MUST be implemented in a <a>receiving browsing context</a>
+          provided by a <a>receiving user agent</a>.
         </p>
         <section>
           <h4>
@@ -1743,9 +1820,10 @@
           </h4>
           <p>
             If set by the <a>controller</a>, the <a for=
-            "Presentation">defaultRequest</a> SHOULD be used by the UA as the
-            <dfn>default presentation request</dfn> for that controller. When
-            the UA wishes to initiate a <a>PresentationConnection</a> on the
+            "Presentation">defaultRequest</a> SHOULD be used by the
+            <a>controlling user agent</a> as the <dfn>default presentation
+            request</dfn> for that controller. When the <a>controlling user
+            agent</a> wishes to initiate a <a>PresentationConnection</a> on the
             controller's behalf, it MUST <a>start a presentation connection</a>
             using the <a>default presentation request</a> for the
             <a>controller</a> (as if the controller had called
@@ -1769,6 +1847,11 @@
             may be cleaner to define a separate set of steps for initiating a
             default presentation.
           </div>
+          <p class="note">
+            This section needs to be updated to split the interface into two
+            partial interfaces, one for the presenting user agent and one for
+            the receiving user agent.
+          </p>
         </section>
       </section>
     </section>

--- a/index.html
+++ b/index.html
@@ -264,8 +264,9 @@
               Web browsers that conform to the specifications of a
               <a>controlling user agent</a> must be able to start and control
               presentations by providing a <a>controlling browsing context</a>
-              as described in this specification. This context MUST implement
-              the <a><code>PresentationConnection</code></a>,
+              as described in this specification. This context implements the
+              <a><code>Presentation</code></a>,
+              <a><code>PresentationConnection</code></a>,
               <a><code>PresentationConnectionAvailableEvent</code></a>, and
               <a><code>PresentationRequest</code></a> interfaces.
             </p>
@@ -278,7 +279,8 @@
               Web browsers that conform to the specifications of a <a>receiving
               user agent</a> must be able to render presentations by providing
               a <a>receiving browsing context</a> as described in this
-              specification. This context must implement the
+              specification. This context implements the
+              <a><code>Presentation</code></a>,
               <a><code>PresentationConnection</code></a>,
               <a><code>PresentationConnectionAvailableEvent</code></a>, and
               <a><code>PresentationReceiver</code></a> interfaces.
@@ -286,13 +288,12 @@
           </dd>
         </dl>
         <p>
-          One user agent may act both as an <a>controlling user agent</a> and
-          as a <a>receiving user agent</a>, if it provides both browsing
-          contexts and implements all of their required interfaces. This can
-          happen when the the same user agent is able to host the
-          <a>controlling browsing context</a> and the <a>receiving browsing
-          context</a> for a presentation, as in the <a>1-UA</a> implementation
-          of the API.
+          One user agent may act both as a <a>controlling user agent</a> and as
+          a <a>receiving user agent</a>, if it provides both browsing contexts
+          and implements all of their required interfaces. This can happen when
+          the same user agent is able to host the <a>controlling browsing
+          context</a> and the <a>receiving browsing context</a> for a
+          presentation, as in the <a>1-UA</a> implementation of the API.
         </p>
       </section>
     </section>
@@ -600,7 +601,7 @@
         <p>
           Each <a>presentation connection</a> is represented by a
           <a>PresentationConnection</a> object. Both the <a>controlling user
-          agent</a> and <a>receiving user agent</a> must implement
+          agent</a> and <a>receiving user agent</a> MUST implement
           <a>PresentationConnection</a>.
         </p>
         <pre class="idl">
@@ -936,12 +937,12 @@
           A <a><code>PresentationAvailability</code></a> object is associated
           with available <a>presentation displays</a> and represents the
           <dfn>presentation display availability</dfn> for a presentation
-          request. The <a><code>PresentationAvailability</code></a> object
-          SHOULD be implemented in a <a>controlling browsing context</a> by a
-          <a>controlling user agent</a>, but may be omitted if the
-          <a>controlling user agent</a> cannot <a>monitor the list of available
-          presentation displays</a> without a pending request to <a>start a
-          presentation connection</a>.
+          request. If the <a>controlling user agent</a> can <a>monitor the list
+          of available presentation displays</a> in the background (without a
+          pending request to <code><a for=
+          "PresentationRequest">start</a>()</code>), the
+          <a><code>PresentationAvailability</code></a> object MUST be
+          implemented in a <a>controlling browsing context</a>.
         </p>
         <p>
           The <dfn for="PresentationAvailability">value</dfn> attribute MUST
@@ -1793,6 +1794,11 @@
           partial interface Navigator {
             [SameObject] readonly attribute Presentation presentation;
           };
+
+          interface Presentation {
+            attribute PresentationRequest? defaultRequest;
+            [SameObject] readonly attribute PresentationReceiver? receiver;
+          };
         
 </pre>
         <p>
@@ -1804,19 +1810,10 @@
             Controlling user agent
           </h4>
           <p>
-            The following partial interface MUST be implemented by a
-            <a>controlling user agent</a>:
-          </p>
-          <pre class="idl">
-            partial interface Presentation {
-              attribute PresentationRequest? defaultRequest;
-            };
-          
-</pre>
-          <p>
-            The <dfn for="Presentation"><code>defaultRequest</code></dfn> MUST
-            return the <a>default presentation request</a> if any,
-            <code>null</code> otherwise.
+            In a <a>controlling user agent</a>, the <dfn for=
+            "Presentation"><code>defaultRequest</code></dfn> MUST return the
+            <a>default presentation request</a> if any, <code>null</code>
+            otherwise.
           </p>
           <p>
             If set by the <a>controller</a>, the <a for=
@@ -1853,21 +1850,11 @@
             Receiving user agent
           </h4>
           <p>
-            The following partial interface MUST be implemented by a
-            <a>receiving user agent</a>:
-          </p>
-          <pre>
-          partial interface Presentation {
-            [SameObject]
-            readonly attribute PresentationReceiver? receiver;
-          };
-          
-</pre>
-          <p>
-            The <dfn for="Presentation"><code>receiver</code></dfn> MUST return
-            <code>null</code> if the current <a>browsing context</a> is not a
-            <a>receiving browsing context</a> and return a
-            <a><code>PresentationReceiver</code></a> instance otherwise.
+            In a <a>receiving user agent</a>, <dfn for=
+            "Presentation"><code>receiver</code></dfn> MUST return
+            <a><code>PresentationReceiver</code></a> instance in a <a>receiving
+            browsing context</a>. In any other <a>browsing context</a>, it MUST
+            return <code>null</code>.
           </p>
         </section>
       </section>

--- a/index.html
+++ b/index.html
@@ -266,7 +266,7 @@
               presentations by providing a <a>controlling browsing context</a>
               as described in this specification. This context MUST implement
               the <a><code>PresentationConnection</code></a>,
-              <a><code>PresentationConnectionAvailable</code></a>, and
+              <a><code>PresentationConnectionAvailableEvent</code></a>, and
               <a><code>PresentationRequest</code></a> interfaces.
             </p>
           </dd>
@@ -280,7 +280,7 @@
               a <a>receiving browsing context</a> as described in this
               specification. This context must implement the
               <a><code>PresentationConnection</code></a>,
-              <a><code>PresentationConnectionAvailable</code></a>, and
+              <a><code>PresentationConnectionAvailableEvent</code></a>, and
               <a><code>PresentationReceiver</code></a> interfaces.
             </p>
           </dd>

--- a/index.html
+++ b/index.html
@@ -1884,10 +1884,10 @@
         The <code>change</code> event fired on the
         <a>PresentationAvailability</a> object reveals one bit of information
         about the presence (or non-presence) of a <a>presentation display</a>
-        typically discovered through the local area network. This could be
-        used in conjunction with other information for fingerprinting the
-        user. However, this information is also dependent on the user's local
-        network context, so the risk is minimized.
+        typically discovered through the local area network. This could be used
+        in conjunction with other information for fingerprinting the user.
+        However, this information is also dependent on the user's local network
+        context, so the risk is minimized.
       </p>
       <h3>
         Cross-origin access
@@ -1902,39 +1902,38 @@
       <p>
         This design allows controlling contexts from different domains to
         connect to a shared presentation resource. The security of the
-        presentation ID prevents arbitrary pages from connecting to an
-        existing presentation.
+        presentation ID prevents arbitrary pages from connecting to an existing
+        presentation.
       </p>
       <p>
         This specification does not prohibit a user agent from publishing
-        information about its <a>set of presentations</a>. The group
-        envisions a user agent on another device (distinct from the
-        controller or presentation) becoming authorized to reconnect to the
-        presentation, either by user action or by discovering the
-        presentation's URL and id.
+        information about its <a>set of presentations</a>. The group envisions
+        a user agent on another device (distinct from the controller or
+        presentation) becoming authorized to reconnect to the presentation,
+        either by user action or by discovering the presentation's URL and id.
       </p>
       <div class="issue">
-        This section should provide informative guidance as to what
-        constitutes a reasonable context for a Web page to become authorized
-        to control a presentation connection.
+        This section should provide informative guidance as to what constitutes
+        a reasonable context for a Web page to become authorized to control a
+        presentation connection.
       </div>
       <h3>
         Device Access
       </h3>
       <p>
         The presentation API abstracts away what "local" means for displays,
-        meaning that it exposes network-accessible displays as though they
-        were local displays. The Presentation API requires user permission
-        for a page to access any display to mitigate issues that could arise,
-        such as showing unwanted content on a display viewable by others.
+        meaning that it exposes network-accessible displays as though they were
+        local displays. The Presentation API requires user permission for a
+        page to access any display to mitigate issues that could arise, such as
+        showing unwanted content on a display viewable by others.
       </p>
       <h3>
         Temporary identifiers and browser state
       </h3>
       <p>
         The presentation URL and presentation ID can be used to connect to a
-        presentation from another browsing context. They can be intercepted
-        if an attacker can inject content into the controlling page.
+        presentation from another browsing context. They can be intercepted if
+        an attacker can inject content into the controlling page.
       </p>
       <div class="issue">
         Should we restrict the API to some extent in non secure contexts?
@@ -1945,14 +1944,14 @@
       <p>
         The content displayed on the presentation is different from the
         controller. In particular, if the user is logged in in both contexts,
-        then logs out of the <a>controlling browsing context</a>, she will
-        not be automatically logged out from the <a>receiving browsing
-          context</a>. Applications that use authentication should pay extra
-        care when communicating between devices.
+        then logs out of the <a>controlling browsing context</a>, she will not
+        be automatically logged out from the <a>receiving browsing context</a>.
+        Applications that use authentication should pay extra care when
+        communicating between devices.
       </p>
       <p>
-        The set of presentations known to the user agent should be cleared
-        when the user requests to "clear browsing data."
+        The set of presentations known to the user agent should be cleared when
+        the user requests to "clear browsing data."
       </p>
       <div class="issue" data-number="14"></div>
       <div class="issue">
@@ -1965,9 +1964,9 @@
       <p>
         This spec will not mandate communication protocols between the
         <a>controlling browsing context</a> and the <a>receiving browsing
-          context</a>, but it should set some guarantees of message
-        confidentiality and authenticity between corresponding
-        <a>presentation connections</a>.
+        context</a>, but it should set some guarantees of message
+        confidentiality and authenticity between corresponding <a>presentation
+        connections</a>.
       </p>
       <div class="issue" data-number="80"></div>
     </section>

--- a/index.html
+++ b/index.html
@@ -265,9 +265,9 @@
               <a>controlling user agent</a> must be able to start and control
               presentations by providing a <a>controlling browsing context</a>
               as described in this specification. This context MUST implement
-              the <code>PresentationConnection</code>,
-              <code>PresentationConnectionAvailable</code>, and
-              <code>PresentationRequest</code> interfaces.
+              the <a><code>PresentationConnection</code></a>,
+              <a><code>PresentationConnectionAvailable</code></a>, and
+              <a><code>PresentationRequest</code></a> interfaces.
             </p>
           </dd>
           <dt>
@@ -279,9 +279,9 @@
               user agent</a> must be able to render presentations by providing
               a <a>receiving browsing context</a> as described in this
               specification. This context must implement the
-              <code>PresentationConnection</code>,
-              <code>PresentationConnectionAvailable</code>, and
-              <code>PresentationReceiver</code> interfaces.
+              <a><code>PresentationConnection</code></a>,
+              <a><code>PresentationConnectionAvailable</code></a>, and
+              <a><code>PresentationReceiver</code></a> interfaces.
             </p>
           </dd>
         </dl>
@@ -1650,7 +1650,7 @@
                 </li>
                 <li>
                   <a>Queue a task</a> to <a>fire</a> an event named
-                  <code>connectionavailable</code> at <a for=
+                  <code>connectionavailable</code> at <a data-lt=
                   "PresentationReceiver"><code>presentation.receiver</code></a>.
                 </li>
               </ol>
@@ -1867,7 +1867,7 @@
             The <dfn for="Presentation"><code>receiver</code></dfn> MUST return
             <code>null</code> if the current <a>browsing context</a> is not a
             <a>receiving browsing context</a> and return a
-            <a>PresentationReceiver</a> instance otherwise.
+            <a><code>PresentationReceiver</code></a> instance otherwise.
           </p>
         </section>
       </section>

--- a/index.html
+++ b/index.html
@@ -801,8 +801,8 @@
           </h4>
           <p>
             When a <a>controlling user agent</a> is to <dfn data-lt=
-            "terminate-algorithm-controller">terminate a presentation</dfn> using
-            <em>connection</em>, it MUST run the following steps:
+            "terminate-algorithm-controller">terminate a presentation</dfn>
+            using <em>connection</em>, it MUST run the following steps:
           </p>
           <ol>
             <li>
@@ -832,24 +832,24 @@
                     </li>
                   </ol>
                 </li>
-                <li>Signal the <a>receiving user agent</a>
-                to <a data-lt="terminate-algorithm-receiver">terminate the
-                presentation</a> using an implementation specific mechanism.</a>
+                <li>Signal the <a>receiving user agent</a> to <a data-lt=
+                "terminate-algorithm-receiver">terminate the presentation</a>
+                using an implementation specific mechanism.
                 </li>
               </ol>
             </li>
           </ol>
           <p>
             When a <a>receiving user agent</a> is to <dfn data-lt=
-            "terminate-algorithm-receiver">terminate a presentation</dfn>
-            using <em>connection</em>, it MUST close the <a>receiving browsing
-            context</a> (equivalent to calling <code> window.close()</code>).
+            "terminate-algorithm-receiver">terminate a presentation</dfn> using
+            <em>connection</em>, it MUST close the <a>receiving browsing
+            context</a> (equivalent to calling <code>window.close()</code>).
           </p>
           <p>
-            In addition, the <a>receiving user agent</a> hosting
-            the <a>receiving browsing context</a> that was closed SHOULD signal
-            each <a>controlling user agent</a> that was connected to
-            the <a>presentation</a>.  In response, each <a>controlling user
+            In addition, the <a>receiving user agent</a> hosting the
+            <a>receiving browsing context</a> that was closed SHOULD signal
+            each <a>controlling user agent</a> that was connected to the
+            <a>presentation</a>. In response, each <a>controlling user
             agent</a> SHOULD run the following steps:
           </p>
           <ol>
@@ -933,7 +933,8 @@
 
             attribute EventHandler onchange;
           };
-        </pre>
+        
+</pre>
         <p>
           A <a><code>PresentationAvailability</code></a> object is associated
           with available <a>presentation displays</a> and represents the
@@ -1115,7 +1116,8 @@
             attribute EventHandler onconnectionavailable;
           };
 
-        </pre>
+        
+</pre>
         <p>
           A <a><code>PresentationRequest</code></a> object is associated with a
           request to initiate or reconnect to a presentation made by a
@@ -1569,30 +1571,22 @@
               required PresentationConnection connection;
             };
 
-          </pre>
+          
+</pre>
           <p>
-            An event named <code>connectionavailable</code> is fired on a
-            <a>PresentationRequest</a> when a connection associated with the
-            object is created. It is fired at the <a>PresentationRequest</a>
-            instance, using the <a>PresentationConnectionAvailableEvent</a>
-            interface, with the <a for=
-            "PresentationConnectionAvailableEvent">connection</a> attribute set
-            to the <a><code>PresentationConnection</code></a> object that was
-            created. The event is fired for all connections that are created
-            for the <a>controller</a>, either by the <a>controller</a> calling
-            <code>start()</code> or <code>reconnect()</code>, or by the
-            <a>controlling user agent</a> creating a connection on the
-            controller's behalf via <a for=
+            A <a>controlling user agent</a> MUST fire an event named
+            <code>connectionavailable</code> on a <a>PresentationRequest</a>
+            when a connection associated with the object is created. It is
+            fired at the <a>PresentationRequest</a> instance, using the
+            <a>PresentationConnectionAvailableEvent</a> interface, with the
+            <a for="PresentationConnectionAvailableEvent">connection</a>
+            attribute set to the <a><code>PresentationConnection</code></a>
+            object that was created. The event is fired for all connections
+            that are created for the <a>controller</a>, either by the
+            <a>controller</a> calling <code>start()</code> or
+            <code>reconnect()</code>, or by the <a>controlling user agent</a>
+            creating a connection on the controller's behalf via <a for=
             "Presentation"><code>defaultRequest</code></a>.
-          </p>
-          <p>
-            The <a>controlling user agent</a> MUST fire the event as soon as it
-            can create the <a><code>PresentationConnection</code></a>
-            associated with the event.
-          </p>
-          <p class="note">
-            This section needs to be split and written from the point of view
-            of both the controlling user agent and the presenting user agent.
           </p>
         </section>
       </section>
@@ -1607,7 +1601,8 @@
             attribute EventHandler onconnectionavailable;
           };
 
-        </pre>
+        
+</pre>
         <p>
           The <a>PresentationReceiver</a> object is available to a <a>receiving
           browsing context</a> in order to access the <a data-lt=
@@ -1622,8 +1617,8 @@
             browsing context
           </h4>
           <p>
-            When the user agent is to start <dfn>monitoring incoming
-            presentation connections</dfn> in a <a>receiving browsing
+            When the <a>receiving user agent</a> is to start <dfn>monitoring
+            incoming presentation connections</dfn> in a <a>receiving browsing
             context</a> from <a>controlling browsing contexts</a>, it MUST run
             the following steps:
           </p>
@@ -1664,6 +1659,23 @@
               </ol>
             </li>
           </ol>
+          <p>
+            A <a>receiving user agent</a> MUST fire an event named
+            <code>connectionavailable</code> on a <a>PresentationReceiver</a>
+            when a connection associated with the object is created. It is
+            fired at the <a>PresentationReceiver</a> instance, using the
+            <a>PresentationConnectionAvailableEvent</a> interface, with the
+            <a for="PresentationConnectionAvailableEvent">connection</a>
+            attribute set to the <a><code>PresentationConnection</code></a>
+            object that was created. The event is fired for all connections
+            that are created for the <a>presentation</a> when <a>monitoring
+            incoming presentation connections</a>.
+          </p>
+          <p>
+            The <a>receiving user agent</a> MUST fire the event as soon as it
+            can create the <a><code>PresentationConnection</code></a>
+            associated with the event.
+          </p>
         </section>
         <section>
           <h4>
@@ -1784,38 +1796,31 @@
           partial interface Navigator {
             [SameObject] readonly attribute Presentation presentation;
           };
-
+        
 </pre>
         <p>
           The <dfn for="Navigator"><code>presentation</code></dfn> attribute is
           used to retrieve an instance of the <a>Presentation</a> interface.
         </p>
-        <pre class="idl">
-          interface Presentation {
-            // This API used by the controlling browsing context.
-            attribute PresentationRequest? defaultRequest;
-
-            // This API is available on the receiving browsing context.
-            [SameObject]
-            readonly attribute PresentationReceiver? receiver;
-          };
-
-</pre>
-        <p>
-          The <dfn for="Presentation"><code>defaultRequest</code></dfn> MUST
-          return the <a>default presentation request</a> if any,
-          <code>null</code> otherwise.
-        </p>
-        <p>
-          The <dfn for="Presentation"><code>receiver</code></dfn> MUST return
-          <code>null</code> if the current <a>browsing context</a> is not a
-          <a>receiving browsing context</a> and return a
-          <a>PresentationReceiver</a> instance otherwise.
-        </p>
         <section>
           <h4>
-            Setting the default presentation request
+            Controlling user agent
           </h4>
+          <p>
+            The following partial interface MUST be implemented by a
+            <a>controlling user agent</a>:
+          </p>
+          <pre class="idl">
+            partial interface Presentation {
+              attribute PresentationRequest? defaultRequest;
+            };
+          
+</pre>
+          <p>
+            The <dfn for="Presentation"><code>defaultRequest</code></dfn> MUST
+            return the <a>default presentation request</a> if any,
+            <code>null</code> otherwise.
+          </p>
           <p>
             If set by the <a>controller</a>, the <a for=
             "Presentation">defaultRequest</a> SHOULD be used by the
@@ -1828,10 +1833,10 @@
             <code>defaultRequest.start()</code>).
           </p>
           <p>
-            The user agent SHOULD initiate presentation using the <a>default
-            presentation request</a> only when the user has expressed an
-            intention to do so, for example by clicking a button in the
-            browser.
+            The <a>controlling user agent</a> SHOULD initiate presentation
+            using the <a>default presentation request</a> only when the user
+            has expressed an intention to do so, for example by clicking a
+            button in the browser.
           </p>
           <div class="note">
             Not all user agents may support initiation of a presentation
@@ -1845,121 +1850,139 @@
             may be cleaner to define a separate set of steps for initiating a
             default presentation.
           </div>
-          <p class="note">
-            This section needs to be updated to split the interface into two
-            partial interfaces, one for the presenting user agent and one for
-            the receiving user agent.
+        </section>
+        <section>
+          <h4>
+            Receiving user agent
+          </h4>
+          <p>
+            The following partial interface MUST be implemented by a
+            <a>receiving user agent</a>:
+          </p>
+          <pre>
+          partial interface Presentation {
+            [SameObject]
+            readonly attribute PresentationReceiver? receiver;
+          };
+          
+</pre>
+          <p>
+            The <dfn for="Presentation"><code>receiver</code></dfn> MUST return
+            <code>null</code> if the current <a>browsing context</a> is not a
+            <a>receiving browsing context</a> and return a
+            <a>PresentationReceiver</a> instance otherwise.
           </p>
         </section>
       </section>
-    </section>
-    <section>
-      <h2>
-        Security and privacy considerations
-      </h2>
-      <div class="issue" data-number="45"></div>
-      <h3>
-        Personally identifiable information
-      </h3>
-      <p>
-        The <code>change</code> event fired on the
-        <a>PresentationAvailability</a> object reveals one bit of information
-        about the presence (or non-presence) of a <a>presentation display</a>
-        typically discovered through the local area network. This could be used
-        in conjunction with other information for fingerprinting the user.
-        However, this information is also dependent on the user's local network
-        context, so the risk is minimized.
-      </p>
-      <h3>
-        Cross-origin access
-      </h3>
-      <p>
-        A <a>presentation</a> is allowed to be accessed across origins; the
-        presentation URL and presentation ID used to create the presentation
-        are the only information needed to reconnect to a connection from any
-        origin in that user agent. In other words, a presentation is not tied
-        to a particular opening origin.
-      </p>
-      <p>
-        This design allows controlling contexts from different domains to
-        connect to a shared presentation resource. The security of the
-        presentation ID prevents arbitrary pages from connecting to an existing
-        presentation.
-      </p>
-      <p>
-        This specification does not prohibit a user agent from publishing
-        information about its <a>set of presentations</a>. The group envisions
-        a user agent on another device (distinct from the controller or
-        presentation) becoming authorized to reconnect to the presentation,
-        either by user action or by discovering the presentation's URL and id.
-      </p>
-      <div class="issue">
-        This section should provide informative guidance as to what constitutes
-        a reasonable context for a Web page to become authorized to control a
-        presentation connection.
-      </div>
-      <h3>
-        Device Access
-      </h3>
-      <p>
-        The presentation API abstracts away what "local" means for displays,
-        meaning that it exposes network-accessible displays as though they were
-        local displays. The Presentation API requires user permission for a
-        page to access any display to mitigate issues that could arise, such as
-        showing unwanted content on a display viewable by others.
-      </p>
-      <h3>
-        Temporary identifiers and browser state
-      </h3>
-      <p>
-        The presentation URL and presentation ID can be used to connect to a
-        presentation from another browsing context. They can be intercepted if
-        an attacker can inject content into the controlling page.
-      </p>
-      <div class="issue">
-        Should we restrict the API to some extent in non secure contexts?
-      </div>
-      <h3>
-        Incognito mode and clearing of browsing data
-      </h3>
-      <p>
-        The content displayed on the presentation is different from the
-        controller. In particular, if the user is logged in in both contexts,
-        then logs out of the <a>controlling browsing context</a>, she will not
-        be automatically logged out from the <a>receiving browsing context</a>.
-        Applications that use authentication should pay extra care when
-        communicating between devices.
-      </p>
-      <p>
-        The set of presentations known to the user agent should be cleared when
-        the user requests to "clear browsing data."
-      </p>
-      <div class="issue" data-number="14"></div>
-      <div class="issue">
-        The spec should clarify what is to happen to the set of known
-        presentations in "incognito" (private browsing context) mode.
-      </div>
-      <h3>
-        Messaging between presentation connections
-      </h3>
-      <p>
-        This spec will not mandate communication protocols between the
-        <a>controlling browsing context</a> and the <a>receiving browsing
-        context</a>, but it should set some guarantees of message
-        confidentiality and authenticity between corresponding <a>presentation
-        connections</a>.
-      </p>
-      <div class="issue" data-number="80"></div>
-    </section>
-    <section>
-      <h2>
-        Acknowledgments
-      </h2>
-      <p>
-        Thanks to Wayne Carr, Louay Bassbouss, Anssi Kostiainen, 闵洪波 (Hongbo
-        Min), Anton Vayvod, and Mark Foltz for help with editing, reviews and
-        feedback to this draft.
-      </p>
+      <section>
+        <h2>
+          Security and privacy considerations
+        </h2>
+        <div class="issue" data-number="45"></div>
+        <h3>
+          Personally identifiable information
+        </h3>
+        <p>
+          The <code>change</code> event fired on the
+          <a>PresentationAvailability</a> object reveals one bit of information
+          about the presence (or non-presence) of a <a>presentation display</a>
+          typically discovered through the local area network. This could be
+          used in conjunction with other information for fingerprinting the
+          user. However, this information is also dependent on the user's local
+          network context, so the risk is minimized.
+        </p>
+        <h3>
+          Cross-origin access
+        </h3>
+        <p>
+          A <a>presentation</a> is allowed to be accessed across origins; the
+          presentation URL and presentation ID used to create the presentation
+          are the only information needed to reconnect to a connection from any
+          origin in that user agent. In other words, a presentation is not tied
+          to a particular opening origin.
+        </p>
+        <p>
+          This design allows controlling contexts from different domains to
+          connect to a shared presentation resource. The security of the
+          presentation ID prevents arbitrary pages from connecting to an
+          existing presentation.
+        </p>
+        <p>
+          This specification does not prohibit a user agent from publishing
+          information about its <a>set of presentations</a>. The group
+          envisions a user agent on another device (distinct from the
+          controller or presentation) becoming authorized to reconnect to the
+          presentation, either by user action or by discovering the
+          presentation's URL and id.
+        </p>
+        <div class="issue">
+          This section should provide informative guidance as to what
+          constitutes a reasonable context for a Web page to become authorized
+          to control a presentation connection.
+        </div>
+        <h3>
+          Device Access
+        </h3>
+        <p>
+          The presentation API abstracts away what "local" means for displays,
+          meaning that it exposes network-accessible displays as though they
+          were local displays. The Presentation API requires user permission
+          for a page to access any display to mitigate issues that could arise,
+          such as showing unwanted content on a display viewable by others.
+        </p>
+        <h3>
+          Temporary identifiers and browser state
+        </h3>
+        <p>
+          The presentation URL and presentation ID can be used to connect to a
+          presentation from another browsing context. They can be intercepted
+          if an attacker can inject content into the controlling page.
+        </p>
+        <div class="issue">
+          Should we restrict the API to some extent in non secure contexts?
+        </div>
+        <h3>
+          Incognito mode and clearing of browsing data
+        </h3>
+        <p>
+          The content displayed on the presentation is different from the
+          controller. In particular, if the user is logged in in both contexts,
+          then logs out of the <a>controlling browsing context</a>, she will
+          not be automatically logged out from the <a>receiving browsing
+          context</a>. Applications that use authentication should pay extra
+          care when communicating between devices.
+        </p>
+        <p>
+          The set of presentations known to the user agent should be cleared
+          when the user requests to "clear browsing data."
+        </p>
+        <div class="issue" data-number="14"></div>
+        <div class="issue">
+          The spec should clarify what is to happen to the set of known
+          presentations in "incognito" (private browsing context) mode.
+        </div>
+        <h3>
+          Messaging between presentation connections
+        </h3>
+        <p>
+          This spec will not mandate communication protocols between the
+          <a>controlling browsing context</a> and the <a>receiving browsing
+          context</a>, but it should set some guarantees of message
+          confidentiality and authenticity between corresponding
+          <a>presentation connections</a>.
+        </p>
+        <div class="issue" data-number="80"></div>
+      </section>
+      <section>
+        <h2>
+          Acknowledgments
+        </h2>
+        <p>
+          Thanks to Wayne Carr, Louay Bassbouss, Anssi Kostiainen, 闵洪波 (Hongbo
+          Min), Anton Vayvod, and Mark Foltz for help with editing, reviews and
+          feedback to this draft.
+        </p>
+      </section>
     </section>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -1871,115 +1871,115 @@
           </p>
         </section>
       </section>
-      <section>
-        <h2>
-          Security and privacy considerations
-        </h2>
-        <div class="issue" data-number="45"></div>
-        <h3>
-          Personally identifiable information
-        </h3>
-        <p>
-          The <code>change</code> event fired on the
-          <a>PresentationAvailability</a> object reveals one bit of information
-          about the presence (or non-presence) of a <a>presentation display</a>
-          typically discovered through the local area network. This could be
-          used in conjunction with other information for fingerprinting the
-          user. However, this information is also dependent on the user's local
-          network context, so the risk is minimized.
-        </p>
-        <h3>
-          Cross-origin access
-        </h3>
-        <p>
-          A <a>presentation</a> is allowed to be accessed across origins; the
-          presentation URL and presentation ID used to create the presentation
-          are the only information needed to reconnect to a connection from any
-          origin in that user agent. In other words, a presentation is not tied
-          to a particular opening origin.
-        </p>
-        <p>
-          This design allows controlling contexts from different domains to
-          connect to a shared presentation resource. The security of the
-          presentation ID prevents arbitrary pages from connecting to an
-          existing presentation.
-        </p>
-        <p>
-          This specification does not prohibit a user agent from publishing
-          information about its <a>set of presentations</a>. The group
-          envisions a user agent on another device (distinct from the
-          controller or presentation) becoming authorized to reconnect to the
-          presentation, either by user action or by discovering the
-          presentation's URL and id.
-        </p>
-        <div class="issue">
-          This section should provide informative guidance as to what
-          constitutes a reasonable context for a Web page to become authorized
-          to control a presentation connection.
-        </div>
-        <h3>
-          Device Access
-        </h3>
-        <p>
-          The presentation API abstracts away what "local" means for displays,
-          meaning that it exposes network-accessible displays as though they
-          were local displays. The Presentation API requires user permission
-          for a page to access any display to mitigate issues that could arise,
-          such as showing unwanted content on a display viewable by others.
-        </p>
-        <h3>
-          Temporary identifiers and browser state
-        </h3>
-        <p>
-          The presentation URL and presentation ID can be used to connect to a
-          presentation from another browsing context. They can be intercepted
-          if an attacker can inject content into the controlling page.
-        </p>
-        <div class="issue">
-          Should we restrict the API to some extent in non secure contexts?
-        </div>
-        <h3>
-          Incognito mode and clearing of browsing data
-        </h3>
-        <p>
-          The content displayed on the presentation is different from the
-          controller. In particular, if the user is logged in in both contexts,
-          then logs out of the <a>controlling browsing context</a>, she will
-          not be automatically logged out from the <a>receiving browsing
+    </section>
+    <section>
+      <h2>
+        Security and privacy considerations
+      </h2>
+      <div class="issue" data-number="45"></div>
+      <h3>
+        Personally identifiable information
+      </h3>
+      <p>
+        The <code>change</code> event fired on the
+        <a>PresentationAvailability</a> object reveals one bit of information
+        about the presence (or non-presence) of a <a>presentation display</a>
+        typically discovered through the local area network. This could be
+        used in conjunction with other information for fingerprinting the
+        user. However, this information is also dependent on the user's local
+        network context, so the risk is minimized.
+      </p>
+      <h3>
+        Cross-origin access
+      </h3>
+      <p>
+        A <a>presentation</a> is allowed to be accessed across origins; the
+        presentation URL and presentation ID used to create the presentation
+        are the only information needed to reconnect to a connection from any
+        origin in that user agent. In other words, a presentation is not tied
+        to a particular opening origin.
+      </p>
+      <p>
+        This design allows controlling contexts from different domains to
+        connect to a shared presentation resource. The security of the
+        presentation ID prevents arbitrary pages from connecting to an
+        existing presentation.
+      </p>
+      <p>
+        This specification does not prohibit a user agent from publishing
+        information about its <a>set of presentations</a>. The group
+        envisions a user agent on another device (distinct from the
+        controller or presentation) becoming authorized to reconnect to the
+        presentation, either by user action or by discovering the
+        presentation's URL and id.
+      </p>
+      <div class="issue">
+        This section should provide informative guidance as to what
+        constitutes a reasonable context for a Web page to become authorized
+        to control a presentation connection.
+      </div>
+      <h3>
+        Device Access
+      </h3>
+      <p>
+        The presentation API abstracts away what "local" means for displays,
+        meaning that it exposes network-accessible displays as though they
+        were local displays. The Presentation API requires user permission
+        for a page to access any display to mitigate issues that could arise,
+        such as showing unwanted content on a display viewable by others.
+      </p>
+      <h3>
+        Temporary identifiers and browser state
+      </h3>
+      <p>
+        The presentation URL and presentation ID can be used to connect to a
+        presentation from another browsing context. They can be intercepted
+        if an attacker can inject content into the controlling page.
+      </p>
+      <div class="issue">
+        Should we restrict the API to some extent in non secure contexts?
+      </div>
+      <h3>
+        Incognito mode and clearing of browsing data
+      </h3>
+      <p>
+        The content displayed on the presentation is different from the
+        controller. In particular, if the user is logged in in both contexts,
+        then logs out of the <a>controlling browsing context</a>, she will
+        not be automatically logged out from the <a>receiving browsing
           context</a>. Applications that use authentication should pay extra
-          care when communicating between devices.
-        </p>
-        <p>
-          The set of presentations known to the user agent should be cleared
-          when the user requests to "clear browsing data."
-        </p>
-        <div class="issue" data-number="14"></div>
-        <div class="issue">
-          The spec should clarify what is to happen to the set of known
-          presentations in "incognito" (private browsing context) mode.
-        </div>
-        <h3>
-          Messaging between presentation connections
-        </h3>
-        <p>
-          This spec will not mandate communication protocols between the
-          <a>controlling browsing context</a> and the <a>receiving browsing
+        care when communicating between devices.
+      </p>
+      <p>
+        The set of presentations known to the user agent should be cleared
+        when the user requests to "clear browsing data."
+      </p>
+      <div class="issue" data-number="14"></div>
+      <div class="issue">
+        The spec should clarify what is to happen to the set of known
+        presentations in "incognito" (private browsing context) mode.
+      </div>
+      <h3>
+        Messaging between presentation connections
+      </h3>
+      <p>
+        This spec will not mandate communication protocols between the
+        <a>controlling browsing context</a> and the <a>receiving browsing
           context</a>, but it should set some guarantees of message
-          confidentiality and authenticity between corresponding
-          <a>presentation connections</a>.
-        </p>
-        <div class="issue" data-number="80"></div>
-      </section>
-      <section>
-        <h2>
-          Acknowledgments
-        </h2>
-        <p>
-          Thanks to Wayne Carr, Louay Bassbouss, Anssi Kostiainen, 闵洪波 (Hongbo
-          Min), Anton Vayvod, and Mark Foltz for help with editing, reviews and
-          feedback to this draft.
-        </p>
-      </section>
+        confidentiality and authenticity between corresponding
+        <a>presentation connections</a>.
+      </p>
+      <div class="issue" data-number="80"></div>
+    </section>
+    <section>
+      <h2>
+        Acknowledgments
+      </h2>
+      <p>
+        Thanks to Wayne Carr, Louay Bassbouss, Anssi Kostiainen, 闵洪波 (Hongbo
+        Min), Anton Vayvod, and Mark Foltz for help with editing, reviews and
+        feedback to this draft.
+      </p>
     </section>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -800,8 +800,8 @@
             Terminating a presentation
           </h4>
           <p>
-            When a user agent is to <dfn data-lt=
-            "terminate-algorithm">terminate a presentation</dfn> using
+            When a <a>controlling user agent</a> is to <dfn data-lt=
+            "terminate-algorithm-controller">terminate a presentation</dfn> using
             <em>connection</em>, it MUST run the following steps:
           </p>
           <ol>
@@ -812,12 +812,8 @@
                 <em>connection</em> is not <code>connected</code>, then abort
                 these steps.
                 </li>
-                <li>If <em>connection</em> is connected to a <a>receiving
-                browsing context</a>, close that context (equivalent to <code>
-                  window.close()</code>) and abort the following steps.
-                </li>
                 <li>Otherwise, for each <em>known connection</em> in the <a>set
-                of presentations</a> in the <a>controller</a>:
+                of presentations</a> in the <a>controlling user agent</a>:
                   <ol>
                     <li>If the <a>presentation identifier</a> of <em>known
                     connection</em> and <em>connection</em> are equal, and the
@@ -836,17 +832,25 @@
                     </li>
                   </ol>
                 </li>
-                <li>Close the <a>receiving browsing context</a>, using an
-                implementation specific mechanism.
+                <li>Signal the <a>receiving user agent</a>
+                to <a data-lt="terminate-algorithm-receiver">terminate the
+                presentation</a> using an implementation specific mechanism.</a>
                 </li>
               </ol>
             </li>
           </ol>
           <p>
-            The user agent hosting the <a>receiving browsing context</a> MAY
-            run the following steps on the <a>controller</a> when closing that
-            context in response to <code>terminate()</code> or
-            <code>window.close()</code>:
+            When a <a>receiving user agent</a> is to <dfn data-lt=
+            "terminate-algorithm-receiver">terminate a presentation</dfn>
+            using <em>connection</em>, it MUST close the <a>receiving browsing
+            context</a> (equivalent to calling <code> window.close()</code>).
+          </p>
+          <p>
+            In addition, the <a>receiving user agent</a> hosting
+            the <a>receiving browsing context</a> that was closed SHOULD signal
+            each <a>controlling user agent</a> that was connected to
+            the <a>presentation</a>.  In response, each <a>controlling user
+            agent</a> SHOULD run the following steps:
           </p>
           <ol>
             <li>
@@ -876,12 +880,6 @@
               </ol>
             </li>
           </ol>
-          <p class="note">
-            This algorithm needs to be refined with different implementations
-            on the controlling browsing context and the receiving browsing
-            context. Alternatively, <code>terminate</code> needs to move to a
-            controller-only interface.
-          </p>
         </section>
         <section>
           <h4>


### PR DESCRIPTION
This PR defines two conformance classes for the specification to address Issue #93:

* A controlling user agent provides the controlling browsing context and its associated interfaces/objects.
* A receiving user agent provides the receiving browsing context and its associated interfaces/objects.

The PR makes normative statements about each of them where it makes sense to do so.  In most cases I say that a particular user agent SHOULD or MUST implement a certain interface in the corresponding browsing context - perhaps there is a better way to make these normative statements.

I didn't try to regroup the definitions by conformance class in this PR, but that might make the spec read better in the long run.  For example, PresentationConnection is required by both UAs.  It may be clearer to have a common definition and then the management algorithms in UA-specific sections. I think that is better done in a different PR.

@tidoust please take a look as you had some specific thoughts about how to describe the conformance classes.
