### PR TITLE
Additional UI guidelines for user agents

### DIFF
--- a/index.html
+++ b/index.html
@@ -2419,23 +2419,23 @@
             When the user is asked permission to use a <a>presentation
             display</a> during the steps to <a>start a presentation</a>, the
             <a>controlling user agent</a> should make it clear what origin is
-            requesting presentation <i>and</i> what origin will be presented in
-            the <a>receiving browsing context</a>.
+            requesting presentation <i>and</i> what origin will be presented.
           </p>
           <p>
             Display of the origin requesting presentation will help the user
             understand what content is making the request, especially when the
             request is initiated from a <a>nested browsing context</a>. For
-            example, third party nested content may convince the user to click
-            and trigger a request to start an unwanted presentation.
+            example, embedded content may try to convince the user to click to
+            trigger a request to start an unwanted presentation.
           </p>
           <p>
-            Showing the origin that will be presented will also help the user
+            Showing the origin that will be presented will help the user
             know if that content is from an <a>potentially secure</a> (e.g.,
             <code>https:</code>) origin, and corresponds to a known or expected
-            site. For example, a malicious site may attempt to convince the
-            user to enter login credentials into a presentation page that
-            imitates a legimitate site.
+            site. For example, a malicious site may attempt to convince the user
+            to enter login credentials into a presentation page that imitates a
+            legimitate site.  Examination of the requested origin will help the
+            user detect these cases.
           </p>
         </dd>
         <dt>
@@ -2444,24 +2444,23 @@
         <dd>
           <p>
             When a user <a data-lt="start a presentation">starts a
-            presentation</a> from a <a>controlling user agent</a>, that user
-            will have exclusive control of the presentation. However, the
-            Presentation API allows additional devices (likely belonging to
-            distinct users) to later connect to and control that presentation
-            as well. When a a second device connects to a presentation, it is
-            recommended that all <a data-lt=
+            presentation</a>, the user will begin with exclusive control of the
+            presentation. However, the Presentation API allows additional
+            devices (likely belonging to distinct users) to connect and thereby
+            control the presentation as well. When a second device connects
+            to a presentation, it is recommended that all connected <a data-lt=
             "controlling user agent">controlling user agents</a> notify their
             users via the browser chrome that the original user has lost
-            exclusive access and there are now multiple controllers for the
+            exclusive access, and there are now multiple controllers for the
             presentation.
           </p>
           <p>
-            In addition, it may be the case that the <a>receiving user
-            agent</a> is capable of receiving user input, as well as acting as
-            a <a>presentation display</a>. In this case, the <a>receiving user
-            agent</a> should notify its user via the browser chrome when a
-            browsing context is under the control of a remote party (i.e., it
-            is a <a>presentation</a> with one or more connected controllers).
+            In addition, it may be the case that the <a>receiving user agent</a>
+            is capable of receiving user input, as well as acting as
+            a <a>presentation display</a>.  In this case, the <a>receiving user
+            agent</a> should notify its user via browser chrome when a
+            browsing context is under the control of a remote party (i.e., it is
+            a <a>presentation</a> with one or more connected controllers).
           </p>
         </dd>
       </dl>

--- a/index.html
+++ b/index.html
@@ -2429,13 +2429,13 @@
             trigger a request to start an unwanted presentation.
           </p>
           <p>
-            Showing the origin that will be presented will help the user
-            know if that content is from an <a>potentially secure</a> (e.g.,
+            Showing the origin that will be presented will help the user know
+            if that content is from an <a>potentially secure</a> (e.g.,
             <code>https:</code>) origin, and corresponds to a known or expected
-            site. For example, a malicious site may attempt to convince the user
-            to enter login credentials into a presentation page that imitates a
-            legimitate site.  Examination of the requested origin will help the
-            user detect these cases.
+            site. For example, a malicious site may attempt to convince the
+            user to enter login credentials into a presentation page that
+            imitates a legimitate site. Examination of the requested origin
+            will help the user detect these cases.
           </p>
         </dd>
         <dt>
@@ -2447,20 +2447,20 @@
             presentation</a>, the user will begin with exclusive control of the
             presentation. However, the Presentation API allows additional
             devices (likely belonging to distinct users) to connect and thereby
-            control the presentation as well. When a second device connects
-            to a presentation, it is recommended that all connected <a data-lt=
+            control the presentation as well. When a second device connects to
+            a presentation, it is recommended that all connected <a data-lt=
             "controlling user agent">controlling user agents</a> notify their
             users via the browser chrome that the original user has lost
             exclusive access, and there are now multiple controllers for the
             presentation.
           </p>
           <p>
-            In addition, it may be the case that the <a>receiving user agent</a>
-            is capable of receiving user input, as well as acting as
-            a <a>presentation display</a>.  In this case, the <a>receiving user
+            In addition, it may be the case that the <a>receiving user
+            agent</a> is capable of receiving user input, as well as acting as
+            a <a>presentation display</a>. In this case, the <a>receiving user
             agent</a> should notify its user via browser chrome when a
-            browsing context is under the control of a remote party (i.e., it is
-            a <a>presentation</a> with one or more connected controllers).
+            <a>receiving browsing context</a> is under the control of a remote
+            party (i.e., it has one or more connected controllers).
           </p>
         </dd>
       </dl>

--- a/index.html
+++ b/index.html
@@ -438,8 +438,10 @@
       </p>
       <p>
         The terms <dfn><a href=
+        "https://www.w3.org/TR/mixed-content/#potentially-secure-origin">potentially
+        secure</a></dfn>, <dfn><a href=
         "https://w3c.github.io/webappsec-mixed-content/#a-priori-authenticated-url">
-        a priori unauthenticated URL</a></dfn> and <dfn><a href=
+        a priori unauthenticated URL</a></dfn>, and <dfn><a href=
         "https://w3c.github.io/webappsec-mixed-content/#categorize-settings-object">
         prohibits mixed security contexts algorithm</a></dfn> are defined in
         [[!MIXED-CONTENT]].
@@ -2408,14 +2410,61 @@
       <h3>
         User interface guidelines
       </h3>
-      <p>
-        When the user is asked permission to use a <a>presentation display</a>
-        during the steps to <a>start a presentation</a>, the <a>controlling
-        user agent</a> should make it clear what origin is requesting
-        presentation. This will help the user understand what content is
-        requesting presentation, especially when the request is initiated from
-        a <a>nested browsing context</a>.
-      </p>
+      <dl>
+        <dt>
+          Origin display
+        </dt>
+        <dd>
+          <p>
+            When the user is asked permission to use a <a>presentation
+            display</a> during the steps to <a>start a presentation</a>, the
+            <a>controlling user agent</a> should make it clear what origin is
+            requesting presentation <i>and</i> what origin will be presented in
+            the <a>receiving browsing context</a>.
+          </p>
+          <p>
+            Display of the origin requesting presentation will help the user
+            understand what content is making the request, especially when the
+            request is initiated from a <a>nested browsing context</a>. For
+            example, third party nested content may convince the user to click
+            and trigger a request to start an unwanted presentation.
+          </p>
+          <p>
+            Showing the origin that will be presented will also help the user
+            know if that content is from an <a>potentially secure</a> (e.g.,
+            <code>https:</code>) origin, and corresponds to a known or expected
+            site. For example, a malicious site may attempt to convince the
+            user to enter login credentials into a presentation page that
+            imitates a legimitate site.
+          </p>
+        </dd>
+        <dt>
+          Cross-device access
+        </dt>
+        <dd>
+          <p>
+            When a user <a data-lt="start a presentation">starts a
+            presentation</a> from a <a>controlling user agent</a>, that user
+            will have exclusive control of the presentation. However, the
+            Presentation API allows additional devices (likely belonging to
+            distinct users) to later connect to and control that presentation
+            as well. When a a second device connects to a presentation, it is
+            recommended that all <a data-lt=
+            "controlling user agent">controlling user agents</a> notify their
+            users via the browser chrome that the original user has lost
+            exclusive access and there are now multiple controllers for the
+            presentation.
+          </p>
+          <p>
+            In addition, it may be the case that the <a>receiving user
+            agent</a> is capable of receiving user input, as well as acting as
+            a <a>presentation display</a>. In this case, the <a>receiving user
+            agent</a> should notify its user via the browser chrome when a
+            browsing context is under the control of a remote party (i.e., it
+            is a <a>presentation</a> with one or more connected controllers).
+          </p>
+        </dd>
+      </dl>
       <h3>
         Device Access
       </h3>


### PR DESCRIPTION
This PR addresses two issues:

- #223: Implementation guideline: users should have a way to know which origin is being presented at any time
- #224: Think more about privacy implications in multi-user scenarios

It adds a guideline that controlling user agents should display the origin of the URL that is to be presented.   It also adds guidelines about notifying the user when there are multiple parties that can control of a presentation.