### PR TITLE
Clarifies when and how presentations are terminated

### DIFF
--- a/index.html
+++ b/index.html
@@ -2101,18 +2101,20 @@
                 objects after 30 minutes.
               </p>
             </li>
-            <li>The <a>receiving user agent</a> receives a signal from a
-            <a>controlling user agent</a> via the algorithm to <a data-lt=
-            "terminate-algorithm-controlling">terminate a presentation in a
-            controlling browsing context</a> that the presentation should be
-            terminated.
+            <li>
+              The <a>receiving user agent</a> receives a signal from a
+              <a>controlling user agent</a> via the algorithm to <a data-lt=
+                 "terminate-algorithm-controlling">terminate a presentation in a
+                 controlling browsing context</a> that the presentation should be
+                 terminated.
             </li>
-            <li>The receiving user agent is to <a>unload a document</a>
-            corresponding to the <a>receiving browsing context</a> in response
-            to a request to <a>navigate</a> that context. Navigation among
-            fragment identifiers within the same presentation document MUST not
-            <a data-lt="terminate-algorithm-receiving">terminate the
-            presentation</a>.
+            <li>
+              The receiving user agent is to <a>unload a document</a>
+              corresponding to the <a>receiving browsing context</a> in response
+              to a request to <a>navigate</a> that context. Navigation among
+              fragment identifiers within the same presentation document MUST not
+              <a data-lt="terminate-algorithm-receiving">terminate the
+                presentation</a>.
             </li>
           </ol>
           <p>
@@ -2124,9 +2126,9 @@
           </p>
           <p>
             In addition, the <a>receiving user agent</a> SHOULD signal each
-            <a>controlling user agent</a> that was connected to the
-            <a>receiving browsing context</a> that was closed using an
-            implementation specific mechanism.
+            <a>controlling user agent</a> that was connected to the presentation
+            that the presentation is now terminated, using an implementation
+            specific mechanism.
           </p>
           <p>
             When a <a>controlling user agent</a> receives such a signal, it
@@ -2135,7 +2137,8 @@
           <ol>
             <li>For each <var>connection</var> in the <a>set of controlled
             presentations</a> that was connected to the <a>receiving browsing
-            context</a>, <a>queue a task</a> to run the following steps:
+            context</a> for the presentation, <a>queue a task</a> to run the
+            following steps:
               <ol>
                 <li>If the <a>presentation connection state</a> of
                 <var>connection</var> is not <a for=

--- a/index.html
+++ b/index.html
@@ -2071,8 +2071,9 @@
               </ol>
             </li>
             <li>
-              <dfn>Send a termination signal</dfn> to the <a>receiving user
-              agent</a> using an implementation specific mechanism.
+              <dfn>Send a termination request</dfn> for the presentation to its
+              <a>receiving user agent</a> using an implementation specific
+              mechanism.
             </li>
           </ol>
         </section>
@@ -2086,11 +2087,14 @@
             context</a>:
           </p>
           <ol>
-            <li>The <a>top-level browsing context</a> of the presentation calls
-            <code>window.close()</code>.
+            <li>The <a>receiving user agent</a> is to <a>unload a document</a>
+            corresponding to the <a>receiving browsing context</a>, e.g. in
+            response to a call to <code>window.close()</code> in the
+            <a>top-level browsing context</a> or to a request to
+            <a>navigate</a> that context to a new resource.
             </li>
-            <li>The <a>receiving user agent</a> closes the presentation at user
-            request.
+            <li>The user requests to terminate the presentation via the
+            <a>receiving user agent</a>.
               <p class="note">
                 This could happen by an explicit user action, or as a policy of
                 the user agent. For example, the <a>receiving user agent</a>
@@ -2101,43 +2105,61 @@
                 minutes.
               </p>
             </li>
-            <li>The <a>controlling user agent</a> <a data-lt=
-            "send a termination signal">sends a termination signal</a> to the
-            <a>receiving user agent</a>.
-            </li>
-            <li>The <a>receiving user agent</a> is to <a>unload a document</a>
-            corresponding to the <a>receiving browsing context</a> in response
-            to a request to <a>navigate</a> that context. Navigation among
-            fragment identifiers within the same presentation document MUST not
-            <a data-lt="terminate-algorithm-receiving">terminate the
-            presentation</a>.
+            <li>A <a>controlling user agent</a> <a data-lt=
+            "send a termination request">sends a termination request</a> to the
+            <a>receiving user agent</a> for that presentation.
             </li>
           </ol>
           <p>
             When a <a>receiving user agent</a> is to <dfn data-lt=
             "terminate-algorithm-receiving">terminate a presentation in a
-            receiving browsing context</dfn> given a <var>connection</var>, it
-            MUST <a>unload a document</a> corresponding to the <a>receiving
-            browsing context</a>, and it SHOULD <a>send a termination
-            confirmation signal</a> to each <a>controlling user agent</a> using
-            an implementation specific mechanism.
+            receiving browsing context</dfn>, it MUST run the following steps:
           </p>
+          <ol>
+            <li>Let <var>P</var> be the presentation to be terminated.
+            </li>
+            <li>If there is a <a>receiving browsing context</a> for
+            <var>P</var>, and it has a document for <var>P</var> that is not
+            unloaded, <a>unload a document</a> corresponding to that
+            <a>browsing context</a>.
+            </li>
+            <li>For each <var>connection</var> in the <a>set of presentation
+            controllers</a> that were created for <var>P</var>, <a>queue a
+            task</a> to run the following steps:
+              <ol>
+                <li>If the <a>presentation connection state</a> of
+                <var>connection</var> is not <a for=
+                "PresentationConnectionState">connected</a>, then abort the
+                following steps.
+                </li>
+                <li>
+                  <dfn>Send a termination confirmation</dfn> for <var>P</var>
+                  using an implementation specific mechanism to the
+                  <a>controlling user agent</a> that owns the <a>destination
+                  browsing context</a> for <var>connection</var>.
+                  <p class="note">
+                    Only one termination confirmation needs to be sent per
+                    <a>controlling user agent</a>.
+                  </p>
+                </li>
+              </ol>
+            </li>
+          </ol>
         </section>
         <section>
           <h4>
-            Reacting to a termination confirmation signal in a controlling
-            browsing context
+            Handling a termination confirmation in a controlling user agent
           </h4>
           <p>
-            When a <a>receiving user agent</a> is to <dfn>send a termination
-            confirmation signal</dfn> to a <a>controlling browsing context</a>,
-            the <a>controlling user agent</a> SHOULD run the following steps:
+            When a <a>receiving user agent</a> has <dfn>sent a termination
+            confirmation</dfn> for a presentation <var>P</var>, and that
+            confirmation was received by a <a>controlling user agent</a>, the
+            <a>controlling user agent</a> SHOULD run the following steps:
           </p>
           <ol>
             <li>For each <var>connection</var> in the <a>set of controlled
-            presentations</a> that was connected to the <a>receiving browsing
-            context</a> for the presentation, <a>queue a task</a> to run the
-            following steps:
+            presentations</a> that was connected to <var>P</var>, <a>queue a
+            task</a> to run the following steps:
               <ol>
                 <li>If the <a>presentation connection state</a> of
                 <var>connection</var> is not <a for=

--- a/index.html
+++ b/index.html
@@ -2088,7 +2088,7 @@
             presentation</a>.
           </p>
           <ol>
-            <li>The <a>top level browsing context</a> of the presentation calls
+            <li>The <a>top-level browsing context</a> of the presentation calls
             <code>window.close()</code>.
             </li>
             <li>The <a>receiving user agent</a> closes the presentation at user
@@ -2102,8 +2102,10 @@
               </p>
             </li>
             <li>The <a>receiving user agent</a> receives a signal from a
-            <a>controlling user agent</a> that the presentation should be
-            closed.
+            <a>controlling user agent</a> via the algorithm to <a data-lt=
+            "terminate-algorithm-controlling">terminate a presentation in a
+            controlling browsing context</a> that the presentation should be
+            terminated.
             </li>
             <li>The receiving user agent is to <a>unload a document</a>
             corresponding to the <a>receiving browsing context</a> in response
@@ -2117,8 +2119,8 @@
             In any of these cases, when a <a>receiving user agent</a> is to
             <dfn data-lt="terminate-algorithm-receiving">terminate a
             presentation in a receiving browsing context</dfn> using
-            <var>connection</var>, it MUST <a>close</a> that <a>receiving
-            browsing context</a>.
+            <var>connection</var>, it MUST <a>unload a document</a>
+            corresponding to the <a>receiving browsing context</a>.
           </p>
           <p>
             In addition, the <a>receiving user agent</a> SHOULD signal each

--- a/index.html
+++ b/index.html
@@ -335,6 +335,8 @@
         to show a popup</a></dfn>, <dfn><a href=
         "http://www.w3.org/TR/html5/browsers.html#top-level-browsing-context">top-level
         browsing context</a></dfn>, <dfn><a href=
+        "https://www.w3.org/TR/html5/browsers.html#unload-a-document">unload a
+        document</a></dfn>, <dfn><a href=
         "http://www.w3.org/TR/html5/browsers.html#session-history">session
         history</a></dfn>, <dfn><a href=
         "https://www.w3.org/TR/html5/browsers.html#sandboxing-flag-set">sandboxing
@@ -2081,11 +2083,42 @@
             Terminating a presentation in a receiving browsing context
           </h4>
           <p>
-            When a <a>receiving user agent</a> is to <dfn data-lt=
-            "terminate-algorithm-receiving">terminate a presentation in a
-            receiving browsing context</dfn> using <var>connection</var>, it
-            MUST close that <a>receiving browsing context</a> (equivalent to
-            calling <code>window.close()</code> on it).
+            When any of the following occur, the <a>receiving user agent</a>
+            MUST <a data-lt="terminate-algorithm-receiving">terminate a
+            presentation</a>.
+          </p>
+          <ol>
+            <li>The <a>top level browsing context</a> of the presentation calls
+            <code>window.close()</code>.
+            </li>
+            <li>The <a>receiving user agent</a> closes the presentation at user
+            request.
+              <p class="note">
+                This could happen by an explicit user action, or as a policy of
+                the user agent. For example, the <a>receiving user agent</a>
+                could be configured to terminate presentations that have no
+                <code>connected</code> <code>PresentationConnection</code>
+                objects after 30 minutes.
+              </p>
+            </li>
+            <li>The <a>receiving user agent</a> receives a signal from a
+            <a>controlling user agent</a> that the presentation should be
+            closed.
+            </li>
+            <li>The receiving user agent is to <a>unload a document</a>
+            corresponding to the <a>receiving browsing context</a> in response
+            to a request to <a>navigate</a> that context. Navigation among
+            fragment identifiers within the same presentation document MUST not
+            <a data-lt="terminate-algorithm-receiving">terminate the
+            presentation</a>.
+            </li>
+          </ol>
+          <p>
+            In any of these cases, when a <a>receiving user agent</a> is to
+            <dfn data-lt="terminate-algorithm-receiving">terminate a
+            presentation in a receiving browsing context</dfn> using
+            <var>connection</var>, it MUST <a>close</a> that <a>receiving
+            browsing context</a>.
           </p>
           <p>
             In addition, the <a>receiving user agent</a> SHOULD signal each

--- a/index.html
+++ b/index.html
@@ -2133,10 +2133,10 @@
                 following steps.
                 </li>
                 <li>
-                  <dfn>Send a termination confirmation</dfn> for <var>P</var>
-                  using an implementation specific mechanism to the
-                  <a>controlling user agent</a> that owns the <a>destination
-                  browsing context</a> for <var>connection</var>.
+                  <a>Send a termination confirmation</a> for <var>P</var> using
+                  an implementation specific mechanism to the <a>controlling
+                  user agent</a> that owns the <a>destination browsing
+                  context</a> for <var>connection</var>.
                   <p class="note">
                     Only one termination confirmation needs to be sent per
                     <a>controlling user agent</a>.
@@ -2151,7 +2151,7 @@
             Handling a termination confirmation in a controlling user agent
           </h4>
           <p>
-            When a <a>receiving user agent</a> has <dfn>sent a termination
+            When a <a>receiving user agent</a> is to <dfn>send a termination
             confirmation</dfn> for a presentation <var>P</var>, and that
             confirmation was received by a <a>controlling user agent</a>, the
             <a>controlling user agent</a> SHOULD run the following steps:


### PR DESCRIPTION
This addresses #18 (Define reconnection for cross-page navigation on presenting user agent) by specifically terminating the presentation when navigation is attempted (other than by fragment identifier).  It also spells out the other circumstances in which a presentation is to be terminated. This list may not be  comprehensive; please point out anything missing.

Reading this, it looks like there are three distinct algorithms:
1. What happens when a controller terminates the presentation
2. What happens to the presentation
3. How connected controllers should respond to the terminated presentation

Perhaps it would be clearer to split 2 and 3 into separate sections.  Thoughts?
