### PR TITLE
Do not trigger "connectionavailable" on reconnect for same presentation

### DIFF
--- a/index.html
+++ b/index.html
@@ -1104,17 +1104,6 @@
                 <li>
                   <a>Resolve</a> <var>P</var> with <var>S</var>.
                 </li>
-                <li>
-                  <a>Queue a task</a> to <a>fire</a> a <a>trusted event</a>
-                  with the name <a for=
-                  "PresentationRequest">connectionavailable</a>, that uses the
-                  <a>PresentationConnectionAvailableEvent</a> interface, with
-                  the <a for=
-                  "PresentationConnectionAvailableEvent">connection</a>
-                  attribute initialized to <var>S</var>, at
-                  <var>presentationRequest</var>. The event must not bubble,
-                  must not be cancelable, and has no default action.
-                </li>
                 <li>If the <a>presentation connection state</a> of <var>S</var>
                 is <a for="PresentationConnectionState">connecting</a> or
                 <a for="PresentationConnectionState">connected</a>, then abort


### PR DESCRIPTION
The reconnect procedure no longer fires a "connectionavailable" event in the case when it finds a matching PresentationConnection for the current browsing context.

Fixes issue #259.