### PR TITLE
Re-inserted the getAvailability procedure

### DIFF
--- a/index.html
+++ b/index.html
@@ -955,10 +955,10 @@
             The details of implementing the permission request and display
             selection are left to the user agent; for example it may show the
             user a dialog and allow the user to select an available display
-            (granting permission), or cancel the selection (denying permission).
-            Implementers are encouraged to show the user whether an available
-            display is currently in use, to facilitate presentations that can
-            make use of multiple displays.
+            (granting permission), or cancel the selection (denying
+            permission). Implementers are encouraged to show the user whether
+            an available display is currently in use, to facilitate
+            presentations that can make use of multiple displays.
           </div>
           <div class="note">
             The <var>presentationUrl</var> should name a resource accessible to
@@ -1191,6 +1191,79 @@
             reasonably guarantee that the presentation of the URL on that
             display will succeed.
           </p>
+        </section>
+        <section>
+          <h4>
+            Getting the <a>presentation displays</a> availability information
+          </h4>
+          <p>
+            When the <code><dfn for=
+            "PresentationRequest">getAvailability</dfn>()</code> method is
+            called, the user agent MUST run the following steps:
+          </p>
+          <dl>
+            <dt>
+              Input
+            </dt>
+            <dd>
+              <var>presentationUrl</var>, the <a>presentation request URL</a>
+            </dd>
+            <dt>
+              Output
+            </dt>
+            <dd>
+              <var>P</var>, a <a>Promise</a>
+            </dd>
+          </dl>
+          <ol>
+            <li>Let <var>P</var> be a new <a>Promise</a>.
+            </li>
+            <li>Return <var>P</var>, but continue running these steps <a>in
+            parallel</a>.
+            </li>
+            <li>If the user agent is unable to <a>monitor the list of of
+            available presentation displays</a> for the entire duration of the
+            <a>controlling browsing context</a> (e.g., because the user has
+            disabled this feature), then:
+              <ol>
+                <li>
+                  <a>Resolve</a> <var>P</var> with a new
+                  <code>PresentationAvailability</code> object with its
+                  <code>value</code> property set to <code>false</code>.
+                </li>
+                <li>Abort all the remaining steps.
+                </li>
+              </ol>
+            </li>
+            <li>If the user agent is unable to continuously <a>monitor the list
+            of available presentation displays</a> but can find presentation
+            displays in order to start a connection, then:
+              <ol>
+                <li>
+                  <a>Reject</a> <var>P</var> with a <a>NotSupportedError</a>
+                  exception.
+                </li>
+                <li>Abort all the remaining steps.
+                </li>
+              </ol>
+            </li>
+            <li>Let <var>A</var> be a new <code>PresentationAvailability</code>
+            object with its <code>value</code> property set to
+            <code>false</code> if the <a>list of available presentation
+            displays</a> is empty or none of them is a <a>compatible
+            presentation display</a>, <code>true</code> otherwise.
+            </li>
+            <li>Create a tuple <em>(<var>A</var>,
+            <var>presentationUrl</var>)</em> and add it to the <a>set of
+            availability objects</a>.
+            </li>
+            <li>Run the algorithm to <a>monitor the list of available
+            presentation displays</a>.
+            </li>
+            <li>
+              <a>Resolve</a> <var>P</var> with <var>A</var>.
+            </li>
+          </ol>
         </section>
         <section>
           <h4>


### PR DESCRIPTION
The procedure was removed when sections were reordered in December, probably
by accident:
https://github.com/w3c/presentation-api/commit/e7ab2291bbdf47406a68ea0a115f0ba682084b7a#diff-eacf331f0ffc35d4b482f1d15a887d3bL1143

This commit brings the procedure back into the spec.

Note I slightly updated the text to fix the use of <var>, <em> and <code>.

This should fix issue #246.