### PR TITLE
Updated acknowledgements list (#301), marked non-normative sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -230,7 +230,7 @@
         <a>presentation display</a> devices through any of the above means.
       </p>
     </section>
-    <section id="use-cases-and-requirements">
+    <section id="use-cases-and-requirements" class="informative">
       <h2>
         Use cases and requirements
       </h2>
@@ -476,7 +476,7 @@
         is defined in [[DIAL]].
       </p>
     </section>
-    <section>
+    <section class="informative">
       <h2>
         Examples
       </h2>
@@ -1262,10 +1262,6 @@
               <a>Reject</a> <var>P</var> with a <a>NotFoundError</a> exception.
             </li>
           </ol>
-          <div class="issue">
-            If no matching presentation is found, we could leave the Promise
-            pending in case a matching presentation is started in the future.
-          </div>
         </section>
         <section>
           <h4>
@@ -2155,10 +2151,6 @@
               </ol>
             </li>
           </ol>
-          <div class="issue" data-number="240">
-            Refine this procedure to specify handling of messages in-flight
-            when the connection is being closed.
-          </div>
         </section>
         <section>
           <h4>
@@ -2655,7 +2647,7 @@
         </ul>
       </section>
     </section>
-    <section>
+    <section class="informative">
       <h2>
         Security and privacy considerations
       </h2>
@@ -2838,13 +2830,20 @@
         </p>
       </section>
     </section>
-    <section>
+    <section class="appendix">
       <h2>
         Acknowledgments
       </h2>
       <p>
-        Thanks to Wayne Carr, Louay Bassbouss, Anssi Kostiainen, 闵洪波 (Hongbo
-        Min), Anton Vayvod, and Mark Foltz for help with editing, reviews and
+        Thanks to Addison Phillips, Anne Van Kesteren, Anssi Kostiainen,
+        Anton Vayvod, Chris Needham, Christine Runnegar, Daniel Davis,
+        Domenic Denicola, Erik Wilde, François Daoust, 闵洪波 (Hongbo Min),
+        Hongki CHA, Hubert Sablonnière, Hyojin Song, Hyun June Kim,
+        Jean-Claude Dufourd, Joanmarie Diggs, Jonas Sicking, Louay Bassbouss,
+        Mark Watson, Martin Dürst, Matt Hammond, Mike West, Mounir Lamouri,
+        Nick Doty, Oleg Beletski, Philip Jägenstedt, Richard Ishida,
+        Shih-Chiang Chien, Takeshi Kanai, Tobie Langel, Tomoyuki Shimizu,
+        Travis Leithead, and Wayne Carr for help with editing, reviews and
         feedback to this draft.
       </p>
     </section>


### PR DESCRIPTION
I updated the acknowledgements list, taking into account contributions to the specifications, GitHub issues, and horizontal reviews. Hopefully I did not miss anyone.

I also dropped the remaining "issue" blocks and marked the use cases section, the examples section and the security guidance section as informative sections.