### PR TITLE
Sync example 6 with changes in #221, rename PresentationReceiver.connections to .connectionList

### DIFF
--- a/index.html
+++ b/index.html
@@ -1665,7 +1665,7 @@
         </h3>
         <pre class="idl">
           interface PresentationReceiver {
-            [SameObject] readonly attribute Promise&lt;PresentationConnectionList&gt; connections;
+            [SameObject] readonly attribute Promise&lt;PresentationConnectionList&gt; connectionList;
           };
 
 
@@ -1680,8 +1680,8 @@
           provided by a <a>receiving user agent</a>.
         </p>
         <p>
-          The <dfn for="PresentationReceiver">connections</dfn> attribute MUST
-          return the <a>connection list promise</a>.
+          The <dfn for="PresentationReceiver">connectionList</dfn> attribute
+          MUST return the <a>connection list promise</a>.
         </p>
         <p>
           For each <a>PresentationReceiver</a>, there is a <dfn>connection list

--- a/index.html
+++ b/index.html
@@ -689,10 +689,9 @@
             <a>controlling user agent</a> as the <dfn>default presentation
             request</dfn> for that controller. When the <a>controlling user
             agent</a> wishes to initiate a <a>PresentationConnection</a> on the
-            controller's behalf, it MUST <a>start a presentation</a>
-            using the <a>default presentation request</a> for the
-            <a>controller</a> (as if the controller had called
-            <code>defaultRequest.start()</code>).
+            controller's behalf, it MUST <a>start a presentation</a> using the
+            <a>default presentation request</a> for the <a>controller</a> (as
+            if the controller had called <code>defaultRequest.start()</code>).
           </p>
           <p>
             The <a>controlling user agent</a> SHOULD initiate presentation
@@ -708,9 +707,9 @@
           <div class="issue">
             It should be clear that user-intiated presentation via the user
             agent may have pre-selected the presentation display. In this case
-            step 6 of <a>start a presentation</a> is optional. It
-            may be cleaner to define a separate set of steps for initiating a
-            default presentation.
+            step 6 of <a>start a presentation</a> is optional. It may be
+            cleaner to define a separate set of steps for initiating a default
+            presentation.
           </div>
         </section>
         <section>
@@ -1227,9 +1226,9 @@
           <p>
             If <a>set of availability objects</a> is non-empty, or there is a
             pending request to <a for="PresentationRequest" data-lt=
-            "start">start a presentation</a>, the user agent MUST
-            <dfn>monitor the list of available presentation displays</dfn> by
-            running the following steps.
+            "start">start a presentation</a>, the user agent MUST <dfn>monitor
+            the list of available presentation displays</dfn> by running the
+            following steps.
           </p>
           <ol link-for="PresentationAvailability">
             <li>
@@ -1282,9 +1281,9 @@
             </li>
             <li>If the <a>set of availability objects</a> is now empty and
             there is no pending request to <a for="PresentationRequest"
-              data-lt="start">start a presentation</a>, cancel any
-              pending task to <a>monitor the list of available presentation
-              displays</a> for power saving purposes.
+              data-lt="start">start a presentation</a>, cancel any pending task
+              to <a>monitor the list of available presentation displays</a> for
+              power saving purposes.
             </li>
           </ol>
           <div class="note">

--- a/index.html
+++ b/index.html
@@ -580,7 +580,7 @@
     };
   };
 
-  navigator.presentation.receiver.connections.then(function (list) {
+  navigator.presentation.receiver.connectionList.then(function (list) {
     list.connections.map(function (connection) {
       addConnection(connection);
     });

--- a/index.html
+++ b/index.html
@@ -579,12 +579,15 @@
         connection.send("hello");
     };
   };
-  navigator.presentation.receiver.getConnection().then(addConnection);
-  navigator.presentation.receiver.onconnectionavailable = function(evt) {
-    navigator.presentation.receiver.getConnections().then(function(connections) {
-      addConnection(connections[connections.length-1]);
+
+  navigator.presentation.receiver.connections.then(function (list) {
+    list.connections.map(function (connection) {
+      addConnection(connection);
     });
-  };
+    list.connections.onconnectionavailable = function (connections) {
+      addConnection(connections[connections.length - 1]);
+    };
+  });
 &lt;/script&gt;
 
 </pre>

--- a/index.html
+++ b/index.html
@@ -1680,6 +1680,10 @@
           provided by a <a>receiving user agent</a>.
         </p>
         <p>
+          The <dfn for="PresentationReceiver">connections</dfn> attribute MUST
+          return the <a>connection list promise</a>.
+        </p>
+        <p>
           For each <a>PresentationReceiver</a>, there is a <dfn>connection list
           promise</dfn> which is initially set to <code>null</code>. It is a
           <a>Promise</a> object which holds a
@@ -1787,7 +1791,7 @@
 
 </pre>
         <p>
-          The <a for="PresentationConnectionList">connections</a> attribute
+          The <dfn for="PresentationConnectionList">connections</dfn> attribute
           MUST return a non-terminated <a>set of presentations</a> connections
           available for the <a>receiving browsing context</a>.
         </p>


### PR DESCRIPTION
* Update Example 6 with the following changes introduced in https://github.com/w3c/presentation-api/pull/221: `receiver.getConnection()` and `receiver.getConnections()` were removed and replaced by a Promise-returning [`connections`][1] attribute.
* Add `<dfn>`s for `PresentationReceiver.connections` and `PresentationConnectionList.connections`.
* (Some noise due to tidy.)

@mounirlamouri @mfoltzgoogle PTAL.

[1]: https://w3c.github.io/presentation-api/#idl-def-presentationreceiver