### PR TITLE
Adds a new "connecting" state and per-state event handlers.

### DIFF
--- a/index.html
+++ b/index.html
@@ -77,7 +77,7 @@
           }
         },
         issueBase: "https://www.github.com/w3c/presentation-api/issues/",
-        githubAPI: "https://api.github.com/repos/w3c/presentation-api",
+        // githubAPI: "https://api.github.com/repos/w3c/presentation-api",
 
         // Temp fix for ReSpec issue #483:
         // https://github.com/w3c/respec/issues/483
@@ -865,21 +865,6 @@
             <li>Otherwise, <em>T</em> has completed with the user <em>granting
             permission</em> to use a display; let <em>D</em> be that display.
             </li>
-            <li>
-              <a>Queue a task</a> <em>C</em> to run the following steps:
-              <ol>
-                <li>
-                  <a>Create a receiving browsing context</a> on <em>D</em> and
-                  let <em>R</em> be the result.
-                </li>
-                <li>
-                  <a>Navigate</a> <em>R</em> to <code>presentationUrl</code>.
-                </li>
-              </ol>
-            </li>
-            <li>If <em>C</em> fails, <a>reject</a> P with an
-            <a>OperationError</a> exception and abort all remaining steps.
-            </li>
             <li>Let <var>I</var> be a new <a>valid presentation identifier</a>
             unique among all <a>presentation identifiers</a> for known
             presentations in the <a>set of presentations</a>.
@@ -903,7 +888,26 @@
               <code>connection</code> attribute.
             </li>
             <li>
-              <a>Establish a presentation connection</a> with <em>S</em>.
+              <a>Queue a task</a> <em>C</em> to run the following steps:
+              <ol>
+                <li>
+                  <a>Create a receiving browsing context</a> on <em>D</em> and
+                  let <em>R</em> be the result.
+                </li>
+                <li>
+                  <a>Navigate</a> <em>R</em> to <code>presentationUrl</code>.
+                </li>
+                <li>
+                  <a>Establish a presentation connection</a> with <em>S</em>.
+                </li>
+              </ol>
+            </li>
+            <li>If any step of <em>C</em> fails, run the steps to 
+              <a data-lt="close-algorithm">close the presentation connection</a> with
+                  <var>S</var>
+                  as <code>presentationConnection</code>, <code>error</code>
+                  as <code>closeReason</code>, and a human readable message
+                  describing the failure as <code>closeMessage</code>.
             </li>
           </ol>
           <div class="note">
@@ -1025,17 +1029,17 @@
               Input
             </dt>
             <dd>
-              <em>presentationConnection</em>, the
+              <code>presentationConnection</code>, the
               <code>PresentationConnection</code> object that is to be connected.
               The <a>presentation connection state</a>
-              of <em>presentationConnection</em> must
+              of <code>presentationConnection</code> must
               be <code>connecting.</code>
             </dd>
           </dl>
           <ol>
             <li>
               <a>Queue a task</a> <em>T</em> to
-              connect <em>presentationConnection</em> to the <a>receiving
+              connect <code>presentationConnection</code> to the <a>receiving
               browsing context</a>.
             </li>
             <li>If <em>T</em> completes successfully, run the following steps:
@@ -1069,14 +1073,6 @@
             If <em>T</em> does not complete successfully, the user agent may
             choose to re-execute the Presentation Connection algorithm at a
             later time.
-          </div>
-          <div class="issue">
-            Do we want to notify the caller of a failure to connect, i.e. with
-            an "error" onstatechange?
-          </div>
-          <div class="issue">
-            Do we want to pass the new state as a property of the statechange
-            event?
           </div>
         </section>
         <section>
@@ -1371,9 +1367,10 @@
           </p>
           <p>
             When the <code><dfn>close</dfn>()</code> method is called on a
-            <a>PresentationConnection</a>, the user agent MUST run the
-            algorithm to <a data-lt="close-algorithm">close a presentation
-            connection</a> with <a>PresentationConnection</a>.
+            <a>PresentationConnection</a>, the user agent MUST run the algorithm
+            to <a data-lt="close-algorithm">close a presentation connection</a>
+            with <a>PresentationConnection</a>, a <code>reason</code>
+            of <code>closed</code>, and an empty <code>message</code>.
           </p>
           <p>
             When the <code><dfn>terminate</dfn>()</code> method is called on a
@@ -1385,8 +1382,17 @@
             When the <code><dfn>send</dfn>()</code> method is called on a
             <a>PresentationConnection</a> object with a <code>message</code>,
             the user agent MUST run the algorithm to <a data-lt=
-            "algorithm-send">send a message through a
+            "send-algorithm">send a message through a
             <code>PresentationConnection</code></a>.
+          </p>
+          <p>
+            When the a <a>PresentationConnection</a> object is discarded
+            (because the document owning it is navigating or is closed), the
+            user agent SHOULD run steps 1 and 4 or 5 of the algorithm
+            to <a data-lt="close-algorithm">close a presentation
+            connection</a> with the <a>PresentationConnection</a> object
+            as <code>presentationConnection</code>, <code>wentAway</code>
+            as <code>closeReason</code>, and an empty <code>closeMessage</code>.
           </p>
         </div>
         <section>
@@ -1406,23 +1412,28 @@
             Let <dfn>presentation message data</dfn> be the payload data to be
             transmitted between two browsing contexts. Let <dfn>presentation
             message type</dfn> be the type of that data, one of
-            <code>text</code> and <code>binary</code>.
+            <code>text</code> or <code>binary</code>.
           </p>
           <p>
-            When the user agent is to <dfn data-lt="algorithm-send">send a
-            message through a <code>PresentationConnection</code> S</dfn>, it
+            When the user agent is to <dfn data-lt="send-algorithm">send a
+            message</dfn> through a <a>presentation connection</a>, it
             MUST run the following steps:
           </p>
+          <dl>
+            <dt>Input</dt>
+            <dd><code>presentationConnection</code>, the <a>presentation connection</a> connected to the other browsing context
+            <dd><code>messageOrData</code>, the <a>presentation message data</a> to send to the other browsing context
+          </dl>
           <ol link-for="PresentationConnection">
-            <li>If the <a>state</a> property of <a>PresentationConnection</a>
-            is not <code>"connected"</code>, throw an
+            <li>If the <a>state</a> property of <code>presentationConnection</code>
+            is not <code>connected</code>, throw an
             <code>InvalidStateError</code> exception.
             </li>
             <li>Let <a>presentation message type</a> <em>messageType</em> be
-            <code>binary</code> if <code>data</code> is one of
+            <code>binary</code> if <code>messageOrData</code> is of type
             <code>ArrayBuffer</code>, <code>ArrayBufferView</code>, or
             <code>Blob</code>. Let <em>messageType</em> be <code>text</code> if
-            <code>data</code> is of type <code>DOMString</code>)
+            <code>messageOrData</code> is of type <code>DOMString</code>.
             </li>
             <li>Assign the <dfn>destination browsing context</dfn> as follows:
               <ol>
@@ -1437,13 +1448,33 @@
                 </li>
               </ol>
             </li>
-            <li>Using an implementation specific mechanism, transmit the
-            contents of the <code>data</code> argument as <a>presentation
-            message data</a> and <a>presentation message type</a>
-            <em>messageType</em> to the <a>destination browsing context</a>
-            side.
+            <li>
+              Using an implementation specific mechanism, transmit the
+              contents of <code>messageOrData</code> as the <a>presentation
+                message data</a> and <em>messageType</em> as the <a>presentation message type</a>
+              to the <a>destination browsing context</a>.
+            </li>
+            <li>
+              If the previous step encounters an unrecoverable error,
+              then <a data-lt="close-algorithm">close the presentation
+              connection</a>
+              with <code>presentationConnection</code>, <code>error</code>
+              as <code>closeReason</code>, and a <code>closeMessage</code>
+              describing the error encountered.
             </li>
           </ol>
+          <div class="note">
+            <p>
+            To assist applications in recovery from a an error sending a message through
+            a <a>presentation connection</a>, the user agent should include
+            details of which attempt failed in <code>closeMessage</code>. 
+            Example renditions of <code>closeMessage</code>:
+            <ul>
+              <li><code>Unable to send message: "hello"</code> for <code>DOMString</code> messages, where <code>"hello"</code> is the first 256 characters of the failed message.</li>
+              <li><code>Unable to send binary message</code> for <code>ArrayBuffer</code>, <code>ArrayBufferView</code> and <code>Blob</code> messages.</li>
+            </ul>
+            </p>
+          </div>
         </section>
         <section>
           <h4>
@@ -1452,11 +1483,19 @@
           <p>
             When the user agent has received a transmission from the remote
             side consisting of <a>presentation message data</a> and
-            <a>presentation message type</a>, it MUST run the following steps:
+            <a>presentation message type</a>, it MUST run the following steps
+            to <dfn data-lt="receive-algorithm">receive a message</dfn> through
+            a <code>PresentationConnection</code>:
           </p>
+          <dl>
+            <dt>Input</dt>
+            <dd><code>presentationConnection</code>, the <a>presentation connection</a> receiving the message</dd>
+            <dd><code>messageType</code>, the <a>presentation message type</a> of the message</dd>
+            <dd><code>messageData</code>, the <a>presentation message data</a> of the message</dd>
+          </dl>
           <ol link-for="PresentationConnection">
-            <li>If the <a>state</a> property of <a>PresentationConnection</a>
-            is not <code>"connected"</code>, abort these steps.
+            <li>If the <a>state</a> property of <code>presentationConnection</code>
+            is not <code>connected</code>, abort these steps.
             </li>
             <li>Let <em>event</em> be a newly created <a>trusted event</a> that
             uses the <code>MessageEvent</code> interface, with the event type
@@ -1465,23 +1504,22 @@
             </li>
             <li>Initialize the <em>event's</em> data attribute as follows:
               <ol>
-                <li>If the <a>presentation message type</a> is
+                <li>If <code>messageType</code> is
                 <code>text</code>, then initialize <em>event's</em>
-                <code>data</code> attribute to the contents of <a>presentation
-                message data</a> of type <code>DOMString</code>.
+                <code>data</code> attribute to <code>messageData</code> with type <code>DOMString</code>.
                 </li>
-                <li>If the <a>presentation message type</a> is
+                <li>If <code>messageType</code> is
                 <code>binary</code>, and <a>binaryType</a> is set to
                 <code>blob</code>, then initialize <em>event</em>'s
                 <code>data</code> attribute to a new <code>Blob</code> object
-                that represents <a>presentation message data</a> as its raw
+                with <code>messageData</code> its raw
                 data.
                 </li>
-                <li>If the <a>presentation message type</a> is
+                <li>If <code>messageType</code> is
                 <code>binary</code>, and <a>binaryType</a> is set to
                 <code>arraybuffer</code>, then initialize <em>event</em>'s
                 <code>data</code> attribute to a new <code>ArrayBuffer</code>
-                object whose contents are <a>presentation message data</a>.
+                object whose contents are <code>messageData</code>.
                 </li>
               </ol>
             </li>
@@ -1490,6 +1528,15 @@
               <a><code>PresentationConnection</code></a>.
             </li>
           </ol>
+          <p>
+            If the user agent encounters an unrecoverable error
+            while <a data-lt="receive-algorithm">receiving a message</a>
+            through <code>presentationConnection</code>, it
+            should <a data-lt="close-algorithm">close the presentation
+            connection</a> with <code>presentationConnection</code>,
+            <code>error</code> as <code>closeReason</code>, and a human readable
+            description of the error encountered as <code>closeMessage</code>.
+          </p>
         </section>
         <section>
           <h4>
@@ -1497,31 +1544,31 @@
           </h4>
           <pre class="idl">
             enum PresentationConnectionClosedReason { "error", "closed", "wentAway" };
-            
+
             [Constructor(DOMString type, PresentationConnectionClosedEventInit eventInitDict)]
             interface PresentationConnectionClosedEvent : Event {
               readonly attribute PresentationConnectionCloseReason reason;
-              readonly optional attribute DOMString errorMessage;
+              readonly attribute DOMString message;
             };
 
             dictionary PresentationConnectionClosedEventInit : EventInit {
               required PresentationConnectionCloseReason reason;
-              optional DOMString errorMessage = "";
+              DOMString message;
             };
 
 
 </pre>
           <p>
             A <code>PresentationConnectionClosedEvent</code> is fired when
-            a <a>presentation connection</a> enters a <code>closed<code> state.
+            a <a>presentation connection</a> enters a <code>closed</code> state.
             The <code>reason</code> attribute provides the reason why the
             connection was closed:
           </p>
           <ul>
-            <li> <code>error</code> means that the underlying communication channel entered an error state. </li>
-            <li> <code>closed<code> means that either the <a>controlling browsing context</a> or the <a>receiving browsing context</a> that were connected by the <code>PresentationConnection</code> called <code>close()</code>. </li>
-            <li> "wentAway" means that the browser closed the connection, for
-              example, because either the controlling or receiving browsing context navigated. </li>
+            <li> <code>error</code> means that the mechanism for connecting or communicating with a presentation entered an unrecoverable error.</li>
+            <li> <code>closed</code> means that either the <a>controlling browsing context</a> or the <a>receiving browsing context</a> that were connected by the <code>PresentationConnection</code> called <code>close()</code>. </li>
+            <li> <code>wentAway</code> means that the browser closed the connection, for
+              example, because the browsing context that owned the connection navigated or was discarded.</li>
           </ul>
           <p>
             When the <code>reason</code> attribute is <code>error</code>, the
@@ -1538,37 +1585,44 @@
             presentation connection</dfn> using <em>connection</em>, it MUST do
             the following:
           </p>
+          <dl>
+            <dt>Input</dt>
+            <dd><code>presentationConnection</code>, the <em>presentation connection</em> to be closed</dd>
+            <dd><code>closeReason</code>, the <code>PresenentationConnectionClosedReason</code> describing why the connection is to be closed</dd>
+            <dd><code>closeMessage</code>, a human-readable message with details of why the connection was closed.</dd>
+          </dl>
           <ol>
             <li>
               <a>Queue a task</a> to run the following steps in order:
               <ol>
                 <li>If the <a>presentation connection state</a> of
-                <em>connection</em> is not <code>connected</code>
+                <code>presentationConnection</code> is not <code>connected</code>
                 or <code>connecting</code>, then abort these steps.
                 </li>
                 <li>Set <a>presentation connection state</a> of
-                <em>connection</em> to <code>closed</code>.
+                <code>presentationConnection</code> to <code>closed</code>.
                 </li>
                 <li>
                   Construct a new <code>PresentationConnectionClosedEvent</code>
-                    <var>E</var> with <code>reason</code> set to <code>closed</code>.
+                    <var>E</var> with <code>reason</code> set to <var>closeReason</var> and
+                    <code>message</code> set to <var>closeMessage</var>.
                 </li>
                 </li>
-                  <a>Fire</a> <var>E</var> at <em>connection</em>.
+                  <a>Fire</a> <var>E</var> at <code>presentationConnection</code>.
                 </li>
-                <li>If <em>connection</em> is owned by a <a>controlling
+                <li>If <code>presentationConnection</code> is owned by a <a>controlling
                 browsing context</a>, signal the <a>receiving browsing
                 context</a> to <a data-lt="close-algorithm">close the
                 presentation connection</a> that was created when
-                <em>connection</em> was used to <a>establish a presentation
-                connection</a> with the presentation via <em>connection</em>,
+                <code>presentationConnection</code> was used to <a>establish a presentation
+                connection</a> with the presentation via <code>presentationConnection</code>,
                 using an implementation-specific mechanism.
                 </li>
-                <li>If <em>connection</em> is owned by a <a>receiving browsing
+                <li>If <code>presentationConnection</code> is owned by a <a>receiving browsing
                 context</a>, signal the <a>controlling browsing context</a> to
                 <a data-lt="close-algorithm">close the presentation
                 connection</a> that was used to <a>establish a presentation
-                connection</a> with the presentation via <em>connection</em>,
+                connection</a> with the presentation via <code>presentationConnection</code>,
                 using an implementation-specific mechanism.
                 </li>
               </ol>

--- a/index.html
+++ b/index.html
@@ -77,6 +77,7 @@
           }
         },
         issueBase: "https://www.github.com/w3c/presentation-api/issues/",
+        // TODO: Uncomment when https://github.com/w3c/presentation-api/issues/228 is fixed
         // githubAPI: "https://api.github.com/repos/w3c/presentation-api",
 
         // Temp fix for ReSpec issue #483:
@@ -498,7 +499,7 @@
   }
 &lt;/script&gt;
 </pre>
-      </section>
+      </section><!-- TODO: Add an example for terminating a presentation. -->
       <section>
         <h3>
           Handling an event for a controlling UA initiated presentation example
@@ -979,7 +980,6 @@
                     identifier</a> of <var>known connection</var> is equal to
                     <code>presentationId</code>, run the following steps:
                     <ol>
-                      <!-- TODO(mfoltz): We should explicitly construct a new connection if necessary. -->
                       <li>Let <var>S</var> be the <a>presentation
                       connection</a> of <var>known connection</var>.
                       </li>
@@ -992,9 +992,9 @@
                         <code>presentationRequest</code> with <em>S</em> as its
                         <code>connection</code> attribute.
                       </li>
-                      <li>If the <a>presentation connection state</a> of <var>
-                        S</var> is <code>closed</code>, then <a>establish a
-                        presentation connection</a> with <var>S</var>.
+                      <li>
+                        <a>Establish a presentation connection</a> with
+                        <var>S</var>.
                       </li>
                       <li>Abort the remaining steps of <var>T</var>.
                       </li>
@@ -1008,6 +1008,7 @@
               </ol>
             </li>
           </ol>
+          <div class="issue" data-number="229"></div>
           <div class="issue">
             If no matching presentation is found, we could leave the Promise
             pending in case a matching presentation is started in the future.
@@ -1033,7 +1034,7 @@
               <code>PresentationConnection</code> object that is to be
               connected. The <a>presentation connection state</a> of
               <code>presentationConnection</code> must be
-              <code>connecting.</code>
+              <code>connecting</code>.
             </dd>
           </dl>
           <ol>

--- a/index.html
+++ b/index.html
@@ -534,27 +534,26 @@
       // save presId in localStorage
       localStorage &amp;&amp; (localStorage["presId"] = connection.id);
       // monitor connection's state
-      connection.onstatechange = function () {
-        if (this == connection) {
-          if (this.state == "closed") {
-            // Offer the user a chance to reconnect(), e.g. if there was a
-            // network disruption, or the user wishes to resume control.
-          } else if (this.state == "terminated") {
-            // The presentation has terminated.  Offer the user a chance to
-            // start a new presentation.
-          } else if (this.state == "connected") {
-            // send initial message to presentation page
-            connection.send("say hello");
-          }
+      connection.onclosed = function () {
+        // Offer the user a chance to reconnect, e.g. if there was a
+        // network disruption, or the user wishes to resume control.
       };
-      // register message handler
-      connection.onmessage = function (evt) {
-        console.log("receive message", evt.data);
+      connection.onconnected = function () {
+        // register message handler
+        this.onmessage = function (message) {
+          console.log("receive message", message.data);
+        };
+        // send initial message to presentation page
+        this.send("say hello");
+      };
+      connection.onterminated = function () {
+        // The presentation has terminated.  Offer the user a chance to
+        // start a new presentation.
       };
     }
   };
   var endConnection = function () {
-    connection &amp;&amp; connection.terminate();
+    connection &amp;&amp; connection.close();
     // remove old presId from localStorage if exists
     localStorage &amp;&amp; delete localStorage["presId"];
   };
@@ -570,13 +569,11 @@
 &lt;!-- receiver.html --&gt;
 &lt;script&gt;
   var addConnection = function(connection) {
-    connection.onstatechange = function () {
-      // connection.state is either 'connected,' 'closed,' or 'terminated'
-      console.log("connection's state is now", connection.state);
-    };
-    connection.onmessage = function (evt) {
-      if (evt.data == "say hello")
-        connection.send("hello");
+    connection.onconnected = function () {
+      this.onmessage = function (message) {
+        if (message.data == "say hello")
+          this.send("hello");
+      };
     };
   };
   navigator.presentation.receiver.getConnection().then(addConnection);
@@ -891,7 +888,7 @@
             </li>
             <li>Set the <a>presentation identifier</a> of <var>S</var> to <var>
               I</var>, and set the <a>presentation connection state</a> of
-              <var>S</var> to <code>disconnected</code>.
+              <var>S</var> to <code>connecting</code>.
             </li>
             <li>Add the tuple {<em>presentationUrl</em>, <em>S.id</em>,
             <em>S</em>} to the <a>set of presentations</a>.
@@ -1015,40 +1012,44 @@
           <h4>
             Establishing a presentation connection
           </h4>
+          <!-- TODO(mfoltz): Move this to 6.5.1, under the
+               PresentationConnection interface.  Leaving here for now to simplify
+               the diff. -->
           <p>
             When the user agent is to <dfn>establish a presentation
-            connection</dfn> using a <a>presentation connection</a> <em>S</em>,
+            connection</dfn> using a <a>presentation connection</a>,
             it MUST run the following steps:
           </p>
+          <dl>
+            <dt>
+              Input
+            </dt>
+            <dd>
+              <em>presentationConnection</em>, the
+              <code>PresentationConnection</code> object that is to be connected.
+              The <a>presentation connection state</a>
+              of <em>presentationConnection</em> must
+              be <code>connecting.</code>
+            </dd>
+          </dl>
           <ol>
             <li>
-              <a>Queue a task</a> <em>T</em> to connect the <a>presentation
-              connection</a> <em>S</em> to the <a>receiving browsing
-              context</a>.
+              <a>Queue a task</a> <em>T</em> to
+              connect <em>presentationConnection</em> to the <a>receiving
+              browsing context</a>.
             </li>
             <li>If <em>T</em> completes successfully, run the following steps:
               <ol>
                 <li>Set the <a>presentation connection state</a> of
-                <var>S</var> to <code>connected.</code>
+                <var>presentationConnection</var> to <code>connected.</code>
                 </li>
-                <li>
-                  <a>Queue a task</a> <em>T</em> to run the following steps in
-                  order:
-                  <ol>
-                    <li>For each <var>known connection</var> in the <a>set of
+                <li>For each <var>known connection</var> in the <a>set of
                     presentations</a>:
-                      <ol>
-                        <li>If the <a>presentation identifier</a> of <var>known
-                        connection</var> and <var>S</var> are equal, then run
-                        the following steps:
-                          <ol>
-                            <li>
-                              <a>Queue a task</a> to <a>fire</a> an event named
-                              <code>statechange</code> at <em>s</em>.
-                            </li>
-                          </ol>
-                        </li>
-                      </ol>
+                  <ol>
+                    <li>If the <a>presentation identifier</a> of <var>known
+                        connection</var> and <var>presentationConnection</var>
+                      are equal, then <a>fire</a> an event named
+                      <code>connected</code> at <em>s</em>.
                     </li>
                   </ol>
                 </li>
@@ -1291,9 +1292,9 @@
           </div>
         </section>
         <section>
-          <h3>
+          <h4>
             Interface <code>PresentationConnectionAvailableEvent</code>
-          </h3>
+          </h4>
           <pre class="idl">
             [Constructor(DOMString type, PresentationConnectionAvailableEventInit eventInitDict)]
             interface PresentationConnectionAvailableEvent : Event {
@@ -1334,7 +1335,7 @@
           <a>PresentationConnection</a>.
         </p>
         <pre class="idl">
-          enum PresentationConnectionState { "connected", "closed", "terminated" };
+          enum PresentationConnectionState { "connecting", "connected", "closed", "terminated" };
           enum BinaryType { "blob", "arraybuffer" };
 
           interface PresentationConnection : EventTarget {
@@ -1342,7 +1343,9 @@
             readonly attribute PresentationConnectionState state;
             void close();
             void terminate();
-            attribute EventHandler onstatechange;
+            attribute EventHandler onconnected;
+            attribute EventHandler onclosed;
+            attribute EventHandler onterminated;
 
             // Communication
             attribute BinaryType binaryType;
@@ -1490,6 +1493,44 @@
         </section>
         <section>
           <h4>
+            Interface <code>PresentationConnectionClosedEvent</code>
+          </h4>
+          <pre class="idl">
+            enum PresentationConnectionClosedReason { "error", "closed", "wentAway" };
+            
+            [Constructor(DOMString type, PresentationConnectionClosedEventInit eventInitDict)]
+            interface PresentationConnectionClosedEvent : Event {
+              readonly attribute PresentationConnectionCloseReason reason;
+              readonly optional attribute DOMString errorMessage;
+            };
+
+            dictionary PresentationConnectionClosedEventInit : EventInit {
+              required PresentationConnectionCloseReason reason;
+              optional DOMString errorMessage = "";
+            };
+
+
+</pre>
+          <p>
+            A <code>PresentationConnectionClosedEvent</code> is fired when
+            a <a>presentation connection</a> enters a <code>closed<code> state.
+            The <code>reason</code> attribute provides the reason why the
+            connection was closed:
+          </p>
+          <ul>
+            <li> <code>error</code> means that the underlying communication channel entered an error state. </li>
+            <li> <code>closed<code> means that either the <a>controlling browsing context</a> or the <a>receiving browsing context</a> that were connected by the <code>PresentationConnection</code> called <code>close()</code>. </li>
+            <li> "wentAway" means that the browser closed the connection, for
+              example, because either the controlling or receiving browsing context navigated. </li>
+          </ul>
+          <p>
+            When the <code>reason</code> attribute is <code>error</code>, the
+            user agent SHOULD set the error message to a human readable
+            description of how the communication channel encountered an error.
+          </p>
+        </section>
+        <section>
+          <h4>
             Closing a <code>PresentationConnection</code>
           </h4>
           <p>
@@ -1502,15 +1543,18 @@
               <a>Queue a task</a> to run the following steps in order:
               <ol>
                 <li>If the <a>presentation connection state</a> of
-                <em>connection</em> is not <code>connected</code>, then abort
-                these steps.
+                <em>connection</em> is not <code>connected</code>
+                or <code>connecting</code>, then abort these steps.
                 </li>
                 <li>Set <a>presentation connection state</a> of
                 <em>connection</em> to <code>closed</code>.
                 </li>
                 <li>
-                  <a>Fire</a> an event named <code>statechange</code> at
-                  <em>connection</em>.
+                  Construct a new <code>PresentationConnectionClosedEvent</code>
+                    <var>E</var> with <code>reason</code> set to <code>closed</code>.
+                </li>
+                </li>
+                  <a>Fire</a> <var>E</var> at <em>connection</em>.
                 </li>
                 <li>If <em>connection</em> is owned by a <a>controlling
                 browsing context</a>, signal the <a>receiving browsing
@@ -1647,10 +1691,26 @@
               </tr>
               <tr>
                 <td>
-                  <dfn><code>onstatechange</code></dfn>
+                  <dfn><code>onconnected</code></dfn>
                 </td>
                 <td>
-                  <code>statechange</code>
+                  <code>connected</code>
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  <dfn><code>onclosed</code></dfn>
+                </td>
+                <td>
+                  <code>closed</code>
+                </td>
+              </tr>
+              <tr>
+                <td>
+                  <dfn><code>onterminated</code></dfn>
+                </td>
+                <td>
+                  <code>terminated</code>
                 </td>
               </tr>
             </tbody>

--- a/index.html
+++ b/index.html
@@ -1054,7 +1054,8 @@
                     <li>If the <a>presentation identifier</a> of <var>known
                     connection</var> and <var>presentationConnection</var> are
                     equal, then <a>fire</a> an event named
-                    <code>connected</code> at <em>s</em>.
+                    <code>connected</code> at
+                    <var>presentationConnection</var>.
                     </li>
                   </ol>
                 </li>
@@ -1628,8 +1629,8 @@
               Input
             </dt>
             <dd>
-              <code>presentationConnection</code>, the <em>presentation
-              connection</em> to be closed
+              <code>presentationConnection</code>, the <a>presentation
+              connection</a> to be closed
             </dd>
             <dd>
               <code>closeReason</code>, the

--- a/index.html
+++ b/index.html
@@ -424,8 +424,9 @@
         <code>presentation.html</code> implements the presentation. Both pages
         are served from the domain <code>http://example.org</code>
         (<code>http://example.org/controller.html</code> and
-        <code>http://example.org/presentation.html</code>). Please refer to the
-        comments in the code examples for further details.
+        <code>http://example.org/presentation.html</code>). These examples
+        assume that the controlling page is managing one presentation at a time.
+        Please refer to the comments in the code examples for further details.
       </p>
       <section>
         <h3>
@@ -433,15 +434,15 @@
         </h3>
         <pre class="example highlight">
 &lt;!-- controller.html --&gt;
-&lt;button id="castBtn" style="display: none;"&gt;Cast&lt;/button&gt;
+&lt;button id="presentBtn" style="display: none;"&gt;Present&lt;/button&gt;
 &lt;script&gt;
-  // it is also possible to use relative presentation URL e.g. "presentation.html"
+  // The Present button is visible if at least one presentation display is available
+  var presentBtn = document.getElementById("presentBtn");
+  // It is also possible to use relative presentation URL e.g. "presentation.html"
   var presUrl = "http://example.com/presentation.html";
-  // the cast button is visible if at least one presentation display is available
-  var castBtn = document.getElementById("castBtn");
-  // show or hide cast button depending on display availability
+  // show or hide present button depending on display availability
   var handleAvailabilityChange = function(available) {
-    castBtn.style.display = available ? "inline" : "none";
+    presentBtn.style.display = available ? "inline" : "none";
   };
   // Promise is resolved as soon as the presentation display availability is
   // known.
@@ -469,13 +470,15 @@
         <pre class="example highlight">
 &lt;!-- controller.html --&gt;
 &lt;script&gt;
-  // Start new presentation.
-  request.start()
-    // The connection to the presentation will be passed to setConnection on
-    // success.
-    .then(setConnection)
-    // User canceled the selection dialog or an error occurred.
-    .catch(endConnection);
+  presentBtn.onclick = function () {
+    // Start new presentation.
+    request.start()
+      // The connection to the presentation will be passed to setConnection on
+      // success.
+      .then(setConnection);
+      // Otherwise, the user canceled the selection dialog or no screens were
+      // found.
+  };
 &lt;/script&gt;
 </pre>
       </section>
@@ -485,24 +488,30 @@
         </h3>
         <pre class="example highlight">
 &lt;!-- controller.html --&gt;
+&lt;button id="reconnectBtn" style="display: none;"&gt;Reconnect&lt;/button&gt;
 &lt;script&gt;
-  // read presId from localStorage if exists
-  var presId = localStorage &amp;&amp; localStorage["presId"] || null;
-  // presId is mandatory when reconnecting to a presentation.
-  if (presId) {
-    request.reconnect(presId)
-      // The resumed connection to the presentation will be passed to
-      // setConnection on success.
-      .then(setConnection)
-      // No connection found for presUrl and presId, or an error occurred.
-      .catch(endConnection);
-  }
+  var reconnect = function () {
+    // read presId from localStorage if exists
+    var presId = localStorage["presId"];
+    // presId is mandatory when reconnecting to a presentation.
+    if (!!presId) {
+      request.reconnect(presId)
+        // The new connection to the presentation will be passed to
+        // setConnection on success.
+        .then(setConnection);
+        // No connection found for presUrl and presId, or an error occurred.
+    }
+  };
+  // On navigation of the controller, reconnect automatically.
+  document.addEventListener("DOMContentLoaded", reconnect);
+  // Or allow manual reconnection.
+  reconnectBtn.onclick = reconnect;
 &lt;/script&gt;
 </pre>
-      </section><!-- TODO: Add an example for terminating a presentation. -->
+      </section>
       <section>
         <h3>
-          Handling an event for a controlling UA initiated presentation example
+          Presentation initation by the controlling UA example
         </h3>
         <pre class="example highlight">
 &lt;!-- controller.html --&gt;
@@ -524,42 +533,56 @@
         </h3>
         <pre class="example highlight">
 &lt;!-- controller.html --&gt;
+&lt;button id="disconnectBtn" style="display: none;"&gt;Disconnect&lt;/button&gt;
+&lt;button id="terminateBtn" style="display: none;"&gt;Stop&lt;/button&gt;
 &lt;script&gt;
   var connection;
-  var setConnection = function (theConnection) {
-    // end existing connection, if any
-    endConnection();
-    // set the new connection
-    connection = theConnection;
-    if (connection) {
-      // save presId in localStorage
-      localStorage &amp;&amp; (localStorage["presId"] = connection.id);
-      // monitor connection's state
-      connection.onclosed = function () {
-        // Offer the user a chance to reconnect, e.g. if there was a
-        // network disruption, or the user wishes to resume control.
-      };
-      connection.onconnected = function () {
-        // register message handler
-        this.onmessage = function (message) {
-          console.log("receive message", message.data);
-        };
-        // send initial message to presentation page
-        this.send("say hello");
-      };
-      connection.onterminated = function () {
-        // The presentation has terminated.  Offer the user a chance to
-        // start a new presentation.
-      };
-    }
-  };
-  var endConnection = function () {
-    connection &amp;&amp; connection.close();
-    // remove old presId from localStorage if exists
-    localStorage &amp;&amp; delete localStorage["presId"];
-  };
-&lt;/script&gt;
 
+  // The Disconnect and Stop buttons are visible if there is a connected presentation
+  var disconnectBtn = document.getElementById("disconnectBtn");
+  var stopBtn = document.getElementById("stopBtn");
+  stopBtn.onclick = function () { connection && connection.terminate(); };
+
+  var setConnection = function (theConnection) {
+    // Disconnect from existing presentation, if any
+    close();
+    // Set the new connection and save the presentation ID
+    connection = theConnection;
+    localStorage["presId"] = connection.id;
+
+    // monitor connection's state
+    connection.onconnected = function () {
+      // Allow the user to disconnect from or terminate the presentation
+      disconnectBtn.style.display = "inline";
+      stopBtn.style.display = "inline";
+      reconnectBtn.style.display = "none";
+
+      // register message handler
+      this.onmessage = function (message) {
+        console.log("receive message", message.data);
+      };
+      // send initial message to presentation page
+      this.send("say hello");
+    };
+    connection.onclosed = reset;
+    connection.onterminated = function () {
+      // remove presId from localStorage if exists
+      delete localStorage["presId"];
+      // Reset the UI
+      reset();
+    };
+  };
+
+  var reset = function () {
+    connection = null;
+    disconnectBtn.style.display = "none";
+    stopBtn.style.display = "none";
+    reconnectBtn.style.display = localStorage["presId"] ? "inline" : "none";
+  };
+
+  var close = function () { connection &amp;&amp; connection.close(); };
+  disconnectBtn.onclick = close;
+&lt;/script&gt;
 </pre>
       </section>
       <section>
@@ -584,7 +607,6 @@
     });
   };
 &lt;/script&gt;
-
 </pre>
       </section>
     </section>
@@ -873,7 +895,7 @@
             </li>
             <li>Set the <a>presentation identifier</a> of <var>S</var> to <var>
               I</var>, and set the <a>presentation connection state</a> of
-              <var>S</var> to <code>connecting</code>.
+              <var>S</var> to <!-- <code>connecting</code>. -->
             </li>
             <li>Add the tuple {<em>presentationUrl</em>, <em>S.id</em>,
             <em>S</em>} to the <a>set of presentations</a>.
@@ -1012,69 +1034,6 @@
           <div class="issue">
             If no matching presentation is found, we could leave the Promise
             pending in case a matching presentation is started in the future.
-          </div>
-        </section>
-        <section>
-          <h4>
-            Establishing a presentation connection
-          </h4><!-- TODO(mfoltz): Move this to 6.5.1, under the
-               PresentationConnection interface.  Leaving here for now to simplify
-               the diff. -->
-          <p>
-            When the user agent is to <dfn>establish a presentation
-            connection</dfn> using a <a>presentation connection</a>, it MUST
-            run the following steps:
-          </p>
-          <dl>
-            <dt>
-              Input
-            </dt>
-            <dd>
-              <code>presentationConnection</code>, the
-              <code>PresentationConnection</code> object that is to be
-              connected. The <a>presentation connection state</a> of
-              <code>presentationConnection</code> must be
-              <code>connecting</code>.
-            </dd>
-          </dl>
-          <ol>
-            <li>
-              <a>Queue a task</a> <em>T</em> to connect
-              <code>presentationConnection</code> to the <a>receiving browsing
-              context</a>.
-            </li>
-            <li>If <em>T</em> completes successfully, run the following steps:
-              <ol>
-                <li>Set the <a>presentation connection state</a> of
-                <var>presentationConnection</var> to <code>connected.</code>
-                </li>
-                <li>For each <var>known connection</var> in the <a>set of
-                presentations</a>:
-                  <ol>
-                    <li>If the <a>presentation identifier</a> of <var>known
-                    connection</var> and <var>presentationConnection</var> are
-                    equal, then <a>fire</a> an event named
-                    <code>connected</code> at
-                    <var>presentationConnection</var>.
-                    </li>
-                  </ol>
-                </li>
-              </ol>
-            </li>
-          </ol>
-          <div class="note">
-            The mechanism that is used to present on the remote display and
-            connect the <a>controlling browsing context</a> with the presented
-            document is an implementation choice of the user agent. The
-            connection must provide a two-way messaging abstraction capable of
-            carrying <code>DOMString</code> payloads in a reliable and in-order
-            fashion as described in the <em>Send Message</em> and <em>Receive
-            Message</em> steps below.
-          </div>
-          <div class="note">
-            If <em>T</em> does not complete successfully, the user agent may
-            choose to re-execute the Presentation Connection algorithm at a
-            later time.
           </div>
         </section>
         <section>
@@ -1398,6 +1357,67 @@
             <code>closeReason</code>, and an empty <code>closeMessage</code>.
           </p>
         </div>
+        <section>
+          <h4>
+            Establishing a presentation connection
+          </h4>
+          <p>
+            When the user agent is to <dfn>establish a presentation
+            connection</dfn> using a <a>presentation connection</a>, it MUST
+            run the following steps:
+          </p>
+          <dl>
+            <dt>
+              Input
+            </dt>
+            <dd>
+              <code>presentationConnection</code>, the
+              <code>PresentationConnection</code> object that is to be
+              connected. The <a>presentation connection state</a> of
+              <code>presentationConnection</code> must be
+              <code>connecting</code>.
+            </dd>
+          </dl>
+          <ol>
+            <li>
+              <a>Queue a task</a> <em>T</em> to connect
+              <code>presentationConnection</code> to the <a>receiving browsing
+              context</a>.
+            </li>
+            <li>If <em>T</em> completes successfully, run the following steps:
+              <ol>
+                <li>Set the <a>presentation connection state</a> of
+                <var>presentationConnection</var> to <code>connected.</code>
+                </li>
+                <li>For each <var>known connection</var> in the <a>set of
+                presentations</a>:
+                  <ol>
+                    <li>If the <a>presentation identifier</a> of <var>known
+                    connection</var> and <var>presentationConnection</var> are
+                    equal, then <a>fire</a> an event named
+                    <code>connected</code> at
+                    <var>presentationConnection</var>.
+                    </li>
+                  </ol>
+                </li>
+              </ol>
+            </li>
+          </ol>
+          <div class="note">
+            The mechanism that is used to present on the remote display and
+            connect the <a>controlling browsing context</a> with the presented
+            document is an implementation choice of the user agent. The
+            connection must provide a two-way messaging abstraction capable of
+            carrying <code>DOMString</code> payloads in a reliable and in-order
+            fashion as described in the <em>Send Message</em> and <em>Receive
+            Message</em> steps below.
+          </div>
+          <div class="note">
+            If <em>T</em> does not complete successfully, the user agent may
+            choose to re-execute the Presentation Connection algorithm at a
+            later time.
+          </div>
+        </section>
         <section>
           <h4>
             Sending a message through <code>PresentationConnection</code>

--- a/index.html
+++ b/index.html
@@ -425,8 +425,9 @@
         are served from the domain <code>http://example.org</code>
         (<code>http://example.org/controller.html</code> and
         <code>http://example.org/presentation.html</code>). These examples
-        assume that the controlling page is managing one presentation at a time.
-        Please refer to the comments in the code examples for further details.
+        assume that the controlling page is managing one presentation at a
+        time. Please refer to the comments in the code examples for further
+        details.
       </p>
       <section>
         <h3>
@@ -541,7 +542,7 @@
   // The Disconnect and Stop buttons are visible if there is a connected presentation
   var disconnectBtn = document.getElementById("disconnectBtn");
   var stopBtn = document.getElementById("stopBtn");
-  stopBtn.onclick = function () { connection && connection.terminate(); };
+  stopBtn.onclick = function () { connection &amp;&amp; connection.terminate(); };
 
   var setConnection = function (theConnection) {
     // Disconnect from existing presentation, if any

--- a/index.html
+++ b/index.html
@@ -683,10 +683,9 @@
             <a>controlling user agent</a> as the <dfn>default presentation
             request</dfn> for that controller. When the <a>controlling user
             agent</a> wishes to initiate a <a>PresentationConnection</a> on the
-            controller's behalf, it MUST <a>start a presentation</a>
-            using the <a>default presentation request</a> for the
-            <a>controller</a> (as if the controller had called
-            <code>defaultRequest.start()</code>).
+            controller's behalf, it MUST <a>start a presentation</a> using the
+            <a>default presentation request</a> for the <a>controller</a> (as
+            if the controller had called <code>defaultRequest.start()</code>).
           </p>
           <p>
             The <a>controlling user agent</a> SHOULD initiate presentation
@@ -702,9 +701,9 @@
           <div class="issue">
             It should be clear that user-intiated presentation via the user
             agent may have pre-selected the presentation display. In this case
-            step 6 of <a>start a presentation</a> is optional. It
-            may be cleaner to define a separate set of steps for initiating a
-            default presentation.
+            step 6 of <a>start a presentation</a> is optional. It may be
+            cleaner to define a separate set of steps for initiating a default
+            presentation.
           </div>
         </section>
         <section>
@@ -902,12 +901,12 @@
                 </li>
               </ol>
             </li>
-            <li>If any step of <em>C</em> fails, run the steps to 
-              <a data-lt="close-algorithm">close the presentation connection</a> with
-                  <var>S</var>
-                  as <code>presentationConnection</code>, <code>error</code>
-                  as <code>closeReason</code>, and a human readable message
-                  describing the failure as <code>closeMessage</code>.
+            <li>If any step of <em>C</em> fails, run the steps to <a data-lt=
+            "close-algorithm">close the presentation connection</a> with <var>
+              S</var> as <code>presentationConnection</code>,
+              <code>error</code> as <code>closeReason</code>, and a human
+              readable message describing the failure as
+              <code>closeMessage</code>.
             </li>
           </ol>
           <div class="note">
@@ -972,13 +971,15 @@
                 <li>For each <var>known connection</var> in the <a>set of
                 presentations</a>,
                   <div style="margin-left: 2em">
-                    If the <a>presentation URL</a> of <var>known
-                    connection</var> is equal to the
-                    <code>presentationUrl</code> of
+                    If <a>presentation connection state</a> of <var>known
+                    presentation</var> is not <code>terminated</code>, the
+                    <a>presentation URL</a> of <var>known connection</var> is
+                    equal to the <code>presentationUrl</code> of
                     <em>presentationRequest</em>, and the <a>presentation
                     identifier</a> of <var>known connection</var> is equal to
                     <code>presentationId</code>, run the following steps:
                     <ol>
+                      <!-- TODO(mfoltz): We should explicitly construct a new connection if necessary. -->
                       <li>Let <var>S</var> be the <a>presentation
                       connection</a> of <var>known connection</var>.
                       </li>
@@ -991,9 +992,9 @@
                         <code>presentationRequest</code> with <em>S</em> as its
                         <code>connection</code> attribute.
                       </li>
-                      <li>
-                        <a>Establish a presentation connection</a> with
-                        <var>S</var>.
+                      <li>If the <a>presentation connection state</a> of <var>
+                        S</var> is <code>closed</code>, then <a>establish a
+                        presentation connection</a> with <var>S</var>.
                       </li>
                       <li>Abort the remaining steps of <var>T</var>.
                       </li>
@@ -1015,14 +1016,13 @@
         <section>
           <h4>
             Establishing a presentation connection
-          </h4>
-          <!-- TODO(mfoltz): Move this to 6.5.1, under the
+          </h4><!-- TODO(mfoltz): Move this to 6.5.1, under the
                PresentationConnection interface.  Leaving here for now to simplify
                the diff. -->
           <p>
             When the user agent is to <dfn>establish a presentation
-            connection</dfn> using a <a>presentation connection</a>,
-            it MUST run the following steps:
+            connection</dfn> using a <a>presentation connection</a>, it MUST
+            run the following steps:
           </p>
           <dl>
             <dt>
@@ -1030,17 +1030,17 @@
             </dt>
             <dd>
               <code>presentationConnection</code>, the
-              <code>PresentationConnection</code> object that is to be connected.
-              The <a>presentation connection state</a>
-              of <code>presentationConnection</code> must
-              be <code>connecting.</code>
+              <code>PresentationConnection</code> object that is to be
+              connected. The <a>presentation connection state</a> of
+              <code>presentationConnection</code> must be
+              <code>connecting.</code>
             </dd>
           </dl>
           <ol>
             <li>
-              <a>Queue a task</a> <em>T</em> to
-              connect <code>presentationConnection</code> to the <a>receiving
-              browsing context</a>.
+              <a>Queue a task</a> <em>T</em> to connect
+              <code>presentationConnection</code> to the <a>receiving browsing
+              context</a>.
             </li>
             <li>If <em>T</em> completes successfully, run the following steps:
               <ol>
@@ -1048,12 +1048,12 @@
                 <var>presentationConnection</var> to <code>connected.</code>
                 </li>
                 <li>For each <var>known connection</var> in the <a>set of
-                    presentations</a>:
+                presentations</a>:
                   <ol>
                     <li>If the <a>presentation identifier</a> of <var>known
-                        connection</var> and <var>presentationConnection</var>
-                      are equal, then <a>fire</a> an event named
-                      <code>connected</code> at <em>s</em>.
+                    connection</var> and <var>presentationConnection</var> are
+                    equal, then <a>fire</a> an event named
+                    <code>connected</code> at <em>s</em>.
                     </li>
                   </ol>
                 </li>
@@ -1221,9 +1221,9 @@
           <p>
             If <a>set of availability objects</a> is non-empty, or there is a
             pending request to <a for="PresentationRequest" data-lt=
-            "start">start a presentation</a>, the user agent MUST
-            <dfn>monitor the list of available presentation displays</dfn> by
-            running the following steps.
+            "start">start a presentation</a>, the user agent MUST <dfn>monitor
+            the list of available presentation displays</dfn> by running the
+            following steps.
           </p>
           <ol link-for="PresentationAvailability">
             <li>
@@ -1276,9 +1276,9 @@
             </li>
             <li>If the <a>set of availability objects</a> is now empty and
             there is no pending request to <a for="PresentationRequest"
-              data-lt="start">start a presentation</a>, cancel any
-              pending task to <a>monitor the list of available presentation
-              displays</a> for power saving purposes.
+              data-lt="start">start a presentation</a>, cancel any pending task
+              to <a>monitor the list of available presentation displays</a> for
+              power saving purposes.
             </li>
           </ol>
           <div class="note">
@@ -1367,10 +1367,11 @@
           </p>
           <p>
             When the <code><dfn>close</dfn>()</code> method is called on a
-            <a>PresentationConnection</a>, the user agent MUST run the algorithm
-            to <a data-lt="close-algorithm">close a presentation connection</a>
-            with <a>PresentationConnection</a>, a <code>reason</code>
-            of <code>closed</code>, and an empty <code>message</code>.
+            <a>PresentationConnection</a>, the user agent MUST run the
+            algorithm to <a data-lt="close-algorithm">close a presentation
+            connection</a> with <a>PresentationConnection</a>, a
+            <code>reason</code> of <code>closed</code>, and an empty
+            <code>message</code>.
           </p>
           <p>
             When the <code><dfn>terminate</dfn>()</code> method is called on a
@@ -1388,11 +1389,11 @@
           <p>
             When the a <a>PresentationConnection</a> object is discarded
             (because the document owning it is navigating or is closed), the
-            user agent SHOULD run steps 1 and 4 or 5 of the algorithm
-            to <a data-lt="close-algorithm">close a presentation
-            connection</a> with the <a>PresentationConnection</a> object
-            as <code>presentationConnection</code>, <code>wentAway</code>
-            as <code>closeReason</code>, and an empty <code>closeMessage</code>.
+            user agent SHOULD run steps 1 and 4 or 5 of the algorithm to
+            <a data-lt="close-algorithm">close a presentation connection</a>
+            with the <a>PresentationConnection</a> object as
+            <code>presentationConnection</code>, <code>wentAway</code> as
+            <code>closeReason</code>, and an empty <code>closeMessage</code>.
           </p>
         </div>
         <section>
@@ -1416,24 +1417,32 @@
           </p>
           <p>
             When the user agent is to <dfn data-lt="send-algorithm">send a
-            message</dfn> through a <a>presentation connection</a>, it
-            MUST run the following steps:
+            message</dfn> through a <a>presentation connection</a>, it MUST run
+            the following steps:
           </p>
           <dl>
-            <dt>Input</dt>
-            <dd><code>presentationConnection</code>, the <a>presentation connection</a> connected to the other browsing context
-            <dd><code>messageOrData</code>, the <a>presentation message data</a> to send to the other browsing context
+            <dt>
+              Input
+            </dt>
+            <dd>
+              <code>presentationConnection</code>, the <a>presentation
+              connection</a> connected to the other browsing context
+            </dd>
+            <dd>
+              <code>messageOrData</code>, the <a>presentation message data</a>
+              to send to the other browsing context
+            </dd>
           </dl>
           <ol link-for="PresentationConnection">
-            <li>If the <a>state</a> property of <code>presentationConnection</code>
-            is not <code>connected</code>, throw an
-            <code>InvalidStateError</code> exception.
+            <li>If the <a>state</a> property of
+            <code>presentationConnection</code> is not <code>connected</code>,
+            throw an <code>InvalidStateError</code> exception.
             </li>
             <li>Let <a>presentation message type</a> <em>messageType</em> be
-            <code>binary</code> if <code>messageOrData</code> is of type
-            <code>ArrayBuffer</code>, <code>ArrayBufferView</code>, or
-            <code>Blob</code>. Let <em>messageType</em> be <code>text</code> if
-            <code>messageOrData</code> is of type <code>DOMString</code>.
+            <code>binary</code> if <code>messageOrData</code> is of type <code>
+              ArrayBuffer</code>, <code>ArrayBufferView</code>, or
+              <code>Blob</code>. Let <em>messageType</em> be <code>text</code>
+              if <code>messageOrData</code> is of type <code>DOMString</code>.
             </li>
             <li>Assign the <dfn>destination browsing context</dfn> as follows:
               <ol>
@@ -1448,32 +1457,38 @@
                 </li>
               </ol>
             </li>
-            <li>
-              Using an implementation specific mechanism, transmit the
-              contents of <code>messageOrData</code> as the <a>presentation
-                message data</a> and <em>messageType</em> as the <a>presentation message type</a>
-              to the <a>destination browsing context</a>.
+            <li>Using an implementation specific mechanism, transmit the
+            contents of <code>messageOrData</code> as the <a>presentation
+            message data</a> and <em>messageType</em> as the <a>presentation
+            message type</a> to the <a>destination browsing context</a>.
             </li>
-            <li>
-              If the previous step encounters an unrecoverable error,
-              then <a data-lt="close-algorithm">close the presentation
-              connection</a>
-              with <code>presentationConnection</code>, <code>error</code>
-              as <code>closeReason</code>, and a <code>closeMessage</code>
-              describing the error encountered.
+            <li>If the previous step encounters an unrecoverable error, then
+            <a data-lt="close-algorithm">close the presentation connection</a>
+            with <code>presentationConnection</code>, <code>error</code> as
+            <code>closeReason</code>, and a <code>closeMessage</code>
+            describing the error encountered.
             </li>
           </ol>
           <div class="note">
             <p>
-            To assist applications in recovery from a an error sending a message through
-            a <a>presentation connection</a>, the user agent should include
-            details of which attempt failed in <code>closeMessage</code>. 
-            Example renditions of <code>closeMessage</code>:
-            <ul>
-              <li><code>Unable to send message: "hello"</code> for <code>DOMString</code> messages, where <code>"hello"</code> is the first 256 characters of the failed message.</li>
-              <li><code>Unable to send binary message</code> for <code>ArrayBuffer</code>, <code>ArrayBufferView</code> and <code>Blob</code> messages.</li>
-            </ul>
+              To assist applications in recovery from a an error sending a
+              message through a <a>presentation connection</a>, the user agent
+              should include details of which attempt failed in
+              <code>closeMessage</code>. Example renditions of
+              <code>closeMessage</code>:
             </p>
+            <ul>
+              <li>
+                <code>Unable to send message: "hello"</code> for
+                <code>DOMString</code> messages, where <code>"hello"</code> is
+                the first 256 characters of the failed message.
+              </li>
+              <li>
+                <code>Unable to send binary message</code> for
+                <code>ArrayBuffer</code>, <code>ArrayBufferView</code> and
+                <code>Blob</code> messages.
+              </li>
+            </ul>
           </div>
         </section>
         <section>
@@ -1488,14 +1503,26 @@
             a <code>PresentationConnection</code>:
           </p>
           <dl>
-            <dt>Input</dt>
-            <dd><code>presentationConnection</code>, the <a>presentation connection</a> receiving the message</dd>
-            <dd><code>messageType</code>, the <a>presentation message type</a> of the message</dd>
-            <dd><code>messageData</code>, the <a>presentation message data</a> of the message</dd>
+            <dt>
+              Input
+            </dt>
+            <dd>
+              <code>presentationConnection</code>, the <a>presentation
+              connection</a> receiving the message
+            </dd>
+            <dd>
+              <code>messageType</code>, the <a>presentation message type</a> of
+              the message
+            </dd>
+            <dd>
+              <code>messageData</code>, the <a>presentation message data</a> of
+              the message
+            </dd>
           </dl>
           <ol link-for="PresentationConnection">
-            <li>If the <a>state</a> property of <code>presentationConnection</code>
-            is not <code>connected</code>, abort these steps.
+            <li>If the <a>state</a> property of
+            <code>presentationConnection</code> is not <code>connected</code>,
+            abort these steps.
             </li>
             <li>Let <em>event</em> be a newly created <a>trusted event</a> that
             uses the <code>MessageEvent</code> interface, with the event type
@@ -1504,22 +1531,21 @@
             </li>
             <li>Initialize the <em>event's</em> data attribute as follows:
               <ol>
-                <li>If <code>messageType</code> is
-                <code>text</code>, then initialize <em>event's</em>
-                <code>data</code> attribute to <code>messageData</code> with type <code>DOMString</code>.
+                <li>If <code>messageType</code> is <code>text</code>, then
+                initialize <em>event's</em> <code>data</code> attribute to
+                <code>messageData</code> with type <code>DOMString</code>.
                 </li>
-                <li>If <code>messageType</code> is
-                <code>binary</code>, and <a>binaryType</a> is set to
-                <code>blob</code>, then initialize <em>event</em>'s
-                <code>data</code> attribute to a new <code>Blob</code> object
-                with <code>messageData</code> its raw
-                data.
+                <li>If <code>messageType</code> is <code>binary</code>, and <a>
+                  binaryType</a> is set to <code>blob</code>, then initialize
+                  <em>event</em>'s <code>data</code> attribute to a new
+                  <code>Blob</code> object with <code>messageData</code> its
+                  raw data.
                 </li>
-                <li>If <code>messageType</code> is
-                <code>binary</code>, and <a>binaryType</a> is set to
-                <code>arraybuffer</code>, then initialize <em>event</em>'s
-                <code>data</code> attribute to a new <code>ArrayBuffer</code>
-                object whose contents are <code>messageData</code>.
+                <li>If <code>messageType</code> is <code>binary</code>, and <a>
+                  binaryType</a> is set to <code>arraybuffer</code>, then
+                  initialize <em>event</em>'s <code>data</code> attribute to a
+                  new <code>ArrayBuffer</code> object whose contents are
+                  <code>messageData</code>.
                 </li>
               </ol>
             </li>
@@ -1529,13 +1555,13 @@
             </li>
           </ol>
           <p>
-            If the user agent encounters an unrecoverable error
-            while <a data-lt="receive-algorithm">receiving a message</a>
-            through <code>presentationConnection</code>, it
-            should <a data-lt="close-algorithm">close the presentation
-            connection</a> with <code>presentationConnection</code>,
-            <code>error</code> as <code>closeReason</code>, and a human readable
-            description of the error encountered as <code>closeMessage</code>.
+            If the user agent encounters an unrecoverable error while
+            <a data-lt="receive-algorithm">receiving a message</a> through
+            <code>presentationConnection</code>, it should <a data-lt=
+            "close-algorithm">close the presentation connection</a> with
+            <code>presentationConnection</code>, <code>error</code> as
+            <code>closeReason</code>, and a human readable description of the
+            error encountered as <code>closeMessage</code>.
           </p>
         </section>
         <section>
@@ -1559,16 +1585,27 @@
 
 </pre>
           <p>
-            A <code>PresentationConnectionClosedEvent</code> is fired when
-            a <a>presentation connection</a> enters a <code>closed</code> state.
+            A <code>PresentationConnectionClosedEvent</code> is fired when a
+            <a>presentation connection</a> enters a <code>closed</code> state.
             The <code>reason</code> attribute provides the reason why the
             connection was closed:
           </p>
           <ul>
-            <li> <code>error</code> means that the mechanism for connecting or communicating with a presentation entered an unrecoverable error.</li>
-            <li> <code>closed</code> means that either the <a>controlling browsing context</a> or the <a>receiving browsing context</a> that were connected by the <code>PresentationConnection</code> called <code>close()</code>. </li>
-            <li> <code>wentAway</code> means that the browser closed the connection, for
-              example, because the browsing context that owned the connection navigated or was discarded.</li>
+            <li>
+              <code>error</code> means that the mechanism for connecting or
+              communicating with a presentation entered an unrecoverable error.
+            </li>
+            <li>
+              <code>closed</code> means that either the <a>controlling browsing
+              context</a> or the <a>receiving browsing context</a> that were
+              connected by the <code>PresentationConnection</code> called
+              <code>close()</code>.
+            </li>
+            <li>
+              <code>wentAway</code> means that the browser closed the
+              connection, for example, because the browsing context that owned
+              the connection navigated or was discarded.
+            </li>
           </ul>
           <p>
             When the <code>reason</code> attribute is <code>error</code>, the
@@ -1586,46 +1623,59 @@
             the following:
           </p>
           <dl>
-            <dt>Input</dt>
-            <dd><code>presentationConnection</code>, the <em>presentation connection</em> to be closed</dd>
-            <dd><code>closeReason</code>, the <code>PresenentationConnectionClosedReason</code> describing why the connection is to be closed</dd>
-            <dd><code>closeMessage</code>, a human-readable message with details of why the connection was closed.</dd>
+            <dt>
+              Input
+            </dt>
+            <dd>
+              <code>presentationConnection</code>, the <em>presentation
+              connection</em> to be closed
+            </dd>
+            <dd>
+              <code>closeReason</code>, the
+              <code>PresenentationConnectionClosedReason</code> describing why
+              the connection is to be closed
+            </dd>
+            <dd>
+              <code>closeMessage</code>, a human-readable message with details
+              of why the connection was closed.
+            </dd>
           </dl>
           <ol>
             <li>
               <a>Queue a task</a> to run the following steps in order:
               <ol>
                 <li>If the <a>presentation connection state</a> of
-                <code>presentationConnection</code> is not <code>connected</code>
-                or <code>connecting</code>, then abort these steps.
+                <code>presentationConnection</code> is not
+                <code>connected</code> or <code>connecting</code>, then abort
+                these steps.
                 </li>
                 <li>Set <a>presentation connection state</a> of
                 <code>presentationConnection</code> to <code>closed</code>.
                 </li>
-                <li>
-                  Construct a new <code>PresentationConnectionClosedEvent</code>
-                    <var>E</var> with <code>reason</code> set to <var>closeReason</var> and
-                    <code>message</code> set to <var>closeMessage</var>.
+                <li>Construct a new
+                <code>PresentationConnectionClosedEvent</code> <var>E</var>
+                with <code>reason</code> set to <var>closeReason</var> and
+                <code>message</code> set to <var>closeMessage</var>.
                 </li>
-                </li>
-                  <a>Fire</a> <var>E</var> at <code>presentationConnection</code>.
-                </li>
-                <li>If <code>presentationConnection</code> is owned by a <a>controlling
-                browsing context</a>, signal the <a>receiving browsing
-                context</a> to <a data-lt="close-algorithm">close the
-                presentation connection</a> that was created when
-                <code>presentationConnection</code> was used to <a>establish a presentation
-                connection</a> with the presentation via <code>presentationConnection</code>,
-                using an implementation-specific mechanism.
-                </li>
-                <li>If <code>presentationConnection</code> is owned by a <a>receiving browsing
-                context</a>, signal the <a>controlling browsing context</a> to
-                <a data-lt="close-algorithm">close the presentation
-                connection</a> that was used to <a>establish a presentation
-                connection</a> with the presentation via <code>presentationConnection</code>,
-                using an implementation-specific mechanism.
-                </li>
-              </ol>
+              </ol><a>Fire</a> <var>E</var> at
+              <code>presentationConnection</code>.
+            </li>
+            <li>If <code>presentationConnection</code> is owned by a
+            <a>controlling browsing context</a>, signal the <a>receiving
+            browsing context</a> to <a data-lt="close-algorithm">close the
+            presentation connection</a> that was created when
+            <code>presentationConnection</code> was used to <a>establish a
+            presentation connection</a> with the presentation via
+            <code>presentationConnection</code>, using an
+            implementation-specific mechanism.
+            </li>
+            <li>If <code>presentationConnection</code> is owned by a
+            <a>receiving browsing context</a>, signal the <a>controlling
+            browsing context</a> to <a data-lt="close-algorithm">close the
+            presentation connection</a> that was used to <a>establish a
+            presentation connection</a> with the presentation via
+            <code>presentationConnection</code>, using an
+            implementation-specific mechanism.
             </li>
           </ol>
         </section>


### PR DESCRIPTION
This PR addresses the following issues:

* https://github.com/w3c/presentation-api/issues/214
* https://github.com/w3c/presentation-api/issues/149
* https://github.com/w3c/presentation-api/issues/198
* https://github.com/w3c/presentation-api/issues/216


Summary of changes:

* Adds a new "connecting" state to the PresentationConnection (Issue #214)
* Adds per-state event handlers `onconnected`, `onclosed` and `onterminated` to replace `onstatechange`
* Adds a `PresentationConnectionCloseEvent` and `PresentationConnectionCloseReason` with details on why a connection was closed, including an error in the underlying message transport (Issue #149).
* Refine example code and algorithms to clarify initial presentation states and ensure message sending happens at the right time.  (Issue #198, Issue #216)

