### PR TITLE
Address issues #254, #269, #273

### DIFF
--- a/index.html
+++ b/index.html
@@ -2493,14 +2493,23 @@
                 </li>
               </ol>
             </li>
-            <li>Otherwise, <a>queue a task</a> to <a>fire</a> a <a>trusted
-            event</a> with the name <a for=
-            "PresentationConnectionList">connectionavailable</a>, that uses the
-            <a>PresentationConnectionAvailableEvent</a> interface, with the
-            <a for="PresentationConnectionAvailableEvent">connection</a>
-            attribute initialized to <var>S</var>, at the <a>presentation
-            controllers monitor</a>. The event must not bubble, must not be
-            cancelable, and has no default action.
+            <li>Otherwise, run the following steps <a>in parallel</a>.
+              <ol>
+                <li>Populate the <a>presentation controllers monitor</a> with
+                the <a>set of presentation controllers</a>.
+                </li>
+                <li>
+                  <a>Queue a task</a> to <a>fire</a> a <a>trusted event</a>
+                  with the name <a for=
+                  "PresentationConnectionList">connectionavailable</a>, that
+                  uses the <a>PresentationConnectionAvailableEvent</a>
+                  interface, with the <a for=
+                  "PresentationConnectionAvailableEvent">connection</a>
+                  attribute initialized to <var>S</var>, at the <a>presentation
+                  controllers monitor</a>. The event must not bubble, must not
+                  be cancelable, and has no default action.
+                </li>
+              </ol>
             </li>
           </ol>
           <p>

--- a/index.html
+++ b/index.html
@@ -771,8 +771,8 @@
           <code>null</code>, provides the <a>presentation controllers
           monitor</a> once the initial <a>presentation connection</a> is
           established. The <a>presentation controllers promise</a> is
-          represented by a <a>Promise</a> that resolves with the <a>presentation
-          controllers monitor</a>.
+          represented by a <a>Promise</a> that resolves with the
+          <a>presentation controllers monitor</a>.
         </p>
       </section>
       <section>
@@ -2347,10 +2347,11 @@
           <li>Otherwise, let the <a>presentation controllers promise</a> be a
           new <a>Promise</a>.
           </li>
-          <li>Return the <a>presentation controllers promise</a>.</li>
-          <li>If the <a>presentation controllers monitor</a> is not <code>null</code>,
-            <a>resolve</a> the <a>presentation controllers promise</a> with the
-            <a>presentation controllers monitor</a>.
+          <li>Return the <a>presentation controllers promise</a>.
+          </li>
+          <li>If the <a>presentation controllers monitor</a> is not
+          <code>null</code>, <a>resolve</a> the <a>presentation controllers
+          promise</a> with the <a>presentation controllers monitor</a>.
           </li>
         </ol>
         <section>
@@ -2474,34 +2475,32 @@
             </li>
             <li>Add <var>S</var> to the <a>set of presentation controllers</a>.
             </li>
-            <li>If the <a>presentation controllers monitor</a> is <code>null</code>,
-              run the following steps <a>in parallel</a>.
+            <li>If the <a>presentation controllers monitor</a> is
+            <code>null</code>, run the following steps <a>in parallel</a>.
               <ol>
                 <li>Let the <a>presentation controllers monitor</a> be a new
-                  <a>PresentationConnectionList</a>.
+                <a>PresentationConnectionList</a>.
                 </li>
-                <li>
-                  Populate the <a>presentation controllers monitor</a> with the
-                  <a>set of presentation controllers</a>.
+                <li>Populate the <a>presentation controllers monitor</a> with
+                the <a>set of presentation controllers</a>.
                 </li>
-                <li>
-                  If the <a>presentation controllers promise</a> is not <code>null</code>,
-                  <a>resolve</a> the <a>presentation controllers promise</a>
-                  with the <a>presentation controllers monitor</a>.
+                <li>If the <a>presentation controllers promise</a> is not
+                <code>null</code>, <a>resolve</a> the <a>presentation
+                controllers promise</a> with the <a>presentation controllers
+                monitor</a>.
                 </li>
                 <li>Abort all remaining steps.
                 </li>
               </ol>
             </li>
-            <li>
-              Otherwise, <a>queue a task</a> to <a>fire</a> a <a>trusted
-                event</a> with the name <a for=
-                                           "PresentationConnectionList">connectionavailable</a>, that uses the
-              <a>PresentationConnectionAvailableEvent</a> interface, with the
-              <a for="PresentationConnectionAvailableEvent">connection</a>
-              attribute initialized to <var>S</var>, at the <a>presentation
-                controllers monitor</a>. The event must not bubble, must not be
-              cancelable, and has no default action.
+            <li>Otherwise, <a>queue a task</a> to <a>fire</a> a <a>trusted
+            event</a> with the name <a for=
+            "PresentationConnectionList">connectionavailable</a>, that uses the
+            <a>PresentationConnectionAvailableEvent</a> interface, with the
+            <a for="PresentationConnectionAvailableEvent">connection</a>
+            attribute initialized to <var>S</var>, at the <a>presentation
+            controllers monitor</a>. The event must not bubble, must not be
+            cancelable, and has no default action.
             </li>
           </ol>
           <p>

--- a/index.html
+++ b/index.html
@@ -391,7 +391,7 @@
       <p>
         The terms <dfn data-lt="resolve"><a href=
         "http://www.w3.org/2001/tag/doc/promises-guide#resolve-promise">resolving
-        a Promise</a></dfn>, and <dfn data-lt="reject"><a href=
+        a Promise</a></dfn> and <dfn data-lt="reject"><a href=
         "http://www.w3.org/2001/tag/doc/promises-guide#reject-promise">rejecting
         a Promise</a></dfn> are used as explained in [[!PROMGUIDE]].
       </p>
@@ -2347,27 +2347,10 @@
           <li>Otherwise, let the <a>presentation controllers promise</a> be a
           new <a>Promise</a>.
           </li>
-          <li>Return the <a>presentation controllers promise</a>, but continue
-          running these steps <a>in parallel</a>.
-          </li>
-          <li>If the <a>set of presentation controllers</a> contains at least
-          one <a>presentation connection</a>, then run the following steps:
-            <ol>
-              <li>Let the <a>presentation controllers monitor</a> be a new <a>
-                PresentationConnectionList</a>.
-              </li>
-              <li>
-                Populate the <a>presentation controllers monitor</a> with the
-                current <a>set of presentation controllers<a>.
-              </li>
-              <li>
-                <a>Resolve</a> the <a>presentation controllers promise</a> with
-                the <a>presentation controllers monitor</a>.
-              </li>
-            </ol>
-          </li>
-          <li>Otherwise, the <a>presentation controllers promise</a> remains
-          unsettled.
+          <li>Return the <a>presentation controllers promise</a>.</li>
+          <li>If the <a>presentation controllers monitor</a> is not <code>null</code>,
+            <a>resolve</a> the <a>presentation controllers promise</a> with the
+            <a>presentation controllers monitor</a>.
           </li>
         </ol>
         <section>
@@ -2491,37 +2474,34 @@
             </li>
             <li>Add <var>S</var> to the <a>set of presentation controllers</a>.
             </li>
-            <li>If the <a>presentation controllers promise</a> is
-            <code>null</code>, then abort all remaining steps.
-            </li>
-            <li>If the <a>presentation controllers promise</a> is <a>settled</a>,
-              then run the following steps:</li>
-            
-            <li>Otherwise, run the following steps:
+            <li>If the <a>presentation controllers monitor</a> is <code>null</code>,
+              run the following steps <a>in parallel</a>.
               <ol>
                 <li>Let the <a>presentation controllers monitor</a> be a new
-                <a>PresentationConnectionList</a>.
+                  <a>PresentationConnectionList</a>.
                 </li>
                 <li>
                   Populate the <a>presentation controllers monitor</a> with the
-                  current <a>set of presentation controllers<a>.
+                  <a>set of presentation controllers</a>.
                 </li>
                 <li>
-                  <a>Resolve</a> the <a>presentation controllers promise</a>
+                  If the <a>presentation controllers promise</a> is not <code>null</code>,
+                  <a>resolve</a> the <a>presentation controllers promise</a>
                   with the <a>presentation controllers monitor</a>.
                 </li>
                 <li>Abort all remaining steps.
                 </li>
               </ol>
             </li>
-            <li>Otherwise, <a>queue a task</a> to <a>fire</a> a <a>trusted
-            event</a> with the name <a for=
-            "PresentationConnectionList">connectionavailable</a>, that uses the
-            <a>PresentationConnectionAvailableEvent</a> interface, with the
-            <a for="PresentationConnectionAvailableEvent">connection</a>
-            attribute initialized to <var>S</var>, at the <a>presentation
-            controllers monitor</a>. The event must not bubble, must not be
-            cancelable, and has no default action.
+            <li>
+              Otherwise, <a>queue a task</a> to <a>fire</a> a <a>trusted
+                event</a> with the name <a for=
+                                           "PresentationConnectionList">connectionavailable</a>, that uses the
+              <a>PresentationConnectionAvailableEvent</a> interface, with the
+              <a for="PresentationConnectionAvailableEvent">connection</a>
+              attribute initialized to <var>S</var>, at the <a>presentation
+                controllers monitor</a>. The event must not bubble, must not be
+              cancelable, and has no default action.
             </li>
           </ol>
           <p>

--- a/index.html
+++ b/index.html
@@ -738,10 +738,10 @@
         <p>
           In a <a>receiving browsing context</a>, the <dfn>presentation
           controllers promise</dfn>, which is initially set to
-          <code>null</code>, exposes the <a>presentation controllers
+          <code>null</code>, provides the <a>presentation controllers
           monitor</a> once the initial <a>presentation connection</a> is
           established. The <a>presentation controllers promise</a> is
-          represented by a <a>Promise</a> that holds the <a>presentation
+          represented by a <a>Promise</a> that resolves with the <a>presentation
           controllers monitor</a>.
         </p>
       </section>
@@ -2319,6 +2319,10 @@
                 PresentationConnectionList</a>.
               </li>
               <li>
+                Populate the <a>presentation controllers monitor</a> with the
+                current <a>set of presentation controllers<a>.
+              </li>
+              <li>
                 <a>Resolve</a> the <a>presentation controllers promise</a> with
                 the <a>presentation controllers monitor</a>.
               </li>
@@ -2442,11 +2446,17 @@
             <li>If the <a>presentation controllers promise</a> is
             <code>null</code>, then abort all remaining steps.
             </li>
-            <li>Otherwise, if the <a>presentation controllers promise</a> is
-            unsettled, then run the following steps:
+            <li>If the <a>presentation controllers promise</a> is <a>settled</a>,
+              then run the following steps:</li>
+            
+            <li>Otherwise, run the following steps:
               <ol>
                 <li>Let the <a>presentation controllers monitor</a> be a new
                 <a>PresentationConnectionList</a>.
+                </li>
+                <li>
+                  Populate the <a>presentation controllers monitor</a> with the
+                  current <a>set of presentation controllers<a>.
                 </li>
                 <li>
                   <a>Resolve</a> the <a>presentation controllers promise</a>

--- a/index.html
+++ b/index.html
@@ -789,18 +789,18 @@
             <code>defaultRequest</code> will have no effect.
           </div>
           <div class="note">
-            Some <a data-lt="controlling user agent">controlling user agents</a>
-            may allow the user to initiate a default <a>presentation
+            Some <a data-lt="controlling user agent">controlling user
+            agents</a> may allow the user to initiate a default <a>presentation
             connection</a> and select a <a>presentation display</a> with the
-            same user gesture.  For example, the browser chrome could allow the
-            user to pick a display from a menu, or allow the user to tap on
-            an <a href="https://nfc-forum.org/">Near Field Communications
+            same user gesture. For example, the browser chrome could allow the
+            user to pick a display from a menu, or allow the user to tap on an
+            <a href="https://nfc-forum.org/">Near Field Communications
             (NFC)</a> enabled display. In this case, when the <a>controlling
-            user agent</a> asks for permission while
-            <a data-lt="start a presentation">starting a presentation</a>, the
-            browser could offer that display as the default choice, or consider
-            the gesture as granting permission for the display and bypass
-            display selection entirely.
+            user agent</a> asks for permission while <a data-lt=
+            "start a presentation">starting a presentation</a>, the browser
+            could offer that display as the default choice, or consider the
+            gesture as granting permission for the display and bypass display
+            selection entirely.
           </div>
         </section>
         <section>
@@ -1031,6 +1031,9 @@
             </li>
             <li>
               <a>Navigate</a> <var>R</var> to <var>presentationUrl</var>.
+            </li>
+            <li>In <var>R</var>, begin <a>monitoring incoming presentation
+            connections</a>.
             </li>
             <li>
               <a>Establish a presentation connection</a> with <var>S</var>.
@@ -1379,6 +1382,17 @@
                 <li>
                   <a>Reject</a> <var>P</var> with a <a>NotSupportedError</a>
                   exception.
+                </li>
+                <li>Abort all the remaining steps.
+                </li>
+              </ol>
+            </li>
+            <li>If there exists a tuple <em>(<var>A</var>,
+            <var>presentationUrl</var>)</em> in the <a>set of availability
+            objects</a>, then:
+              <ol>
+                <li>
+                  <a>Resolve</a> <var>P</var> with <var>A</var>.
                 </li>
                 <li>Abort all the remaining steps.
                 </li>
@@ -1888,7 +1902,7 @@
 
             dictionary PresentationConnectionClosedEventInit : EventInit {
               required PresentationConnectionClosedReason reason;
-              DOMString message;
+              DOMString message = "";
             };
 
 

--- a/index.html
+++ b/index.html
@@ -40,6 +40,19 @@
             ]
           },
           {
+            key: 'Test suite',
+            data: [
+              {
+                value: 'GitHub web-platform-tests/presentation-api',
+                href: 'https://github.com/w3c/web-platform-tests/tree/master/presentation-api'
+              },
+              {
+                value: 'w3c-test.org/presentation-api/',
+                href: 'http://w3c-test.org/presentation-api/'
+              }
+            ]
+          },
+          {
             key: 'Participate',
             data: [
               {


### PR DESCRIPTION
This PR makes minor spec changes to address outstanding issues.

#254: When is the first presentation connection created in the receiving browsing context?
#269: Only allow one PresentationAvailability per PresentationRequest
#273: PresentationConnectionClosedEventInit.message needs to have a default value