### PR TITLE
Switched to "generic" language in Travis CI to avoid warnings (#265)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-language: node_js
+language: generic
 
 sudo: false
 
@@ -11,9 +11,6 @@ env:
     - URL="https://rawgit.com/w3c/presentation-api/TR/ECHIDNA"
     - DECISION="https://lists.w3.org/Archives/Public/public-secondscreen/2015Jun/0096.html"
     - secure: "nJ8QtGEN8dzi2syMLFDpK8AAfTtvR/6QXe+H/rymwXHyD0LuoBGtH8NxZ6uyV1TfqTC3YcjuM0pFqtO+9gNi1L2uYeJH808cb6QjM9+qhuL9E0xE6qcoud7jqMeMY/K6HsSDqjEDJdTKNBOygMIzg69TASBoe9V/yGmpGZzGDZg="
- 
-script:
-  - echo "ok"
 
 after_success:
   - curl "https://labs.w3.org/echidna/api/request" --data "url=$URL" --data "decision=$DECISION" --data "token=$TOKEN"


### PR DESCRIPTION
The "language" key is mandatory but our build does not need a Node.js environment. The "generic" value should tell Travis CI to use a simple bash environment to run the "curl" request. In turn, this should make all nvm related messages disappear from build logs.

I also dropped the "script" key since it is not needed (it might have been in the past) and does not do anything useful.