### PR TITLE
Updates to PR #277 that addresses issues #254, #269, #273

### DIFF
--- a/index.html
+++ b/index.html
@@ -1275,9 +1275,10 @@
               <var>A</var> is a live <a>PresentationAvailability</a> object;
             </li>
             <li>
-              <var>availabilityUrl</var> is the parameter passed to
-              <code><a for="PresentationRequest">getAvailability</a>()</code>
-              to create <var>A</var>.
+              <var>availabilityUrl</var> is the <a>presentation request URL</a>
+              when <code><a for=
+              "PresentationRequest">getAvailability</a>()</code> is called to
+              create <var>A</var>.
             </li>
           </ol>
         </section>

--- a/index.html
+++ b/index.html
@@ -2283,6 +2283,10 @@
           <a>receiving user agent</a>.
         </p>
         <p>
+          A <a>PresentationReceiver</a> object is associated with a
+          <a>PresentationConnectionList</a> object when it is created.
+        </p>
+        <p>
           On getting, the <dfn for="PresentationReceiver">connectionList</dfn>
           attribute MUST return the result of running the following steps:
         </p>
@@ -2298,14 +2302,15 @@
           <li>Return <var>P</var>, but continue running these steps <a>in
           parallel</a>.
           </li>
-          <li>Let <var>list</var> be a new <a>PresentationConnectionList</a>.
+          <li>If the <a>set of presentation controllers</a> contains at least
+          one <a>presentation connection</a>, <a>resolve</a> <var>P</var> with
+          the <a>PresentationConnectionList</a> object associated with the <a>
+            PresentationReceiver</a> object.
           </li>
-          <li>Resolve <var>P</var> with <var>list</var>.
-          </li>
-          <li>If the <a>user agent</a> is not <a>monitoring incoming
-          presentation connections</a>, start <a>monitoring incoming
-          presentation connections</a> from <a>controlling browsing
-          contexts</a>.
+          <li>Otherwise, <var>P</var> remains unsettled. It will be resolved
+          when the first <a>presentation connection</a> is added to the <a>set
+          of presentation controllers</a> as part of the <a>monitoring incoming
+          presentation connections</a> algorithm.
           </li>
         </ol>
         <section>
@@ -2419,6 +2424,14 @@
             </li>
             <li>Add <var>S</var> to the <a>set of presentation controllers</a>.
             </li>
+            <li>If there is an unsettled <a>Promise</a> <var>P</var> from a
+            previous call to get the <a for=
+            "PresentationReceiver">connectionList</a> attribute for the same
+            <a>PresentationReceiver</a> object, <a>resolve</a> <var>P</var>
+            with the <a>PresentationConnectionList</a> object associated with
+            the <a>PresentationReceiver</a> object and abort all remaining
+            steps.
+            </li>
             <li>
               <a>Queue a task</a> to <a>fire</a> a <a>trusted event</a> with
               the name <a for=
@@ -2426,7 +2439,7 @@
               the <a>PresentationConnectionAvailableEvent</a> interface, with
               the <a for="PresentationConnectionAvailableEvent">connection</a>
               attribute initialized to <var>S</var>, at the
-              <a>PresentationConnectionList</a> instance associated with the
+              <a>PresentationConnectionList</a> object associated with the
               <a>PresentationReceiver</a> object. The event must not bubble,
               must not be cancelable, and has no default action.
             </li>

--- a/index.html
+++ b/index.html
@@ -2283,8 +2283,9 @@
           <a>receiving user agent</a>.
         </p>
         <p>
-          A <a>PresentationReceiver</a> object is associated with a
-          <a>PresentationConnectionList</a> object when it is created.
+          When the <a>PresentationReceiver</a> object is created, a
+          <a>PresentationConnectionList</a> object is also created and
+          associated with that <a>PresentationReceiver</a> object.
         </p>
         <p>
           On getting, the <dfn for="PresentationReceiver">connectionList</dfn>
@@ -2307,10 +2308,8 @@
           the <a>PresentationConnectionList</a> object associated with the <a>
             PresentationReceiver</a> object.
           </li>
-          <li>Otherwise, <var>P</var> remains unsettled. It will be resolved
-          when the first <a>presentation connection</a> is added to the <a>set
-          of presentation controllers</a> as part of the <a>monitoring incoming
-          presentation connections</a> algorithm.
+          <li>Otherwise, <var>P</var> remains unsettled and associated with the
+          <a>PresentationReceiver</a> object.
           </li>
         </ol>
         <section>

--- a/index.html
+++ b/index.html
@@ -728,6 +728,22 @@
           connections</a> in this set share the same <a>presentation URL</a>
           and <a>presentation identifier</a>.
         </p>
+        <p>
+          In a <a>receiving browsing context</a>, the <dfn>presentation
+          controllers monitor</dfn>, initially set to <code>null</code>,
+          exposes the current <a>set of presentation controllers</a> to the
+          receiving application. The <a>presentation controllers monitor</a> is
+          represented by a <a>PresentationConnectionList</a>.
+        </p>
+        <p>
+          In a <a>receiving browsing context</a>, the <dfn>presentation
+          controllers promise</dfn>, which is initially set to
+          <code>null</code>, exposes the <a>presentation controllers
+          monitor</a> once the initial <a>presentation connection</a> is
+          established. The <a>presentation controllers promise</a> is
+          represented by a <a>Promise</a> that holds the <a>presentation
+          controllers monitor</a>.
+        </p>
       </section>
       <section>
         <h3>
@@ -1524,10 +1540,9 @@
             A <a>receiving user agent</a> <a>fires</a> a <a>trusted event</a>
             named <a for="PresentationConnectionList">connectionavailable</a>
             on a <a>PresentationReceiver</a> when an incoming connection is
-            created. It is fired at the <a>PresentationConnectionList</a>
-            instance associated with the <a>PresentationReceiver</a> instance,
-            using the <a>PresentationConnectionAvailableEvent</a> interface,
-            with the <a for=
+            created. It is fired at the <a>presentation controllers
+            monitor</a>, using the <a>PresentationConnectionAvailableEvent</a>
+            interface, with the <a for=
             "PresentationConnectionAvailableEvent">connection</a> attribute set
             to the <a><code>PresentationConnection</code></a> object that was
             created. The event is fired for all connections that are created
@@ -2283,33 +2298,34 @@
           <a>receiving user agent</a>.
         </p>
         <p>
-          When the <a>PresentationReceiver</a> object is created, a
-          <a>PresentationConnectionList</a> object is also created and
-          associated with that <a>PresentationReceiver</a> object.
-        </p>
-        <p>
           On getting, the <dfn for="PresentationReceiver">connectionList</dfn>
           attribute MUST return the result of running the following steps:
         </p>
         <ol>
-          <li>If there is already an unsettled <a>Promise</a> <var>P</var> from
-          a previous call to get the <a for=
-          "PresentationReceiver">connectionList</a> attribute for the same <a>
-            PresentationReceiver</a> object, return <var>P</var> and abort all
-            remaining steps.
+          <li>If the <a>presentation controllers promise</a> is not
+          <code>null</code>, return the <a>presentation controllers promise</a>
+          and abort all remaining steps.
           </li>
-          <li>Let <var>P</var> be a new <a>Promise</a>.
+          <li>Otherwise, let the <a>presentation controllers promise</a> be a
+          new <a>Promise</a>.
           </li>
-          <li>Return <var>P</var>, but continue running these steps <a>in
-          parallel</a>.
+          <li>Return the <a>presentation controllers promise</a>, but continue
+          running these steps <a>in parallel</a>.
           </li>
           <li>If the <a>set of presentation controllers</a> contains at least
-          one <a>presentation connection</a>, <a>resolve</a> <var>P</var> with
-          the <a>PresentationConnectionList</a> object associated with the <a>
-            PresentationReceiver</a> object.
+          one <a>presentation connection</a>, then run the following steps:
+            <ol>
+              <li>Let the <a>presentation controllers monitor</a> be a new <a>
+                PresentationConnectionList</a>.
+              </li>
+              <li>
+                <a>Resolve</a> the <a>presentation controllers promise</a> with
+                the <a>presentation controllers monitor</a>.
+              </li>
+            </ol>
           </li>
-          <li>Otherwise, <var>P</var> remains unsettled and associated with the
-          <a>PresentationReceiver</a> object.
+          <li>Otherwise, the <a>presentation controllers promise</a> remains
+          unsettled.
           </li>
         </ol>
         <section>
@@ -2423,24 +2439,31 @@
             </li>
             <li>Add <var>S</var> to the <a>set of presentation controllers</a>.
             </li>
-            <li>If there is an unsettled <a>Promise</a> <var>P</var> from a
-            previous call to get the <a for=
-            "PresentationReceiver">connectionList</a> attribute for the same
-            <a>PresentationReceiver</a> object, <a>resolve</a> <var>P</var>
-            with the <a>PresentationConnectionList</a> object associated with
-            the <a>PresentationReceiver</a> object and abort all remaining
-            steps.
+            <li>If the <a>presentation controllers promise</a> is
+            <code>null</code>, then abort all remaining steps.
             </li>
-            <li>
-              <a>Queue a task</a> to <a>fire</a> a <a>trusted event</a> with
-              the name <a for=
-              "PresentationConnectionList">connectionavailable</a>, that uses
-              the <a>PresentationConnectionAvailableEvent</a> interface, with
-              the <a for="PresentationConnectionAvailableEvent">connection</a>
-              attribute initialized to <var>S</var>, at the
-              <a>PresentationConnectionList</a> object associated with the
-              <a>PresentationReceiver</a> object. The event must not bubble,
-              must not be cancelable, and has no default action.
+            <li>Otherwise, if the <a>presentation controllers promise</a> is
+            unsettled, then run the following steps:
+              <ol>
+                <li>Let the <a>presentation controllers monitor</a> be a new
+                <a>PresentationConnectionList</a>.
+                </li>
+                <li>
+                  <a>Resolve</a> the <a>presentation controllers promise</a>
+                  with the <a>presentation controllers monitor</a>.
+                </li>
+                <li>Abort all remaining steps.
+                </li>
+              </ol>
+            </li>
+            <li>Otherwise, <a>queue a task</a> to <a>fire</a> a <a>trusted
+            event</a> with the name <a for=
+            "PresentationConnectionList">connectionavailable</a>, that uses the
+            <a>PresentationConnectionAvailableEvent</a> interface, with the
+            <a for="PresentationConnectionAvailableEvent">connection</a>
+            attribute initialized to <var>S</var>, at the <a>presentation
+            controllers monitor</a>. The event must not bubble, must not be
+            cancelable, and has no default action.
             </li>
           </ol>
           <p>


### PR DESCRIPTION
This is pull request for the pull request #277...

I have the following comments on PR #277:

1. The definition of the set of availability objects still asserts that `availabilityUrl` is the parameter passed to `getAvailability()`. That's an old remain of some past version where `getAvailability()` indeed took a parameter.
2. Getting the `connectionList` attribute creates a new `PresentationConnectionList` instance for each call, whereas I would assume we would rather return the same instance each time.
3. Getting the `connectionList` attribute always returns a promise that is immediately resolved. I believe the reason why we want a Promise in the first place is to ensure that the app gets a `connectionList` with at least one presentation connection in it (the one that gave birth to the receiving browsing context), so we should wait for that to happen, or we should not return a Promise.
4. There should no longer be any need to "start monitoring incoming presentation connections" when getting the `connectionList` attribute, since that is now done in the "starting a presentation" steps

This PR updates the PR #277 to address each of these points:

1. I dropped "parameter" and used "presentation request URL" instead
2. I added the fact that a `PresentationReceiver` has an associated `PresentationConnectionList` object, and that getting the `connectionList` attribute resolves the returned promise with that object.
3. Getting the `connectionList` attribute now only returns a resolved promise if the set of presentation controllers is non empty. The promise is resolved when the first `PresentationConnection` object is added to the list otherwise (note that the `connectionavailable` event is *not* fired when that happens, which seems to be the right thing to do).
4. I dropped the step that instructed the user agent to start monitoring incoming presentation connections.

For 2., it could be better to find a real `dfn` name for the `PresentationConnectionList` object associated with the `PresentationReceiver` object, but I could not really come up with a good name (we already have "set of presentation controllers", I tried "incoming connection reporter" but that looked awkwards).