### PR TITLE
Reorder api

### DIFF
--- a/index.html
+++ b/index.html
@@ -653,515 +653,74 @@
       </section>
       <section>
         <h3>
-          Interface <code>PresentationConnection</code>
+          Interface <code>Presentation</code>
         </h3>
-        <p>
-          Each <a>presentation connection</a> is represented by a
-          <a>PresentationConnection</a> object. Both the <a>controlling user
-          agent</a> and <a>receiving user agent</a> MUST implement
-          <a>PresentationConnection</a>.
-        </p>
         <pre class="idl">
-          enum PresentationConnectionState { "connected", "closed", "terminated" };
-          enum BinaryType { "blob", "arraybuffer" };
-
-          interface PresentationConnection : EventTarget {
-            readonly attribute DOMString? id;
-            readonly attribute PresentationConnectionState state;
-            void close();
-            void terminate();
-            attribute EventHandler onstatechange;
-
-            // Communication
-            attribute BinaryType binaryType;
-            attribute EventHandler onmessage;
-            void send (DOMString message);
-            void send (Blob data);
-            void send (ArrayBuffer data);
-            void send (ArrayBufferView data);
+          partial interface Navigator {
+            [SameObject] readonly attribute Presentation presentation;
           };
 
-</pre>
-        <div dfn-for="PresentationConnection" link-for=
-        "PresentationConnection">
-          <p>
-            The <dfn><code>id</code></dfn> attribute specifies the
-            <a>presentation connection</a>'s <a>presentation identifier</a>.
-          </p>
-          <p>
-            The <dfn><code>state</code></dfn> attribute represents the
-            <a>presentation connection</a>'s current state. It can take one of
-            the values of <a>PresentationConnectionState</a> depending on
-            connection state.
-          </p>
-          <p>
-            When the <code><dfn>close</dfn>()</code> method is called on a
-            <a>PresentationConnection</a>, the user agent MUST run the
-            algorithm to <a data-lt="close-algorithm">close a presentation
-            connection</a> with <a>PresentationConnection</a>.
-          </p>
-          <p>
-            When the <code><dfn>terminate</dfn>()</code> method is called on a
-            <a>PresentationConnection</a>, the user agent MUST run the
-            algorithm to <a data-lt="terminate-algorithm">terminate a
-            presentation</a> with <a>PresentationConnection</a>.
-          </p>
-          <p>
-            When the <code><dfn>send</dfn>()</code> method is called on a
-            <a>PresentationConnection</a> object with a <code>message</code>,
-            the user agent MUST run the algorithm to <a data-lt=
-            "algorithm-send">send a message through a
-            <code>PresentationConnection</code></a>.
-          </p>
-        </div>
-        <section>
-          <h4>
-            Sending a message through <code>PresentationConnection</code>
-          </h4>
-          <div class="note">
-            No specific transport for the connection between the <a>controlling
-            browsing context</a> and the <a>receiving browsing context</a> is
-            mandated, except that for multiple calls to <code><a for=
-            "PresentationConnection">send</a>()</code> it has to be ensured
-            that messages are delivered to the other end reliably and in
-            sequence. The transport should function equivalently to an
-            <a><code>RTCDataChannel</code></a> in reliable mode.
-          </div>
-          <p>
-            Let <dfn>presentation message data</dfn> be the payload data to be
-            transmitted between two browsing contexts. Let <dfn>presentation
-            message type</dfn> be the type of that data, one of
-            <code>text</code> and <code>binary</code>.
-          </p>
-          <p>
-            When the user agent is to <dfn data-lt="algorithm-send">send a
-            message through a <code>PresentationConnection</code> S</dfn>, it
-            MUST run the following steps:
-          </p>
-          <ol link-for="PresentationConnection">
-            <li>If the <a>state</a> property of <a>PresentationConnection</a>
-            is not <code>"connected"</code>, throw an
-            <code>InvalidStateError</code> exception.
-            </li>
-            <li>Let <a>presentation message type</a> <em>messageType</em> be
-            <code>binary</code> if <code>data</code> is one of
-            <code>ArrayBuffer</code>, <code>ArrayBufferView</code>, or
-            <code>Blob</code>. Let <em>messageType</em> be <code>text</code> if
-            <code>data</code> is of type <code>DOMString</code>)
-            </li>
-            <li>Assign the <dfn>destination browsing context</dfn> as follows:
-              <ol>
-                <li>Let the <a>destination browsing context</a> be the
-                <a>controlling browsing context</a> if
-                <code><a>send</a>()</code> is called in the <a>receiving
-                browsing context</a>.
-                </li>
-                <li>Let <a>destination browsing context</a> be the <a>receiving
-                browsing context</a> if <code><a>send</a>()</code> is called
-                from the <a>controlling browsing context</a>.
-                </li>
-              </ol>
-            </li>
-            <li>Using an implementation specific mechanism, transmit the
-            contents of the <code>data</code> argument as <a>presentation
-            message data</a> and <a>presentation message type</a>
-            <em>messageType</em> to the <a>destination browsing context</a>
-            side.
-            </li>
-          </ol>
-        </section>
-        <section>
-          <h4>
-            Receiving a message through <code>PresentationConnection</code>
-          </h4>
-          <p>
-            When the user agent has received a transmission from the remote
-            side consisting of <a>presentation message data</a> and
-            <a>presentation message type</a>, it MUST run the following steps:
-          </p>
-          <ol link-for="PresentationConnection">
-            <li>If the <a>state</a> property of <a>PresentationConnection</a>
-            is not <code>"connected"</code>, abort these steps.
-            </li>
-            <li>Let <em>event</em> be a newly created <a>trusted event</a> that
-            uses the <code>MessageEvent</code> interface, with the event type
-            <code>message</code>, which does not bubble, is not cancelable, and
-            has no default action.
-            </li>
-            <li>Initialize the <em>event's</em> data attribute as follows:
-              <ol>
-                <li>If the <a>presentation message type</a> is
-                <code>text</code>, then initialize <em>event's</em>
-                <code>data</code> attribute to the contents of <a>presentation
-                message data</a> of type <code>DOMString</code>.
-                </li>
-                <li>If the <a>presentation message type</a> is
-                <code>binary</code>, and <a>binaryType</a> is set to
-                <code>blob</code>, then initialize <em>event</em>'s
-                <code>data</code> attribute to a new <code>Blob</code> object
-                that represents <a>presentation message data</a> as its raw
-                data.
-                </li>
-                <li>If the <a>presentation message type</a> is
-                <code>binary</code>, and <a>binaryType</a> is set to
-                <code>arraybuffer</code>, then initialize <em>event</em>'s
-                <code>data</code> attribute to a new <code>ArrayBuffer</code>
-                object whose contents are <a>presentation message data</a>.
-                </li>
-              </ol>
-            </li>
-            <li>
-              <a>Queue a task</a> to <a>fire</a> <em>event</em> at
-              <a><code>PresentationConnection</code></a>.
-            </li>
-          </ol>
-        </section>
-        <section>
-          <h4>
-            Closing a <code>PresentationConnection</code>
-          </h4>
-          <p>
-            When the user agent is to <dfn data-lt="close-algorithm">close a
-            presentation connection</dfn> using <em>connection</em>, it MUST do
-            the following:
-          </p>
-          <ol>
-            <li>
-              <a>Queue a task</a> to run the following steps in order:
-              <ol>
-                <li>If the <a>presentation connection state</a> of
-                <em>connection</em> is not <code>connected</code>, then abort
-                these steps.
-                </li>
-                <li>Set <a>presentation connection state</a> of
-                <em>connection</em> to <code>closed</code>.
-                </li>
-                <li>
-                  <a>Fire</a> an event named <code>statechange</code> at
-                  <em>connection</em>.
-                </li>
-                <li>If <em>connection</em> is owned by a <a>controlling
-                browsing context</a>, signal the <a>receiving browsing
-                context</a> to <a data-lt="close-algorithm">close the
-                presentation connection</a> that was created when
-                <em>connection</em> was used to <a>establish a presentation
-                connection</a> with the presentation via <em>connection</em>,
-                using an implementation-specific mechanism.
-                </li>
-                <li>If <em>connection</em> is owned by a <a>receiving browsing
-                context</a>, signal the <a>controlling browsing context</a> to
-                <a data-lt="close-algorithm">close the presentation
-                connection</a> that was used to <a>establish a presentation
-                connection</a> with the presentation via <em>connection</em>,
-                using an implementation-specific mechanism.
-                </li>
-              </ol>
-            </li>
-          </ol>
-        </section>
-        <section>
-          <h4>
-            Terminating a <code>PresentationConnection</code>
-          </h4>
-          <p>
-            When a <a>controlling user agent</a> is to <dfn data-lt=
-            "terminate-algorithm">terminate a presentation</dfn> using
-            <em>connection</em>, it MUST run the following steps:
-          </p>
-          <ol>
-            <li>
-              <a>Queue a task</a> to run the following steps in order:
-              <ol>
-                <li>If the <a>presentation connection state</a> of
-                <em>connection</em> is not <code>connected</code>, then abort
-                these steps.
-                </li>
-                <li>Otherwise, for each <em>known connection</em> in the <a>set
-                of presentations</a> in the <a>controlling user agent</a>:
-                  <ol>
-                    <li>If the <a>presentation identifier</a> of <em>known
-                    connection</em> and <em>connection</em> are equal, and the
-                    <a>presentation connection state</a> of <em>known
-                    connection</em> is <code>connected</code>, then run the
-                    following steps:
-                      <ol>
-                        <li>Set <a>presentation connection state</a> of
-                        <em>known connection</em> to <code>terminated</code>.
-                        </li>
-                        <li>
-                          <a>Fire</a> an event named <code>statechange</code>
-                          at <em>known connection</em>.
-                        </li>
-                      </ol>
-                    </li>
-                  </ol>
-                </li>
-                <li>Signal the <a>receiving user agent</a> to terminate the
-                presentation using an implementation specific mechanism.
-                </li>
-              </ol>
-            </li>
-          </ol>
-          <p>
-            When a <a>receiving user agent</a> is to terminate a presentation
-            using <em>connection</em>, it MUST close the <a>receiving browsing
-            context</a> (equivalent to calling <code>window.close()</code>).
-          </p>
-          <p>
-            In addition, the <a>receiving user agent</a> hosting the
-            <a>receiving browsing context</a> that was closed SHOULD signal
-            each <a>controlling user agent</a> that was connected to the
-            <a>presentation</a>. In response, each <a>controlling user
-            agent</a> SHOULD run the following steps:
-          </p>
-          <ol>
-            <li>
-              <a>Queue a task</a> to run the following steps:
-              <ol>
-                <li>For each <em>connection</em> that was connected to the <a>
-                  receiving browsing context</a>:
-                  <ol>
-                    <li>If the <a>presentation connection state</a> of
-                    <em>connection</em> is not <code>connected</code>, then
-                    abort the following steps.
-                    </li>
-                    <li>Let <em>controllingConnection</em> be the
-                    <a>presentation connection</a> in the <a>controlling
-                    browsing context</a> that was used to <a>establish a
-                    presentation connection</a> via <em>connection</em>.
-                    </li>
-                    <li>Set the <a>presentation connection state</a> of
-                    <em>controllingConnection</em> to <code>terminated</code>.
-                    </li>
-                    <li>
-                      <a>Fire</a> an event named <code>statechange</code> at
-                      <em>controllingConnection</em>.
-                    </li>
-                  </ol>
-                </li>
-              </ol>
-            </li>
-          </ol>
-        </section>
-        <section>
-          <h4>
-            Event Handlers
-          </h4>
-          <p>
-            The following are the event handlers (and their corresponding event
-            handler event types) that must be supported, as event handler IDL
-            attributes, by objects implementing the
-            <a>PresentationConnection</a> interface:
-          </p>
-          <table dfn-for="PresentationConnection">
-            <thead>
-              <tr>
-                <th>
-                  Event handler
-                </th>
-                <th>
-                  Event handler event type
-                </th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <td>
-                  <dfn><code>onmessage</code></dfn>
-                </td>
-                <td>
-                  <code>message</code>
-                </td>
-              </tr>
-              <tr>
-                <td>
-                  <dfn><code>onstatechange</code></dfn>
-                </td>
-                <td>
-                  <code>statechange</code>
-                </td>
-              </tr>
-            </tbody>
-          </table>
-        </section>
-      </section>
-      <section>
-        <h3>
-          Interface <code>PresentationAvailability</code>
-        </h3>
-        <pre class="idl">
-          interface PresentationAvailability : EventTarget {
-            readonly attribute boolean value;
-
-            attribute EventHandler onchange;
+          interface Presentation {
+            attribute PresentationRequest? defaultRequest;
+            [SameObject] readonly attribute PresentationReceiver? receiver;
           };
 
 </pre>
         <p>
-          A <a><code>PresentationAvailability</code></a> object is associated
-          with available <a>presentation displays</a> and represents the
-          <dfn>presentation display availability</dfn> for a presentation
-          request. If the <a>controlling user agent</a> can <a>monitor the list
-          of available presentation displays</a> in the background (without a
-          pending request to <code><a for=
-          "PresentationRequest">start</a>()</code>), the
-          <a><code>PresentationAvailability</code></a> object MUST be
-          implemented in a <a>controlling browsing context</a>.
-        </p>
-        <p>
-          The <dfn for="PresentationAvailability">value</dfn> attribute MUST
-          return the last value it was set to. The value is updated by the
-          <a>monitor the list of available presentation displays</a> algorithm.
-        </p>
-        <p>
-          The <dfn for="PresentationAvailability">onchange</dfn> attribute is
-          an <a>event handler</a> whose corresponding <a>event handler event
-          type</a> is <code>change</code>.
+          The <dfn for="Navigator"><code>presentation</code></dfn> attribute is
+          used to retrieve an instance of the <a>Presentation</a> interface.
         </p>
         <section>
           <h4>
-            The set of availability objects
+            Controlling user agent
           </h4>
           <p>
-            The user agent MUST keep track of the <dfn>set of availability
-            objects</dfn> requested through the <code><a for=
-            "PresentationRequest">getAvailability</a>()</code> method. The
-            <a>set of availability objects</a> is represented as a set of
-            tuples <em>(A, availabilityUrl)</em>, initially empty, where:
-          </p>
-          <ol>
-            <li>
-              <em>A</em> is a live <a>PresentationAvailability</a> object;
-            </li>
-            <li>
-              <em>availabilityUrl</em> is the <code>availabilityUrl</code>
-              passed to <code><a for=
-              "PresentationRequest">getAvailability</a>()</code> to create A.
-            </li>
-          </ol>
-        </section>
-        <section>
-          <h4>
-            The list of available presentation displays
-          </h4>
-          <p>
-            The user agent MUST keep a <dfn>list of available presentation
-            displays</dfn>. This current list of <a>presentation displays</a>
-            may be used for starting new presentations, and is populated based
-            on an implementation specific discovery mechanism. It is set to the
-            most recent result of the algorithm to <a>monitor the list of
-            available presentation displays</a>.
+            In a <a>controlling user agent</a>, the <dfn for=
+            "Presentation"><code>defaultRequest</code></dfn> MUST return the
+            <a>default presentation request</a> if any, <code>null</code>
+            otherwise.
           </p>
           <p>
-            While there are live <a>PresentationAvailability</a> objects, the
-            user agent MAY <a>monitor the list of available presentation
-            displays</a> continuously, so that pages can use the <a for=
-            "PresentationAvailability">value</a> property of a
-            <a>PresentationAvailability</a> object to offer presentation only
-            when there are available displays. However, the user agent may not
-            support continuous availability monitoring; for example, because of
-            platform or power consumption restrictions. In this case the
-            <a>Promise</a> returned by <code>getAvailability()</code> MUST be
-            <a data-lt="reject">rejected</a> and the algorithm to <a>monitor
-            the list of available presentation displays</a> will only run as
-            part of the <a for="PresentationRequest" data-lt="start">start a
-            presentation connection</a> algorithm.
+            If set by the <a>controller</a>, the <a for=
+            "Presentation">defaultRequest</a> SHOULD be used by the
+            <a>controlling user agent</a> as the <dfn>default presentation
+            request</dfn> for that controller. When the <a>controlling user
+            agent</a> wishes to initiate a <a>PresentationConnection</a> on the
+            controller's behalf, it MUST <a>start a presentation connection</a>
+            using the <a>default presentation request</a> for the
+            <a>controller</a> (as if the controller had called
+            <code>defaultRequest.start()</code>).
           </p>
           <p>
-            When there are no live <a>PresentationAvailability</a> objects
-            (that is, the <a>set of availability objects</a> is empty), user
-            agents SHOULD NOT <a>monitor the list of available presentation
-            displays</a> to satisfy the <a href=
-            "https://github.com/w3c/presentation-api/blob/gh-pages/uc-req.md#nf-req01-power-saving-friendly">
-            power saving non-functional requirement</a>. To further save power,
-            the user agent MAY also keep track of whether the page holding a
-            <a>PresentationAvailability</a> object is in the foreground. Using
-            this information, implementation specific discovery of
-            <a>presentation displays</a> can be resumed or suspended.
+            The <a>controlling user agent</a> SHOULD initiate presentation
+            using the <a>default presentation request</a> only when the user
+            has expressed an intention to do so, for example by clicking a
+            button in the browser.
           </p>
-          <p>
-            Some <a>presentation displays</a> may only be able to display a
-            subset of Web content because of functional, security or hardware
-            limitations. Examples are set-top boxes, smart TVs or networked
-            speakers capable of rendering only audio. We say that such a
-            display is a <dfn>compatible presentation display</dfn> for a
-            <dfn>display availability URL</dfn> if the user agent can
-            reasonably guarantee that the presentation of the URL on that
-            display will succeed.
-          </p>
-        </section>
-        <section>
-          <h4>
-            Monitoring the list of available presentation displays
-          </h4>
-          <p>
-            If <a>set of availability objects</a> is non-empty, or there is a
-            pending request to <a for="PresentationRequest" data-lt=
-            "start">start a presentation connection</a>, the user agent MUST
-            <dfn>monitor the list of available presentation displays</dfn> by
-            running the following steps.
-          </p>
-          <ol link-for="PresentationAvailability">
-            <li>
-              <a>Queue a task</a> to retrieve available presentation displays
-              (using an implementation specific mechanism) and let
-              <em>newDisplays</em> be this list.
-            </li>
-            <li>Wait for the completion of that task.
-            </li>
-            <li>For each member <em>(A, availabilityUrl)</em> of the <a>set of
-            availability objects</a>:
-              <ol>
-                <li>Set <em>previousAvailability</em> to the value of
-                <em>A</em>'s <a>value</a> property.
-                </li>
-                <li>Let <em>newAvailability</em> be <code>true</code> if
-                <em>newDisplays</em> is not empty and at least one display in
-                <em>newDisplays</em> is a <a>compatible presentation
-                display</a> for <em>availabilityUrl</em>. Otherwise, set
-                <em>newAvailability</em> to <code>false</code>.
-                </li>
-                <li>If <em>previousAvailability</em> is not equal to
-                <em>newAvailability</em>, then <a>queue a task</a> to run the
-                following steps:
-                  <ol>
-                    <li>Set <em>A</em>'s <a>value</a> property to
-                    <em>newAvailability</em>.
-                    </li>
-                    <li>
-                      <a data-lt='firing a simple event'>Fire a simple
-                      event</a> named <code>change</code> at <em>A</em>.
-                    </li>
-                  </ol>
-                </li>
-              </ol>
-            </li>
-            <li>Set the <a>list of available presentation displays</a> to the
-            value of <em>newDisplays</em>.
-            </li>
-          </ol>
-          <p>
-            When a <a>PresentationAvailability</a> object is no longer alive
-            (i.e., is eligible for garbage collection), the user agent SHOULD
-            run the following steps:
-          </p>
-          <ol>
-            <li>Find and remove any entry <em>(A, availabilityUrl)</em> in the
-            <a>set of availability objects</a> for the newly deceased
-            <em>A</em>.
-            </li>
-            <li>If the <a>set of availability objects</a> is now empty and
-            there is no pending request to <a for="PresentationRequest"
-              data-lt="start">start a presentation connection</a>, cancel any
-              pending task to <a>monitor the list of available presentation
-              displays</a> for power saving purposes.
-            </li>
-          </ol>
           <div class="note">
-            The mechanism used to monitor <a>presentation displays</a>
-            availability and determine the compatibility of a <a>presentation
-            display</a> with a given URL is left to the user agent.
+            Not all user agents may support initiation of a presentation
+            connection outside of the content area. In this case setting
+            <code>defaultRequest</code> has no effect.
           </div>
+          <div class="issue">
+            It should be clear that user-intiated presentation via the user
+            agent may have pre-selected the presentation display. In this case
+            step 6 of <a>start a presentation connection</a> is optional. It
+            may be cleaner to define a separate set of steps for initiating a
+            default presentation.
+          </div>
+        </section>
+        <section>
+          <h4>
+            Receiving user agent
+          </h4>
+          <p>
+            In a <a>receiving user agent</a>, <dfn for=
+            "Presentation"><code>receiver</code></dfn> MUST return
+            <a><code>PresentationReceiver</code></a> instance in a <a>receiving
+            browsing context</a>. In any other <a>browsing context</a>, it MUST
+            return <code>null</code>.
+          </p>
         </section>
       </section>
       <section>
@@ -1718,6 +1277,575 @@
       </section>
       <section>
         <h3>
+          Interface <code>PresentationAvailability</code>
+        </h3>
+        <pre class="idl">
+          interface PresentationAvailability : EventTarget {
+            readonly attribute boolean value;
+
+            attribute EventHandler onchange;
+          };
+
+</pre>
+        <p>
+          A <a><code>PresentationAvailability</code></a> object is associated
+          with available <a>presentation displays</a> and represents the
+          <dfn>presentation display availability</dfn> for a presentation
+          request. If the <a>controlling user agent</a> can <a>monitor the list
+          of available presentation displays</a> in the background (without a
+          pending request to <code><a for=
+          "PresentationRequest">start</a>()</code>), the
+          <a><code>PresentationAvailability</code></a> object MUST be
+          implemented in a <a>controlling browsing context</a>.
+        </p>
+        <p>
+          The <dfn for="PresentationAvailability">value</dfn> attribute MUST
+          return the last value it was set to. The value is updated by the
+          <a>monitor the list of available presentation displays</a> algorithm.
+        </p>
+        <p>
+          The <dfn for="PresentationAvailability">onchange</dfn> attribute is
+          an <a>event handler</a> whose corresponding <a>event handler event
+          type</a> is <code>change</code>.
+        </p>
+        <section>
+          <h4>
+            The set of availability objects
+          </h4>
+          <p>
+            The user agent MUST keep track of the <dfn>set of availability
+            objects</dfn> requested through the <code><a for=
+            "PresentationRequest">getAvailability</a>()</code> method. The
+            <a>set of availability objects</a> is represented as a set of
+            tuples <em>(A, availabilityUrl)</em>, initially empty, where:
+          </p>
+          <ol>
+            <li>
+              <em>A</em> is a live <a>PresentationAvailability</a> object;
+            </li>
+            <li>
+              <em>availabilityUrl</em> is the <code>availabilityUrl</code>
+              passed to <code><a for=
+              "PresentationRequest">getAvailability</a>()</code> to create A.
+            </li>
+          </ol>
+        </section>
+        <section>
+          <h4>
+            The list of available presentation displays
+          </h4>
+          <p>
+            The user agent MUST keep a <dfn>list of available presentation
+            displays</dfn>. This current list of <a>presentation displays</a>
+            may be used for starting new presentations, and is populated based
+            on an implementation specific discovery mechanism. It is set to the
+            most recent result of the algorithm to <a>monitor the list of
+            available presentation displays</a>.
+          </p>
+          <p>
+            While there are live <a>PresentationAvailability</a> objects, the
+            user agent MAY <a>monitor the list of available presentation
+            displays</a> continuously, so that pages can use the <a for=
+            "PresentationAvailability">value</a> property of a
+            <a>PresentationAvailability</a> object to offer presentation only
+            when there are available displays. However, the user agent may not
+            support continuous availability monitoring; for example, because of
+            platform or power consumption restrictions. In this case the
+            <a>Promise</a> returned by <code>getAvailability()</code> MUST be
+            <a data-lt="reject">rejected</a> and the algorithm to <a>monitor
+            the list of available presentation displays</a> will only run as
+            part of the <a for="PresentationRequest" data-lt="start">start a
+            presentation connection</a> algorithm.
+          </p>
+          <p>
+            When there are no live <a>PresentationAvailability</a> objects
+            (that is, the <a>set of availability objects</a> is empty), user
+            agents SHOULD NOT <a>monitor the list of available presentation
+            displays</a> to satisfy the <a href=
+            "https://github.com/w3c/presentation-api/blob/gh-pages/uc-req.md#nf-req01-power-saving-friendly">
+            power saving non-functional requirement</a>. To further save power,
+            the user agent MAY also keep track of whether the page holding a
+            <a>PresentationAvailability</a> object is in the foreground. Using
+            this information, implementation specific discovery of
+            <a>presentation displays</a> can be resumed or suspended.
+          </p>
+          <p>
+            Some <a>presentation displays</a> may only be able to display a
+            subset of Web content because of functional, security or hardware
+            limitations. Examples are set-top boxes, smart TVs or networked
+            speakers capable of rendering only audio. We say that such a
+            display is a <dfn>compatible presentation display</dfn> for a
+            <dfn>display availability URL</dfn> if the user agent can
+            reasonably guarantee that the presentation of the URL on that
+            display will succeed.
+          </p>
+        </section>
+        <section>
+          <h4>
+            Monitoring the list of available presentation displays
+          </h4>
+          <p>
+            If <a>set of availability objects</a> is non-empty, or there is a
+            pending request to <a for="PresentationRequest" data-lt=
+            "start">start a presentation connection</a>, the user agent MUST
+            <dfn>monitor the list of available presentation displays</dfn> by
+            running the following steps.
+          </p>
+          <ol link-for="PresentationAvailability">
+            <li>
+              <a>Queue a task</a> to retrieve available presentation displays
+              (using an implementation specific mechanism) and let
+              <em>newDisplays</em> be this list.
+            </li>
+            <li>Wait for the completion of that task.
+            </li>
+            <li>For each member <em>(A, availabilityUrl)</em> of the <a>set of
+            availability objects</a>:
+              <ol>
+                <li>Set <em>previousAvailability</em> to the value of
+                <em>A</em>'s <a>value</a> property.
+                </li>
+                <li>Let <em>newAvailability</em> be <code>true</code> if
+                <em>newDisplays</em> is not empty and at least one display in
+                <em>newDisplays</em> is a <a>compatible presentation
+                display</a> for <em>availabilityUrl</em>. Otherwise, set
+                <em>newAvailability</em> to <code>false</code>.
+                </li>
+                <li>If <em>previousAvailability</em> is not equal to
+                <em>newAvailability</em>, then <a>queue a task</a> to run the
+                following steps:
+                  <ol>
+                    <li>Set <em>A</em>'s <a>value</a> property to
+                    <em>newAvailability</em>.
+                    </li>
+                    <li>
+                      <a data-lt='firing a simple event'>Fire a simple
+                      event</a> named <code>change</code> at <em>A</em>.
+                    </li>
+                  </ol>
+                </li>
+              </ol>
+            </li>
+            <li>Set the <a>list of available presentation displays</a> to the
+            value of <em>newDisplays</em>.
+            </li>
+          </ol>
+          <p>
+            When a <a>PresentationAvailability</a> object is no longer alive
+            (i.e., is eligible for garbage collection), the user agent SHOULD
+            run the following steps:
+          </p>
+          <ol>
+            <li>Find and remove any entry <em>(A, availabilityUrl)</em> in the
+            <a>set of availability objects</a> for the newly deceased
+            <em>A</em>.
+            </li>
+            <li>If the <a>set of availability objects</a> is now empty and
+            there is no pending request to <a for="PresentationRequest"
+              data-lt="start">start a presentation connection</a>, cancel any
+              pending task to <a>monitor the list of available presentation
+              displays</a> for power saving purposes.
+            </li>
+          </ol>
+          <div class="note">
+            The mechanism used to monitor <a>presentation displays</a>
+            availability and determine the compatibility of a <a>presentation
+            display</a> with a given URL is left to the user agent.
+          </div>
+        </section>
+      </section>
+      <section>
+        <h3>
+          Interface <code>PresentationConnection</code>
+        </h3>
+        <p>
+          Each <a>presentation connection</a> is represented by a
+          <a>PresentationConnection</a> object. Both the <a>controlling user
+          agent</a> and <a>receiving user agent</a> MUST implement
+          <a>PresentationConnection</a>.
+        </p>
+        <pre class="idl">
+          enum PresentationConnectionState { "connected", "closed", "terminated" };
+          enum BinaryType { "blob", "arraybuffer" };
+
+          interface PresentationConnection : EventTarget {
+            readonly attribute DOMString? id;
+            readonly attribute PresentationConnectionState state;
+            void close();
+            void terminate();
+            attribute EventHandler onstatechange;
+
+            // Communication
+            attribute BinaryType binaryType;
+            attribute EventHandler onmessage;
+            void send (DOMString message);
+            void send (Blob data);
+            void send (ArrayBuffer data);
+            void send (ArrayBufferView data);
+          };
+
+</pre>
+        <div dfn-for="PresentationConnection" link-for=
+        "PresentationConnection">
+          <p>
+            The <dfn><code>id</code></dfn> attribute specifies the
+            <a>presentation connection</a>'s <a>presentation identifier</a>.
+          </p>
+          <p>
+            The <dfn><code>state</code></dfn> attribute represents the
+            <a>presentation connection</a>'s current state. It can take one of
+            the values of <a>PresentationConnectionState</a> depending on
+            connection state.
+          </p>
+          <p>
+            When the <code><dfn>close</dfn>()</code> method is called on a
+            <a>PresentationConnection</a>, the user agent MUST run the
+            algorithm to <a data-lt="close-algorithm">close a presentation
+            connection</a> with <a>PresentationConnection</a>.
+          </p>
+          <p>
+            When the <code><dfn>terminate</dfn>()</code> method is called on a
+            <a>PresentationConnection</a>, the user agent MUST run the
+            algorithm to <a data-lt="terminate-algorithm">terminate a
+            presentation</a> with <a>PresentationConnection</a>.
+          </p>
+          <p>
+            When the <code><dfn>send</dfn>()</code> method is called on a
+            <a>PresentationConnection</a> object with a <code>message</code>,
+            the user agent MUST run the algorithm to <a data-lt=
+            "algorithm-send">send a message through a
+            <code>PresentationConnection</code></a>.
+          </p>
+        </div>
+        <section>
+          <h4>
+            Sending a message through <code>PresentationConnection</code>
+          </h4>
+          <div class="note">
+            No specific transport for the connection between the <a>controlling
+            browsing context</a> and the <a>receiving browsing context</a> is
+            mandated, except that for multiple calls to <code><a for=
+            "PresentationConnection">send</a>()</code> it has to be ensured
+            that messages are delivered to the other end reliably and in
+            sequence. The transport should function equivalently to an
+            <a><code>RTCDataChannel</code></a> in reliable mode.
+          </div>
+          <p>
+            Let <dfn>presentation message data</dfn> be the payload data to be
+            transmitted between two browsing contexts. Let <dfn>presentation
+            message type</dfn> be the type of that data, one of
+            <code>text</code> and <code>binary</code>.
+          </p>
+          <p>
+            When the user agent is to <dfn data-lt="algorithm-send">send a
+            message through a <code>PresentationConnection</code> S</dfn>, it
+            MUST run the following steps:
+          </p>
+          <ol link-for="PresentationConnection">
+            <li>If the <a>state</a> property of <a>PresentationConnection</a>
+            is not <code>"connected"</code>, throw an
+            <code>InvalidStateError</code> exception.
+            </li>
+            <li>Let <a>presentation message type</a> <em>messageType</em> be
+            <code>binary</code> if <code>data</code> is one of
+            <code>ArrayBuffer</code>, <code>ArrayBufferView</code>, or
+            <code>Blob</code>. Let <em>messageType</em> be <code>text</code> if
+            <code>data</code> is of type <code>DOMString</code>)
+            </li>
+            <li>Assign the <dfn>destination browsing context</dfn> as follows:
+              <ol>
+                <li>Let the <a>destination browsing context</a> be the
+                <a>controlling browsing context</a> if
+                <code><a>send</a>()</code> is called in the <a>receiving
+                browsing context</a>.
+                </li>
+                <li>Let <a>destination browsing context</a> be the <a>receiving
+                browsing context</a> if <code><a>send</a>()</code> is called
+                from the <a>controlling browsing context</a>.
+                </li>
+              </ol>
+            </li>
+            <li>Using an implementation specific mechanism, transmit the
+            contents of the <code>data</code> argument as <a>presentation
+            message data</a> and <a>presentation message type</a>
+            <em>messageType</em> to the <a>destination browsing context</a>
+            side.
+            </li>
+          </ol>
+        </section>
+        <section>
+          <h4>
+            Receiving a message through <code>PresentationConnection</code>
+          </h4>
+          <p>
+            When the user agent has received a transmission from the remote
+            side consisting of <a>presentation message data</a> and
+            <a>presentation message type</a>, it MUST run the following steps:
+          </p>
+          <ol link-for="PresentationConnection">
+            <li>If the <a>state</a> property of <a>PresentationConnection</a>
+            is not <code>"connected"</code>, abort these steps.
+            </li>
+            <li>Let <em>event</em> be a newly created <a>trusted event</a> that
+            uses the <code>MessageEvent</code> interface, with the event type
+            <code>message</code>, which does not bubble, is not cancelable, and
+            has no default action.
+            </li>
+            <li>Initialize the <em>event's</em> data attribute as follows:
+              <ol>
+                <li>If the <a>presentation message type</a> is
+                <code>text</code>, then initialize <em>event's</em>
+                <code>data</code> attribute to the contents of <a>presentation
+                message data</a> of type <code>DOMString</code>.
+                </li>
+                <li>If the <a>presentation message type</a> is
+                <code>binary</code>, and <a>binaryType</a> is set to
+                <code>blob</code>, then initialize <em>event</em>'s
+                <code>data</code> attribute to a new <code>Blob</code> object
+                that represents <a>presentation message data</a> as its raw
+                data.
+                </li>
+                <li>If the <a>presentation message type</a> is
+                <code>binary</code>, and <a>binaryType</a> is set to
+                <code>arraybuffer</code>, then initialize <em>event</em>'s
+                <code>data</code> attribute to a new <code>ArrayBuffer</code>
+                object whose contents are <a>presentation message data</a>.
+                </li>
+              </ol>
+            </li>
+            <li>
+              <a>Queue a task</a> to <a>fire</a> <em>event</em> at
+              <a><code>PresentationConnection</code></a>.
+            </li>
+          </ol>
+        </section>
+        <section>
+          <h4>
+            Closing a <code>PresentationConnection</code>
+          </h4>
+          <p>
+            When the user agent is to <dfn data-lt="close-algorithm">close a
+            presentation connection</dfn> using <em>connection</em>, it MUST do
+            the following:
+          </p>
+          <ol>
+            <li>
+              <a>Queue a task</a> to run the following steps in order:
+              <ol>
+                <li>If the <a>presentation connection state</a> of
+                <em>connection</em> is not <code>connected</code>, then abort
+                these steps.
+                </li>
+                <li>Set <a>presentation connection state</a> of
+                <em>connection</em> to <code>closed</code>.
+                </li>
+                <li>
+                  <a>Fire</a> an event named <code>statechange</code> at
+                  <em>connection</em>.
+                </li>
+                <li>If <em>connection</em> is owned by a <a>controlling
+                browsing context</a>, signal the <a>receiving browsing
+                context</a> to <a data-lt="close-algorithm">close the
+                presentation connection</a> that was created when
+                <em>connection</em> was used to <a>establish a presentation
+                connection</a> with the presentation via <em>connection</em>,
+                using an implementation-specific mechanism.
+                </li>
+                <li>If <em>connection</em> is owned by a <a>receiving browsing
+                context</a>, signal the <a>controlling browsing context</a> to
+                <a data-lt="close-algorithm">close the presentation
+                connection</a> that was used to <a>establish a presentation
+                connection</a> with the presentation via <em>connection</em>,
+                using an implementation-specific mechanism.
+                </li>
+              </ol>
+            </li>
+          </ol>
+        </section>
+        <section>
+          <h4>
+            Terminating a <code>PresentationConnection</code>
+          </h4>
+          <p>
+            When a <a>controlling user agent</a> is to <dfn data-lt=
+            "terminate-algorithm">terminate a presentation</dfn> using
+            <em>connection</em>, it MUST run the following steps:
+          </p>
+          <ol>
+            <li>
+              <a>Queue a task</a> to run the following steps in order:
+              <ol>
+                <li>If the <a>presentation connection state</a> of
+                <em>connection</em> is not <code>connected</code>, then abort
+                these steps.
+                </li>
+                <li>Otherwise, for each <em>known connection</em> in the <a>set
+                of presentations</a> in the <a>controlling user agent</a>:
+                  <ol>
+                    <li>If the <a>presentation identifier</a> of <em>known
+                    connection</em> and <em>connection</em> are equal, and the
+                    <a>presentation connection state</a> of <em>known
+                    connection</em> is <code>connected</code>, then run the
+                    following steps:
+                      <ol>
+                        <li>Set <a>presentation connection state</a> of
+                        <em>known connection</em> to <code>terminated</code>.
+                        </li>
+                        <li>
+                          <a>Fire</a> an event named <code>statechange</code>
+                          at <em>known connection</em>.
+                        </li>
+                      </ol>
+                    </li>
+                  </ol>
+                </li>
+                <li>Signal the <a>receiving user agent</a> to terminate the
+                presentation using an implementation specific mechanism.
+                </li>
+              </ol>
+            </li>
+          </ol>
+          <p>
+            When a <a>receiving user agent</a> is to terminate a presentation
+            using <em>connection</em>, it MUST close the <a>receiving browsing
+            context</a> (equivalent to calling <code>window.close()</code>).
+          </p>
+          <p>
+            In addition, the <a>receiving user agent</a> hosting the
+            <a>receiving browsing context</a> that was closed SHOULD signal
+            each <a>controlling user agent</a> that was connected to the
+            <a>presentation</a>. In response, each <a>controlling user
+            agent</a> SHOULD run the following steps:
+          </p>
+          <ol>
+            <li>
+              <a>Queue a task</a> to run the following steps:
+              <ol>
+                <li>For each <em>connection</em> that was connected to the <a>
+                  receiving browsing context</a>:
+                  <ol>
+                    <li>If the <a>presentation connection state</a> of
+                    <em>connection</em> is not <code>connected</code>, then
+                    abort the following steps.
+                    </li>
+                    <li>Let <em>controllingConnection</em> be the
+                    <a>presentation connection</a> in the <a>controlling
+                    browsing context</a> that was used to <a>establish a
+                    presentation connection</a> via <em>connection</em>.
+                    </li>
+                    <li>Set the <a>presentation connection state</a> of
+                    <em>controllingConnection</em> to <code>terminated</code>.
+                    </li>
+                    <li>
+                      <a>Fire</a> an event named <code>statechange</code> at
+                      <em>controllingConnection</em>.
+                    </li>
+                  </ol>
+                </li>
+              </ol>
+            </li>
+          </ol>
+        </section>
+        <section>
+          <h4>
+            Event Handlers
+          </h4>
+          <p>
+            The following are the event handlers (and their corresponding event
+            handler event types) that must be supported, as event handler IDL
+            attributes, by objects implementing the
+            <a>PresentationConnection</a> interface:
+          </p>
+          <table dfn-for="PresentationConnection">
+            <thead>
+              <tr>
+                <th>
+                  Event handler
+                </th>
+                <th>
+                  Event handler event type
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>
+                  <dfn><code>onmessage</code></dfn>
+                </td>
+                <td>
+                  <code>message</code>
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  <dfn><code>onstatechange</code></dfn>
+                </td>
+                <td>
+                  <code>statechange</code>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </section>
+      </section>
+      <section>
+        <h3>
+          Interface <a><code>PresentationReceiver</code></a>
+        </h3>
+        <pre class="idl">
+          interface PresentationReceiver {
+            [SameObject] readonly attribute Promise&lt;PresentationConnectionList&gt; connections;
+          };
+
+
+</pre>
+        <div class='issue' data-number='193'></div>
+        <p>
+          The <a>PresentationReceiver</a> object is available to a <a>receiving
+          browsing context</a> in order to access the <a data-lt=
+          "controlling browsing context">controlling browsing context</a> and
+          communicate with it. The <a><code>PresentationReceiver</code></a>
+          object MUST be implemented in a <a>receiving browsing context</a>
+          provided by a <a>receiving user agent</a>.
+        </p>
+        <p>
+          For each <a>PresentationReceiver</a>, there is a <dfn>connection list
+          promise</dfn> which is initially set to <code>null</code>. It is a
+          <a>Promise</a> object which holds a
+          <a>PresentationConnectionList</a>.
+        </p>
+        <ol>
+          <li>If <a>connection list promise</a> is not <code>null</code>,
+          return <a>connection list promise</a> and abort these steps.
+          </li>
+          <li>Otherwise, set <a>connection list promise</a> be a new
+          <a>Promise</a>.
+          </li>
+          <li>Return <a>connection list promise</a>.
+          </li>
+          <li>Run the following substeps asynchronously:
+            <ol>
+              <li>Let <var>list</var> be a new
+              <a>PresentationConnectionList</a>.
+              </li>
+              <li>Initialize <var>list</var> with the <a>set of
+              presentations</a> associated with the <a>receiving browsing
+              context</a>.
+              </li>
+              <li>If the user agent is not <a>monitoring incoming presentation
+              connections</a>, <a>queue a task</a> to start <a>monitoring
+              incoming presentation connections</a> from <a>controlling
+              browsing contexts</a>.
+              </li>
+              <li>Resolve <a>connection list promise</a> with <var>list</var>.
+              </li>
+            </ol>
+          </li>
+        </ol>
+      </section>
+    </section>
+      <section>
+        <h3>
           Interface <a><code>PresentationConnectionList</code></a>
         </h3>
         <pre class="idl">
@@ -1832,134 +1960,6 @@
           </table>
         </section>
       </section>
-      <section>
-        <h3>
-          Interface <a><code>PresentationReceiver</code></a>
-        </h3>
-        <pre class="idl">
-          interface PresentationReceiver {
-            [SameObject] readonly attribute Promise&lt;PresentationConnectionList&gt; connections;
-          };
-
-
-</pre>
-        <div class='issue' data-number='193'></div>
-        <p>
-          The <a>PresentationReceiver</a> object is available to a <a>receiving
-          browsing context</a> in order to access the <a data-lt=
-          "controlling browsing context">controlling browsing context</a> and
-          communicate with it. The <a><code>PresentationReceiver</code></a>
-          object MUST be implemented in a <a>receiving browsing context</a>
-          provided by a <a>receiving user agent</a>.
-        </p>
-        <p>
-          For each <a>PresentationReceiver</a>, there is a <dfn>connection list
-          promise</dfn> which is initially set to <code>null</code>. It is a
-          <a>Promise</a> object which holds a
-          <a>PresentationConnectionList</a>.
-        </p>
-        <ol>
-          <li>If <a>connection list promise</a> is not <code>null</code>,
-          return <a>connection list promise</a> and abort these steps.
-          </li>
-          <li>Otherwise, set <a>connection list promise</a> be a new
-          <a>Promise</a>.
-          </li>
-          <li>Return <a>connection list promise</a>.
-          </li>
-          <li>Run the following substeps asynchronously:
-            <ol>
-              <li>Let <var>list</var> be a new
-              <a>PresentationConnectionList</a>.
-              </li>
-              <li>Initialize <var>list</var> with the <a>set of
-              presentations</a> associated with the <a>receiving browsing
-              context</a>.
-              </li>
-              <li>If the user agent is not <a>monitoring incoming presentation
-              connections</a>, <a>queue a task</a> to start <a>monitoring
-              incoming presentation connections</a> from <a>controlling
-              browsing contexts</a>.
-              </li>
-              <li>Resolve <a>connection list promise</a> with <var>list</var>.
-              </li>
-            </ol>
-          </li>
-        </ol>
-      </section>
-      <section>
-        <h3>
-          Interface <a><code>Presentation</code></a>
-        </h3>
-        <pre class="idl">
-          partial interface Navigator {
-            [SameObject] readonly attribute Presentation presentation;
-          };
-
-          interface Presentation {
-            attribute PresentationRequest? defaultRequest;
-            [SameObject] readonly attribute PresentationReceiver? receiver;
-          };
-
-</pre>
-        <p>
-          The <dfn for="Navigator"><code>presentation</code></dfn> attribute is
-          used to retrieve an instance of the <a>Presentation</a> interface.
-        </p>
-        <section>
-          <h4>
-            Controlling user agent
-          </h4>
-          <p>
-            In a <a>controlling user agent</a>, the <dfn for=
-            "Presentation"><code>defaultRequest</code></dfn> MUST return the
-            <a>default presentation request</a> if any, <code>null</code>
-            otherwise.
-          </p>
-          <p>
-            If set by the <a>controller</a>, the <a for=
-            "Presentation">defaultRequest</a> SHOULD be used by the
-            <a>controlling user agent</a> as the <dfn>default presentation
-            request</dfn> for that controller. When the <a>controlling user
-            agent</a> wishes to initiate a <a>PresentationConnection</a> on the
-            controller's behalf, it MUST <a>start a presentation connection</a>
-            using the <a>default presentation request</a> for the
-            <a>controller</a> (as if the controller had called
-            <code>defaultRequest.start()</code>).
-          </p>
-          <p>
-            The <a>controlling user agent</a> SHOULD initiate presentation
-            using the <a>default presentation request</a> only when the user
-            has expressed an intention to do so, for example by clicking a
-            button in the browser.
-          </p>
-          <div class="note">
-            Not all user agents may support initiation of a presentation
-            connection outside of the content area. In this case setting
-            <code>defaultRequest</code> has no effect.
-          </div>
-          <div class="issue">
-            It should be clear that user-intiated presentation via the user
-            agent may have pre-selected the presentation display. In this case
-            step 6 of <a>start a presentation connection</a> is optional. It
-            may be cleaner to define a separate set of steps for initiating a
-            default presentation.
-          </div>
-        </section>
-        <section>
-          <h4>
-            Receiving user agent
-          </h4>
-          <p>
-            In a <a>receiving user agent</a>, <dfn for=
-            "Presentation"><code>receiver</code></dfn> MUST return
-            <a><code>PresentationReceiver</code></a> instance in a <a>receiving
-            browsing context</a>. In any other <a>browsing context</a>, it MUST
-            return <code>null</code>.
-          </p>
-        </section>
-      </section>
-    </section>
     <section>
       <h2>
         Security and privacy considerations

--- a/index.html
+++ b/index.html
@@ -686,7 +686,7 @@
             <a>controlling user agent</a> as the <dfn>default presentation
             request</dfn> for that controller. When the <a>controlling user
             agent</a> wishes to initiate a <a>PresentationConnection</a> on the
-            controller's behalf, it MUST <a>start a presentation connection</a>
+            controller's behalf, it MUST <a>start a presentation</a>
             using the <a>default presentation request</a> for the
             <a>controller</a> (as if the controller had called
             <code>defaultRequest.start()</code>).
@@ -705,7 +705,7 @@
           <div class="issue">
             It should be clear that user-intiated presentation via the user
             agent may have pre-selected the presentation display. In this case
-            step 6 of <a>start a presentation connection</a> is optional. It
+            step 6 of <a>start a presentation</a> is optional. It
             may be cleaner to define a separate set of steps for initiating a
             default presentation.
           </div>
@@ -790,12 +790,12 @@
         </section>
         <section>
           <h4>
-            Starting a presentation connection
+            Starting a presentation
           </h4>
           <p>
             When the <code><dfn for="PresentationRequest">start</dfn></code>
             method is called, the user agent MUST run the following steps to
-            <dfn>start a presentation connection</dfn>:
+            <dfn>start a presentation</dfn>:
           </p>
           <dl>
             <dt>
@@ -931,67 +931,7 @@
         </section>
         <section>
           <h4>
-            Creating a receiving browsing context
-          </h4>
-          <dl>
-            <dt>
-              Input
-            </dt>
-            <dd>
-              <em>D</em>, a <a>presentation display</a> chosen by the user
-            </dd>
-            <dt>
-              Output
-            </dt>
-            <dd>
-              <em>R</em>, a <a>receiving browsing context</a>
-            </dd>
-          </dl>
-          <p>
-            When the user agent is to <dfn>create a receiving browsing
-            context</dfn>, it must run the following steps:
-          </p>
-          <ol>
-            <li>Create a new <a>top-level browsing context</a> <em>C</em> on
-            the user agent connected to <em>D</em>.
-            </li>
-            <li>Set the <a>session history</a> of <em>C</em> to be the empty
-            list.
-            </li>
-            <li>Set the <a>sandboxed auxiliary navigation browsing context
-            flag</a> on <em>C</em>.
-            </li>
-            <li>Set the <a><code>sessionStorage</code></a> attribute for the
-            <code>Window</code> object associated with <em>C</em> to a new,
-            empty storage area.
-            </li>
-            <li>Set the <a><code>localStorage</code></a> attribute for the
-            <code>Window</code> object associated with <em>C</em> to a new,
-            empty storage area.
-            </li>
-            <li>Set the <a>cookie store</a> for <em>C</em> to an empty
-            <a>cookie store</a>.
-            </li>
-            <li>Set the <a>permission state</a> of all <a>Permissions</a> for
-            <em>C</em> to <code>"denied"</code>.
-            </li>
-            <li>Set the IndexedDB <a>databases</a> for <em>C</em> to an empty
-            set of <a>databases</a>.
-            </li>
-            <li>Return <em>C</em>.
-            </li>
-          </ol>
-          <p>
-            When the <a>receiving browsing context</a> is closed, any
-            associated browsing state, including <a>session history</a>,
-            <code>sessionStorage</code>, <code>localStorage</code>, the
-            <a>cookie store</a>, and <a>databases</a> must be discarded and not
-            used for any other <a>receiving browsing context</a>.
-          </p>
-        </section>
-        <section>
-          <h4>
-            Reconnecting to a presentation connection
+            Reconnecting to a presentation
           </h4>
           <p>
             When the <code><dfn for=
@@ -1073,8 +1013,7 @@
         </section>
         <section>
           <h4>
-            Establishing a presentation connection in a controlling browsing
-            context
+            Establishing a presentation connection
           </h4>
           <p>
             When the user agent is to <dfn>establish a presentation
@@ -1141,76 +1080,6 @@
         </section>
         <section>
           <h4>
-            Getting the <a>presentation displays</a> availability information
-          </h4>
-          <p>
-            When the <code><dfn for=
-            "PresentationRequest">getAvailability</dfn>()</code> method is
-            called, the user agent MUST run the following steps:
-          </p>
-          <dl>
-            <dt>
-              Input
-            </dt>
-            <dd>
-              <code>presentationUrl</code>, the <a>presentation request URL</a>
-            </dd>
-            <dt>
-              Output
-            </dt>
-            <dd>
-              <em>P</em>, a <a>Promise</a>
-            </dd>
-          </dl>
-          <ol>
-            <li>Let <em>P</em> be a new <a>Promise</a>.
-            </li>
-            <li>Return <em>P</em>.
-            </li>
-            <li>If the user agent is unable to monitor presentation displays
-            for the entire duration of the controlling browsing context (e.g.,
-            because the user has disabled this feature), then:
-              <ol>
-                <li>
-                  <a>Resolve</a> <em>P</em> with a new
-                  <code>PresentationAvailability</code> object with its
-                  <code>value</code> property set to <code>false</code>.
-                </li>
-                <li>Abort all the remaining steps.
-                </li>
-              </ol>
-            </li>
-            <li>If the user agent is unable to continuously <a>monitor the list
-            of available presentation displays</a> but can find presentation
-            displays in order to start a connection, then:
-              <ol>
-                <li>
-                  <a>Reject</a> <em>P</em> with a <a>NotSupportedError</a>
-                  exception.
-                </li>
-                <li>Abort all the remaining steps.
-                </li>
-              </ol>
-            </li>
-            <li>Let <em>A</em> be a new <code>PresentationAvailability</code>
-            object with its <code>value</code> property set to
-            <code>false</code> if the <a>list of available presentation
-            displays</a> is empty or non of them is a <a>compatible
-            presentation display</a>, <code>true</code> otherwise.
-            </li>
-            <li>Create a tuple <em>(A, presentationUrl)</em> and add it to the
-            <a>set of availability objects</a>.
-            </li>
-            <li>Run the algorithm to <a>monitor the list of available
-            presentation displays</a>.
-            </li>
-            <li>
-              <a>Resolve</a> <em>P</em> with <em>A</em>.
-            </li>
-          </ol>
-        </section>
-        <section>
-          <h4>
             Event Handlers
           </h4>
           <p>
@@ -1241,38 +1110,6 @@
               </tr>
             </tbody>
           </table>
-        </section>
-        <section>
-          <h3>
-            Interface <code>PresentationConnectionAvailableEvent</code>
-          </h3>
-          <pre class="idl">
-            [Constructor(DOMString type, PresentationConnectionAvailableEventInit eventInitDict)]
-            interface PresentationConnectionAvailableEvent : Event {
-              [SameObject] readonly attribute PresentationConnection connection;
-            };
-
-            dictionary PresentationConnectionAvailableEventInit : EventInit {
-              required PresentationConnection connection;
-            };
-
-
-</pre>
-          <p>
-            A <a>controlling user agent</a> MUST fire an event named
-            <code>connectionavailable</code> on a <a>PresentationRequest</a>
-            when a connection associated with the object is created. It is
-            fired at the <a>PresentationRequest</a> instance, using the
-            <a>PresentationConnectionAvailableEvent</a> interface, with the
-            <a for="PresentationConnectionAvailableEvent">connection</a>
-            attribute set to the <a><code>PresentationConnection</code></a>
-            object that was created. The event is fired for each connection
-            that is created for the <a>controller</a>, either by the
-            <a>controller</a> calling <code>start()</code> or
-            <code>reconnect()</code>, or by the <a>controlling user agent</a>
-            creating a connection on the controller's behalf via <a for=
-            "Presentation"><code>defaultRequest</code></a>.
-          </p>
         </section>
       </section>
       <section>
@@ -1387,7 +1224,7 @@
           <p>
             If <a>set of availability objects</a> is non-empty, or there is a
             pending request to <a for="PresentationRequest" data-lt=
-            "start">start a presentation connection</a>, the user agent MUST
+            "start">start a presentation</a>, the user agent MUST
             <dfn>monitor the list of available presentation displays</dfn> by
             running the following steps.
           </p>
@@ -1442,7 +1279,7 @@
             </li>
             <li>If the <a>set of availability objects</a> is now empty and
             there is no pending request to <a for="PresentationRequest"
-              data-lt="start">start a presentation connection</a>, cancel any
+              data-lt="start">start a presentation</a>, cancel any
               pending task to <a>monitor the list of available presentation
               displays</a> for power saving purposes.
             </li>
@@ -1452,6 +1289,38 @@
             availability and determine the compatibility of a <a>presentation
             display</a> with a given URL is left to the user agent.
           </div>
+        </section>
+        <section>
+          <h3>
+            Interface <code>PresentationConnectionAvailableEvent</code>
+          </h3>
+          <pre class="idl">
+            [Constructor(DOMString type, PresentationConnectionAvailableEventInit eventInitDict)]
+            interface PresentationConnectionAvailableEvent : Event {
+              [SameObject] readonly attribute PresentationConnection connection;
+            };
+
+            dictionary PresentationConnectionAvailableEventInit : EventInit {
+              required PresentationConnection connection;
+            };
+
+
+</pre>
+          <p>
+            A <a>controlling user agent</a> MUST fire an event named
+            <code>connectionavailable</code> on a <a>PresentationRequest</a>
+            when a connection associated with the object is created. It is
+            fired at the <a>PresentationRequest</a> instance, using the
+            <a>PresentationConnectionAvailableEvent</a> interface, with the
+            <a for="PresentationConnectionAvailableEvent">connection</a>
+            attribute set to the <a><code>PresentationConnection</code></a>
+            object that was created. The event is fired for each connection
+            that is created for the <a>controller</a>, either by the
+            <a>controller</a> calling <code>start()</code> or
+            <code>reconnect()</code>, or by the <a>controlling user agent</a>
+            creating a connection on the controller's behalf via <a for=
+            "Presentation"><code>defaultRequest</code></a>.
+          </p>
         </section>
       </section>
       <section>
@@ -1842,8 +1711,67 @@
             </ol>
           </li>
         </ol>
+        <section>
+          <h4>
+            Creating a receiving browsing context
+          </h4>
+          <dl>
+            <dt>
+              Input
+            </dt>
+            <dd>
+              <em>D</em>, a <a>presentation display</a> chosen by the user
+            </dd>
+            <dt>
+              Output
+            </dt>
+            <dd>
+              <em>R</em>, a <a>receiving browsing context</a>
+            </dd>
+          </dl>
+          <p>
+            When the user agent is to <dfn>create a receiving browsing
+            context</dfn>, it must run the following steps:
+          </p>
+          <ol>
+            <li>Create a new <a>top-level browsing context</a> <em>C</em> on
+            the user agent connected to <em>D</em>.
+            </li>
+            <li>Set the <a>session history</a> of <em>C</em> to be the empty
+            list.
+            </li>
+            <li>Set the <a>sandboxed auxiliary navigation browsing context
+            flag</a> on <em>C</em>.
+            </li>
+            <li>Set the <a><code>sessionStorage</code></a> attribute for the
+            <code>Window</code> object associated with <em>C</em> to a new,
+            empty storage area.
+            </li>
+            <li>Set the <a><code>localStorage</code></a> attribute for the
+            <code>Window</code> object associated with <em>C</em> to a new,
+            empty storage area.
+            </li>
+            <li>Set the <a>cookie store</a> for <em>C</em> to an empty
+            <a>cookie store</a>.
+            </li>
+            <li>Set the <a>permission state</a> of all <a>Permissions</a> for
+            <em>C</em> to <code>"denied"</code>.
+            </li>
+            <li>Set the IndexedDB <a>databases</a> for <em>C</em> to an empty
+            set of <a>databases</a>.
+            </li>
+            <li>Return <em>C</em>.
+            </li>
+          </ol>
+          <p>
+            When the <a>receiving browsing context</a> is closed, any
+            associated browsing state, including <a>session history</a>,
+            <code>sessionStorage</code>, <code>localStorage</code>, the
+            <a>cookie store</a>, and <a>databases</a> must be discarded and not
+            used for any other <a>receiving browsing context</a>.
+          </p>
+        </section>
       </section>
-    </section>
       <section>
         <h3>
           Interface <a><code>PresentationConnectionList</code></a>
@@ -1863,8 +1791,7 @@
         </p>
         <section>
           <h4>
-            Monitoring incoming presentation connections in a receiving
-            browsing context
+            Monitoring incoming presentation connections
           </h4>
           <p>
             When the <a>receiving user agent</a> is to start <dfn>monitoring
@@ -1960,6 +1887,7 @@
           </table>
         </section>
       </section>
+    </section>
     <section>
       <h2>
         Security and privacy considerations


### PR DESCRIPTION
This PR reorganizes the API section to be more logical, starting from the top level interface and working down.  It also improves naming for a couple of the algorithms.

The new outline:

```
6. API
6.1 Common idioms
6.2 Interface Presentation
6.2.1 Controlling user agent
6.2.2 Receiving user agent
6.3 Interface PresentationRequest
6.3.1 Constructing a PresentationRequest
6.3.2 Starting a presentation
6.3.3 Reconnecting to a presentation
6.3.4 Establishing a presentation connection
6.3.5 Event Handlers
6.4 Interface PresentationAvailability
6.4.1 The set of availability objects
6.4.2 The list of available presentation displays
6.4.3 Monitoring the list of available presentation displays
6.4.4 Interface PresentationConnectionAvailableEvent
6.5 Interface PresentationConnection
6.5.1 Sending a message through PresentationConnection
6.5.2 Receiving a message through PresentationConnection
6.5.3 Closing a PresentationConnection
6.5.4 Terminating a PresentationConnection
6.5.5 Event Handlers
6.6 Interface PresentationReceiver
6.6.1 Creating a receiving browsing context
6.7 Interface PresentationConnectionList
6.7.1 Monitoring incoming presentation connections
6.7.2 Event Handlers
```