### PR TITLE
Styles adjusted for new official 2016 stylesheet

### DIFF
--- a/index.html
+++ b/index.html
@@ -99,7 +99,7 @@
             publisher: 'Netflix'
           }
         },
-        issueBase: "https://www.github.com/w3c/presentation-api/issues/",
+        issueBase: "https://www.github.com/w3c/presentation-api/issues/"
         // TODO: Uncomment when https://github.com/w3c/presentation-api/issues/228 is fixed
         // githubAPI: "https://api.github.com/repos/w3c/presentation-api"
       };
@@ -116,28 +116,6 @@
     .non-normative { border-left-style: solid; border-left-width: 0.25em; background: none repeat scroll 0 0 #E9FBE9; border-color: #52E052; }
     p.non-normative:before { content: 'Non-normative: '; font-weight: bolder;}
     p.non-normative, div.non-normative { padding: 0.5em 2em; }
-
-
-    /* Pre.idl formatting taken from HTML5 spec */
-    pre.idl { border: solid thin #d3d3d3; background: #FCFCFC; color: black; padding: 0.5em 1em; position: relative; }
-    pre.idl :link, pre.idl :visited { color: inherit; background: transparent; }
-    pre.idl::before { content: "IDL"; font: bold small sans-serif;
-    padding: 0.5em; background: white; position: absolute; top: 0;
-    margin: -1px 0 0 -4em; width: 1.5em; border: thin solid;
-    border-radius: 0 0 0 0.5em }
-
-    /* .example idl formatting taken from HTML5 nightly spec */
-    .example {
-        display: block;
-        color: #222222;
-        background: #FCFCFC;
-        border-left-style: solid;
-        border-color: #c0c0c0;
-        border-left-width: 0.25em;
-        margin-left: 1em;
-        padding-left: 1em;
-        padding-bottom: 0.5em;
-    }
 
     .algorithm li {
         margin-bottom: 0.5em;
@@ -2518,170 +2496,184 @@
       <h2>
         Security and privacy considerations
       </h2>
-      <h3>
-        Personally identifiable information
-      </h3>
-      <p>
-        The <code>change</code> event fired on the
-        <a>PresentationAvailability</a> object reveals one bit of information
-        about the presence (or non-presence) of a <a>presentation display</a>
-        typically discovered through the local area network. This could be used
-        in conjunction with other information for fingerprinting the user.
-        However, this information is also dependent on the user's local network
-        context, so the risk is minimized.
-      </p>
-      <p>
-        The API enables <a href=
-        "#monitoring-the-list-of-available-presentation-displays">monitoring
-        the list of available presentation displays</a>. How the user agent
-        determines the compatibility and availability of a <a>presentation
-        display</a> with a given URL is an implementation detail. If a
-        <a>controlling user agent</a> matches a <a>presentation request URL</a>
-        to a <a>DIAL</a> application to determine its availability, this
-        feature can be used to probe information about which <a>DIAL</a>
-        applications the user has installed on the <a>presentation display</a>
-        without user consent.
-      </p>
-      <h3>
-        Cross-origin access
-      </h3>
-      <p>
-        A <a>presentation</a> is allowed to be accessed across origins; the
-        presentation URL and presentation ID used to create the presentation
-        are the only information needed to reconnect to a connection from any
-        origin in that user agent. In other words, a presentation is not tied
-        to a particular opening origin.
-      </p>
-      <p>
-        This design allows controlling contexts from different domains to
-        connect to a shared presentation resource. The security of the
-        presentation ID prevents arbitrary pages from connecting to an existing
-        presentation.
-      </p>
-      <p>
-        This specification allows a user agent to publish information about its
-        <a>set of controlled presentations</a>, and allows a browsing context
-        on another user agent to connect to a running presentation via
-        <code><a for="PresentationRequest">reconnect</a>()</code>. To connect,
-        the additional browsing context must discover the presentation URL and
-        presentation ID of the presentation, either provided by the user, or
-        via a shared service.
-      </p>
-      <p>
-        However, this specification makes no guarantee as to the identity of
-        the connecting party. Once connected, the receiving application may
-        wish to further verify the identity of the connecting party through
-        application-specific means. For example, the connecting application
-        could provide a token via <code><a for=
-        "PresentationConnection">send</a>()</code> that the receiving
-        application could verify corresponds an authorized entity.
-      </p>
-      <h3>
-        User interface guidelines
-      </h3>
-      <dl>
-        <dt>
-          Origin display
-        </dt>
-        <dd>
-          <p>
-            When the user is asked permission to use a <a>presentation
-            display</a> during the steps to <a>start a presentation</a>, the
-            <a>controlling user agent</a> should make it clear what origin is
-            requesting presentation <i>and</i> what origin will be presented.
-          </p>
-          <p>
-            Display of the origin requesting presentation will help the user
-            understand what content is making the request, especially when the
-            request is initiated from a <a>nested browsing context</a>. For
-            example, embedded content may try to convince the user to click to
-            trigger a request to start an unwanted presentation.
-          </p>
-          <p>
-            Showing the origin that will be presented will help the user know
-            if that content is from an <a>potentially secure</a> (e.g.,
-            <code>https:</code>) origin, and corresponds to a known or expected
-            site. For example, a malicious site may attempt to convince the
-            user to enter login credentials into a presentation page that
-            imitates a legimitate site. Examination of the requested origin
-            will help the user detect these cases.
-          </p>
-        </dd>
-        <dt>
-          Cross-device access
-        </dt>
-        <dd>
-          <p>
-            When a user <a data-lt="start a presentation">starts a
-            presentation</a>, the user will begin with exclusive control of the
-            presentation. However, the Presentation API allows additional
-            devices (likely belonging to distinct users) to connect and thereby
-            control the presentation as well. When a second device connects to
-            a presentation, it is recommended that all connected <a data-lt=
-            "controlling user agent">controlling user agents</a> notify their
-            users via the browser chrome that the original user has lost
-            exclusive access, and there are now multiple controllers for the
-            presentation.
-          </p>
-          <p>
-            In addition, it may be the case that the <a>receiving user
-            agent</a> is capable of receiving user input, as well as acting as
-            a <a>presentation display</a>. In this case, the <a>receiving user
-            agent</a> should notify its user via browser chrome when a
-            <a>receiving browsing context</a> is under the control of a remote
-            party (i.e., it has one or more connected controllers).
-          </p>
-        </dd>
-      </dl>
-      <h3>
-        Device Access
-      </h3>
-      <p>
-        The presentation API abstracts away what "local" means for displays,
-        meaning that it exposes network-accessible displays as though they were
-        local displays. The Presentation API requires user permission for a
-        page to access any display to mitigate issues that could arise, such as
-        showing unwanted content on a display viewable by others.
-      </p>
-      <h3>
-        Temporary identifiers and browser state
-      </h3>
-      <p>
-        The presentation URL and presentation ID can be used to connect to a
-        presentation from another browsing context. They can be intercepted if
-        an attacker can inject content into the controlling page.
-      </p>
-      <h3>
-        Incognito mode and clearing of browsing data
-      </h3>
-      <p>
-        The content displayed on the presentation is different from the
-        controller. In particular, if the user is logged in in both contexts,
-        then logs out of the <a>controlling browsing context</a>, she will not
-        be automatically logged out from the <a>receiving browsing context</a>.
-        Applications that use authentication should pay extra care when
-        communicating between devices.
-      </p>
-      <p>
-        The set of presentations known to the user agent should be cleared when
-        the user requests to "clear browsing data."
-      </p>
-      <p>
-        When in private browsing mode ("incognito"), the initial <a>set of
-        controlled presentations</a> in that browsing session must be empty.
-        Any <a data-lt="presentation connection">presentation connections</a>
-        added to it must be discarded when the session terminates.
-      </p>
-      <h3>
-        Messaging between presentation connections
-      </h3>
-      <p>
-        This spec will not mandate communication protocols between the
-        <a>controlling browsing context</a> and the <a>receiving browsing
-        context</a>, but it should set some guarantees of message
-        confidentiality and authenticity between corresponding <a>presentation
-        connections</a>.
-      </p>
+      <section>
+        <h3>
+          Personally identifiable information
+        </h3>
+        <p>
+          The <code>change</code> event fired on the
+          <a>PresentationAvailability</a> object reveals one bit of information
+          about the presence (or non-presence) of a <a>presentation display</a>
+          typically discovered through the local area network. This could be
+          used in conjunction with other information for fingerprinting the
+          user. However, this information is also dependent on the user's local
+          network context, so the risk is minimized.
+        </p>
+        <p>
+          The API enables <a href=
+          "#monitoring-the-list-of-available-presentation-displays">monitoring
+          the list of available presentation displays</a>. How the user agent
+          determines the compatibility and availability of a <a>presentation
+          display</a> with a given URL is an implementation detail. If a
+          <a>controlling user agent</a> matches a <a>presentation request
+          URL</a> to a <a>DIAL</a> application to determine its availability,
+          this feature can be used to probe information about which <a>DIAL</a>
+          applications the user has installed on the <a>presentation
+          display</a> without user consent.
+        </p>
+      </section>
+      <section>
+        <h3>
+          Cross-origin access
+        </h3>
+        <p>
+          A <a>presentation</a> is allowed to be accessed across origins; the
+          presentation URL and presentation ID used to create the presentation
+          are the only information needed to reconnect to a connection from any
+          origin in that user agent. In other words, a presentation is not tied
+          to a particular opening origin.
+        </p>
+        <p>
+          This design allows controlling contexts from different domains to
+          connect to a shared presentation resource. The security of the
+          presentation ID prevents arbitrary pages from connecting to an
+          existing presentation.
+        </p>
+        <p>
+          This specification allows a user agent to publish information about
+          its <a>set of controlled presentations</a>, and allows a browsing
+          context on another user agent to connect to a running presentation
+          via <code><a for="PresentationRequest">reconnect</a>()</code>. To
+          connect, the additional browsing context must discover the
+          presentation URL and presentation ID of the presentation, either
+          provided by the user, or via a shared service.
+        </p>
+        <p>
+          However, this specification makes no guarantee as to the identity of
+          the connecting party. Once connected, the receiving application may
+          wish to further verify the identity of the connecting party through
+          application-specific means. For example, the connecting application
+          could provide a token via <code><a for=
+          "PresentationConnection">send</a>()</code> that the receiving
+          application could verify corresponds an authorized entity.
+        </p>
+      </section>
+      <section>
+        <h3>
+          User interface guidelines
+        </h3>
+        <dl>
+          <dt>
+            Origin display
+          </dt>
+          <dd>
+            <p>
+              When the user is asked permission to use a <a>presentation
+              display</a> during the steps to <a>start a presentation</a>, the
+              <a>controlling user agent</a> should make it clear what origin is
+              requesting presentation <i>and</i> what origin will be presented.
+            </p>
+            <p>
+              Display of the origin requesting presentation will help the user
+              understand what content is making the request, especially when
+              the request is initiated from a <a>nested browsing context</a>.
+              For example, embedded content may try to convince the user to
+              click to trigger a request to start an unwanted presentation.
+            </p>
+            <p>
+              Showing the origin that will be presented will help the user know
+              if that content is from an <a>potentially secure</a> (e.g.,
+              <code>https:</code>) origin, and corresponds to a known or
+              expected site. For example, a malicious site may attempt to
+              convince the user to enter login credentials into a presentation
+              page that imitates a legimitate site. Examination of the
+              requested origin will help the user detect these cases.
+            </p>
+          </dd>
+          <dt>
+            Cross-device access
+          </dt>
+          <dd>
+            <p>
+              When a user <a data-lt="start a presentation">starts a
+              presentation</a>, the user will begin with exclusive control of
+              the presentation. However, the Presentation API allows additional
+              devices (likely belonging to distinct users) to connect and
+              thereby control the presentation as well. When a second device
+              connects to a presentation, it is recommended that all connected
+              <a data-lt="controlling user agent">controlling user agents</a>
+              notify their users via the browser chrome that the original user
+              has lost exclusive access, and there are now multiple controllers
+              for the presentation.
+            </p>
+            <p>
+              In addition, it may be the case that the <a>receiving user
+              agent</a> is capable of receiving user input, as well as acting
+              as a <a>presentation display</a>. In this case, the <a>receiving
+              user agent</a> should notify its user via browser chrome when a
+              <a>receiving browsing context</a> is under the control of a
+              remote party (i.e., it has one or more connected controllers).
+            </p>
+          </dd>
+        </dl>
+      </section>
+      <section>
+        <h3>
+          Device Access
+        </h3>
+        <p>
+          The presentation API abstracts away what "local" means for displays,
+          meaning that it exposes network-accessible displays as though they
+          were local displays. The Presentation API requires user permission
+          for a page to access any display to mitigate issues that could arise,
+          such as showing unwanted content on a display viewable by others.
+        </p>
+      </section>
+      <section>
+        <h3>
+          Temporary identifiers and browser state
+        </h3>
+        <p>
+          The presentation URL and presentation ID can be used to connect to a
+          presentation from another browsing context. They can be intercepted
+          if an attacker can inject content into the controlling page.
+        </p>
+      </section>
+      <section>
+        <h3>
+          Incognito mode and clearing of browsing data
+        </h3>
+        <p>
+          The content displayed on the presentation is different from the
+          controller. In particular, if the user is logged in in both contexts,
+          then logs out of the <a>controlling browsing context</a>, she will
+          not be automatically logged out from the <a>receiving browsing
+          context</a>. Applications that use authentication should pay extra
+          care when communicating between devices.
+        </p>
+        <p>
+          The set of presentations known to the user agent should be cleared
+          when the user requests to "clear browsing data."
+        </p>
+        <p>
+          When in private browsing mode ("incognito"), the initial <a>set of
+          controlled presentations</a> in that browsing session must be empty.
+          Any <a data-lt="presentation connection">presentation connections</a>
+          added to it must be discarded when the session terminates.
+        </p>
+      </section>
+      <section>
+        <h3>
+          Messaging between presentation connections
+        </h3>
+        <p>
+          This spec will not mandate communication protocols between the
+          <a>controlling browsing context</a> and the <a>receiving browsing
+          context</a>, but it should set some guarantees of message
+          confidentiality and authenticity between corresponding
+          <a>presentation connections</a>.
+        </p>
+      </section>
     </section>
     <section>
       <h2>


### PR DESCRIPTION
The custom styles that we had for examples should no longer be needed, and the ones for IDL declarations cause the "WebIDL" banner to appear truncated.

Also fixed the structure of the Security and privacy considerations section, as ReSpec needs <section> tags to detect the headings and build the appropriate Table of Contents.