### PR TITLE
Addresses APIs with user input on receiving user agent (Issue #99)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-language: node_js
+language: generic
 
 sudo: false
 
@@ -11,9 +11,6 @@ env:
     - URL="https://rawgit.com/w3c/presentation-api/TR/ECHIDNA"
     - DECISION="https://lists.w3.org/Archives/Public/public-secondscreen/2015Jun/0096.html"
     - secure: "nJ8QtGEN8dzi2syMLFDpK8AAfTtvR/6QXe+H/rymwXHyD0LuoBGtH8NxZ6uyV1TfqTC3YcjuM0pFqtO+9gNi1L2uYeJH808cb6QjM9+qhuL9E0xE6qcoud7jqMeMY/K6HsSDqjEDJdTKNBOygMIzg69TASBoe9V/yGmpGZzGDZg="
- 
-script:
-  - echo "ok"
 
 after_success:
   - curl "https://labs.w3.org/echidna/api/request" --data "url=$URL" --data "decision=$DECISION" --data "token=$TOKEN"

--- a/index.html
+++ b/index.html
@@ -2541,11 +2541,6 @@
               </ol>
             </li>
           </ol>
-          <p>
-            The <a>receiving user agent</a> MUST fire the event as soon as it
-            can create the <a><code>PresentationConnection</code></a>
-            associated with the event.
-          </p>
         </section>
         <section>
           <h4>

--- a/index.html
+++ b/index.html
@@ -558,7 +558,7 @@
       </section>
       <section>
         <h3>
-          Presentation initation by the controlling UA example
+          Presentation initiation by the controlling UA example
         </h3>
         <pre class="example highlight">
 &lt;!-- controller.html --&gt;
@@ -2747,7 +2747,7 @@
               <code>https:</code>) origin, and corresponds to a known or
               expected site. For example, a malicious site may attempt to
               convince the user to enter login credentials into a presentation
-              page that imitates a legimitate site. Examination of the
+              page that imitates a legitimate site. Examination of the
               requested origin will help the user detect these cases.
             </p>
           </dd>

--- a/index.html
+++ b/index.html
@@ -1275,9 +1275,10 @@
               <var>A</var> is a live <a>PresentationAvailability</a> object;
             </li>
             <li>
-              <var>availabilityUrl</var> is the parameter passed to
-              <code><a for="PresentationRequest">getAvailability</a>()</code>
-              to create <var>A</var>.
+              <var>availabilityUrl</var> is the <a>presentation request URL</a>
+              when <code><a for=
+              "PresentationRequest">getAvailability</a>()</code> is called to
+              create <var>A</var>.
             </li>
           </ol>
         </section>

--- a/index.html
+++ b/index.html
@@ -391,7 +391,7 @@
       <p>
         The terms <dfn data-lt="resolve"><a href=
         "http://www.w3.org/2001/tag/doc/promises-guide#resolve-promise">resolving
-        a Promise</a></dfn>, and <dfn data-lt="reject"><a href=
+        a Promise</a></dfn> and <dfn data-lt="reject"><a href=
         "http://www.w3.org/2001/tag/doc/promises-guide#reject-promise">rejecting
         a Promise</a></dfn> are used as explained in [[!PROMGUIDE]].
       </p>
@@ -2347,27 +2347,10 @@
           <li>Otherwise, let the <a>presentation controllers promise</a> be a
           new <a>Promise</a>.
           </li>
-          <li>Return the <a>presentation controllers promise</a>, but continue
-          running these steps <a>in parallel</a>.
-          </li>
-          <li>If the <a>set of presentation controllers</a> contains at least
-          one <a>presentation connection</a>, then run the following steps:
-            <ol>
-              <li>Let the <a>presentation controllers monitor</a> be a new <a>
-                PresentationConnectionList</a>.
-              </li>
-              <li>
-                Populate the <a>presentation controllers monitor</a> with the
-                current <a>set of presentation controllers<a>.
-              </li>
-              <li>
-                <a>Resolve</a> the <a>presentation controllers promise</a> with
-                the <a>presentation controllers monitor</a>.
-              </li>
-            </ol>
-          </li>
-          <li>Otherwise, the <a>presentation controllers promise</a> remains
-          unsettled.
+          <li>Return the <a>presentation controllers promise</a>.</li>
+          <li>If the <a>presentation controllers monitor</a> is not <code>null</code>,
+            <a>resolve</a> the <a>presentation controllers promise</a> with the
+            <a>presentation controllers monitor</a>.
           </li>
         </ol>
         <section>
@@ -2511,37 +2494,34 @@
             </li>
             <li>Add <var>S</var> to the <a>set of presentation controllers</a>.
             </li>
-            <li>If the <a>presentation controllers promise</a> is
-            <code>null</code>, then abort all remaining steps.
-            </li>
-            <li>If the <a>presentation controllers promise</a> is <a>settled</a>,
-              then run the following steps:</li>
-            
-            <li>Otherwise, run the following steps:
+            <li>If the <a>presentation controllers monitor</a> is <code>null</code>,
+              run the following steps <a>in parallel</a>.
               <ol>
                 <li>Let the <a>presentation controllers monitor</a> be a new
-                <a>PresentationConnectionList</a>.
+                  <a>PresentationConnectionList</a>.
                 </li>
                 <li>
                   Populate the <a>presentation controllers monitor</a> with the
-                  current <a>set of presentation controllers<a>.
+                  <a>set of presentation controllers</a>.
                 </li>
                 <li>
-                  <a>Resolve</a> the <a>presentation controllers promise</a>
+                  If the <a>presentation controllers promise</a> is not <code>null</code>,
+                  <a>resolve</a> the <a>presentation controllers promise</a>
                   with the <a>presentation controllers monitor</a>.
                 </li>
                 <li>Abort all remaining steps.
                 </li>
               </ol>
             </li>
-            <li>Otherwise, <a>queue a task</a> to <a>fire</a> a <a>trusted
-            event</a> with the name <a for=
-            "PresentationConnectionList">connectionavailable</a>, that uses the
-            <a>PresentationConnectionAvailableEvent</a> interface, with the
-            <a for="PresentationConnectionAvailableEvent">connection</a>
-            attribute initialized to <var>S</var>, at the <a>presentation
-            controllers monitor</a>. The event must not bubble, must not be
-            cancelable, and has no default action.
+            <li>
+              Otherwise, <a>queue a task</a> to <a>fire</a> a <a>trusted
+                event</a> with the name <a for=
+                                           "PresentationConnectionList">connectionavailable</a>, that uses the
+              <a>PresentationConnectionAvailableEvent</a> interface, with the
+              <a for="PresentationConnectionAvailableEvent">connection</a>
+              attribute initialized to <var>S</var>, at the <a>presentation
+                controllers monitor</a>. The event must not bubble, must not be
+              cancelable, and has no default action.
             </li>
           </ol>
           <p>

--- a/index.html
+++ b/index.html
@@ -405,6 +405,11 @@
         in the File API specification [[!FILEAPI]].
       </p>
       <p>
+        The header <dfn><a href=
+        "https://tools.ietf.org/html/rfc7231#section-5.3.5">Accept-Language</a></dfn>
+        is defined in HTTP 1/.1 [[!rfc7231]].
+      </p>
+      <p>
         The term <dfn><a href=
         "http://w3c.github.io/webrtc-pc/#idl-def-RTCDataChannel">RTCDataChannel</a></dfn>
         is defined in the WebRTC API specification [[WEBRTC]].
@@ -645,6 +650,28 @@
       addConnection(connections[connections.length - 1]);
     };
   });
+&lt;/script&gt;
+</pre>
+      </section>
+      <section>
+        <h3>
+          Passing locale information with a message
+        </h3>
+        <pre class="example highlight">
+&lt;!-- controller.html --&gt;
+&lt;script&gt;
+  connection.send("{string: 'Hello, world!', lang: 'en-US'}");
+&lt;/script&gt;
+
+&lt;!-- receiver.html --&gt;
+&lt;script&gt;
+  connection.onmessage = function (message) {
+    var messageObj = JSON.parse(message);
+    var spanElt = document.createElement("SPAN");
+    spanElt.lang = messageObj.lang;
+    spanElt.textContent = messageObj.string;
+    document.appendChild(spanElt);
+  };
 &lt;/script&gt;
 </pre>
       </section>
@@ -1813,6 +1840,14 @@
               </li>
             </ul>
           </div>
+          <div class="note">
+            When sending a user-visible string via a <a>presentation
+            connection</a>, the page author should take care to ensure that
+            locale information is also propagated so that the destination user
+            agent can know how to best render the string. See <a href=
+            "#passing-locale-information-with-a-message">the examples</a> for
+            one solution.
+          </div>
         </section>
         <section>
           <h4>
@@ -2364,6 +2399,16 @@
             <li>Return <var>C</var>.
             </li>
           </ol>
+          <p>
+            The <a>receiving user agent</a> SHOULD fetch resources in a
+            <a>receiving browsing context</a> with an HTTP
+            <a>Accept-Language</a> header that reflects the language
+            preferences of the <a>controlling user agent</a> (i.e., with the
+            same <a>Accept-Language</a> that the controlling user agent would
+            have sent). This will help the <a>receiving user agent</a> render
+            the presentation with fonts and locale-specific attributes that
+            reflect the user's preferences.
+          </p>
           <p>
             When the <a>receiving browsing context</a> is closed, any
             associated browsing state, including <a>session history</a>,

--- a/index.html
+++ b/index.html
@@ -230,7 +230,7 @@
         <a>presentation display</a> devices through any of the above means.
       </p>
     </section>
-    <section id="use-cases-and-requirements">
+    <section id="use-cases-and-requirements" class="informative">
       <h2>
         Use cases and requirements
       </h2>
@@ -476,7 +476,7 @@
         is defined in [[DIAL]].
       </p>
     </section>
-    <section>
+    <section class="informative">
       <h2>
         Examples
       </h2>
@@ -1262,10 +1262,6 @@
               <a>Reject</a> <var>P</var> with a <a>NotFoundError</a> exception.
             </li>
           </ol>
-          <div class="issue">
-            If no matching presentation is found, we could leave the Promise
-            pending in case a matching presentation is started in the future.
-          </div>
         </section>
         <section>
           <h4>
@@ -2155,10 +2151,6 @@
               </ol>
             </li>
           </ol>
-          <div class="issue" data-number="240">
-            Refine this procedure to specify handling of messages in-flight
-            when the connection is being closed.
-          </div>
         </section>
         <section>
           <h4>
@@ -2675,7 +2667,7 @@
         </ul>
       </section>
     </section>
-    <section>
+    <section class="informative">
       <h2>
         Security and privacy considerations
       </h2>
@@ -2858,13 +2850,20 @@
         </p>
       </section>
     </section>
-    <section>
+    <section class="appendix">
       <h2>
         Acknowledgments
       </h2>
       <p>
-        Thanks to Wayne Carr, Louay Bassbouss, Anssi Kostiainen, 闵洪波 (Hongbo
-        Min), Anton Vayvod, and Mark Foltz for help with editing, reviews and
+        Thanks to Addison Phillips, Anne Van Kesteren, Anssi Kostiainen,
+        Anton Vayvod, Chris Needham, Christine Runnegar, Daniel Davis,
+        Domenic Denicola, Erik Wilde, François Daoust, 闵洪波 (Hongbo Min),
+        Hongki CHA, Hubert Sablonnière, Hyojin Song, Hyun June Kim,
+        Jean-Claude Dufourd, Joanmarie Diggs, Jonas Sicking, Louay Bassbouss,
+        Mark Watson, Martin Dürst, Matt Hammond, Mike West, Mounir Lamouri,
+        Nick Doty, Oleg Beletski, Philip Jägenstedt, Richard Ishida,
+        Shih-Chiang Chien, Takeshi Kanai, Tobie Langel, Tomoyuki Shimizu,
+        Travis Leithead, and Wayne Carr for help with editing, reviews and
         feedback to this draft.
       </p>
     </section>

--- a/index.html
+++ b/index.html
@@ -143,24 +143,25 @@
       </p>
     </section>
     <section id="sotd">
-      <p>
+       <p>
         Since publication as Working Draft on <a href=
-        "https://www.w3.org/TR/2015/WD-presentation-api-20151013/">13 October
-        2015</a>, the Working Group has refined the interfaces and
-        significantly improved all procedures. Security and privacy
-        considerations have been completed based on feedback and interactions
-        with other W3C groups. The Working Group intends to publish a Candidate
-        Recommendation soon and seeks wide review of this document. Horizontal
-        reviews and feedback from early experimentations and developers willing
-        to use this specification are encouraged.
+        "https://www.w3.org/TR/2016/WD-presentation-api-20160211/">11 February
+        2016</a>, the Working Group has further refined some of the procedures,
+        notably those linked to the receiving user agent, specified the
+        algorithm for generating a presentation identifier, clarified the
+        expected behavior when a presentation is started using the default
+        presentation request, added recommendations for reusing the locale
+        settings of the controller in presentations, and further refined text
+        to ease testing. The Working Group also conducted horizontal reviews on
+        accessibility, internationalization, privacy, security and technical
+        architecture principles with the help of relevant groups at W3C.
       </p>
       <p>
-        Some open issues remain, including on ways to pass the language
-        settings from the controller to the presentation and on whether the
-        messaging channel should expose a congestion control mechanism; please
-        check the group's <a href=
-        "https://github.com/w3c/presentation-api/issues">issue tracker</a> on
-        GitHub for a complete list of open issues.
+        The Working Group intends to publish a Candidate Recommendation once it
+        has fixed <a href=
+        "https://github.com/w3c/presentation-api/issues">remaining issues</a>
+        and made initial progress on the test suite. Wide reviews of this
+        document are encouraged.
       </p>
     </section>
     <section class="informative">

--- a/index.html
+++ b/index.html
@@ -2472,26 +2472,16 @@
             <a>databases</a> MUST be discarded and not used for any other
             <a>receiving browsing context</a>.
           </p>
-          <h4>Non-interactive versus interactive contexts</h4>
-          <p>
-            The <a>presentation display<a> rendering the <a>receiving browsing
-            context</a> may or may not have the ability to receive user input.
-            As such, the <a>receiving browsing context</a> should behave
-            reasonably when it knows that no user input is possible  That
-            implies that the following functions declared on <code>window</code>
-            should behave as no-ops:
+          <p class="note">
+            The <a>receiving user agent</a> may be a display-only device lacking
+            the ability to accept user input.  When this is the case, it should
+            handle functions that require user input carefully, especially when
+            the interaction is modal.  For example, functions such as
+            <code>window.alert</code>,
+            <code>window.confirm</code>,
+            <code>window.prompt</code>, and
+            <code>window.print</code> could be treated as no-ops.
           </p>
-          <ul>
-            <li><code>alert(<var>message</var>)</code></li>
-            <li><code>confirm(<var>message</var>)</code></li>
-            <li><code>prompt(<var>message, default</var>)</code></li>
-            <li><code>print()</code></li>
-          </ul>
-          In addition, <code>PresentationRequest.start()</code>
-
-
-            
-
         </section>
       </section>
       <section>

--- a/index.html
+++ b/index.html
@@ -2561,8 +2561,12 @@
             <a>receiving browsing contexts</a> using an implementation specific
             mechanism.
             </li>
-            <li>Set the <a>presentation connection state</a> of <var>S</var> to
-            <a for="PresentationConnectionState">connected</a>.
+            <li>If connection establishment completes successfully, set the
+            <a>presentation connection state</a> of <var>S</var> to
+            <a for="PresentationConnectionState">connected</a>. Otherwise, set
+            the <a>presentation connection state</a> of <var>S</var> to
+            <a for="PresentationConnectionState">closed</a> and abort all
+            remaining steps.
             </li>
             <li>Add <var>S</var> to the <a>set of presentation controllers</a>.
             </li>

--- a/index.html
+++ b/index.html
@@ -1037,7 +1037,8 @@
             all remaining steps.
             </li>
             <li>Otherwise, the user <em>granted permission</em> to use a
-            display; let <var>D</var> be that display.
+            display; let <var>D</var> be that display and <var>U</var> the user
+            agent connected to <var>D</var>.
             </li>
             <li>Let <var>I</var> be a new <a>valid presentation identifier</a>
             unique among all <a>presentation identifiers</a> for known
@@ -1078,15 +1079,9 @@
             <var>closeReason</var>, and a human readable message describing the
             failure as <var>closeMessage</var>.
             </li>
-            <li>
-              <a>Create a receiving browsing context</a> on <var>D</var> and
-              let <var>R</var> be the result.
-            </li>
-            <li>
-              <a>Navigate</a> <var>R</var> to <var>presentationUrl</var>.
-            </li>
-            <li>In <var>R</var>, begin <a>monitoring incoming presentation
-            connections</a>.
+            <li>Using an implementation specific mechanism, tell <var>U</var>
+            to <a>create a receiving browsing context</a> with <var>D</var> and
+            <var>presentationUrl</var> as parameters.
             </li>
             <li>
               <a>Establish a presentation connection</a> with <var>S</var>.
@@ -2367,6 +2362,10 @@
           <h4>
             Creating a receiving browsing context
           </h4>
+          <p>
+            When the <a>user agent</a> is to <dfn>create a receiving browsing
+            context</dfn>, it MUST run the following steps:
+          </p>
           <dl>
             <dt>
               Input
@@ -2374,20 +2373,13 @@
             <dd>
               <var>D</var>, a <a>presentation display</a> chosen by the user
             </dd>
-            <dt>
-              Output
-            </dt>
             <dd>
-              <var>R</var>, a <a>receiving browsing context</a>
+              <var>presentationUrl</var>, the <a>presentation request URL</a>
             </dd>
           </dl>
-          <p>
-            When the <a>user agent</a> is to <dfn>create a receiving browsing
-            context</dfn>, it MUST run the following steps:
-          </p>
           <ol>
-            <li>Create a new <a>top-level browsing context</a> <var>C</var> on
-            the user agent connected to <var>D</var>.
+            <li>Create a new <a>top-level browsing context</a> <var>C</var>,
+            set to display content on <var>D</var>.
             </li>
             <li>Set the <a>session history</a> of <var>C</var> to be the empty
             list.
@@ -2412,7 +2404,11 @@
             <li>Set the IndexedDB <a>databases</a> for <var>C</var> to an empty
             set of <a>databases</a>.
             </li>
-            <li>Return <var>C</var>.
+            <li>
+              <a>Navigate</a> <var>C</var> to <var>presentationUrl</var>.
+            </li>
+            <li>Start <a>monitoring incoming presentation connections</a> for
+            <var>C</var>.
             </li>
           </ol>
           <p>

--- a/index.html
+++ b/index.html
@@ -755,6 +755,22 @@
           connections</a> in this set share the same <a>presentation URL</a>
           and <a>presentation identifier</a>.
         </p>
+        <p>
+          In a <a>receiving browsing context</a>, the <dfn>presentation
+          controllers monitor</dfn>, initially set to <code>null</code>,
+          exposes the current <a>set of presentation controllers</a> to the
+          receiving application. The <a>presentation controllers monitor</a> is
+          represented by a <a>PresentationConnectionList</a>.
+        </p>
+        <p>
+          In a <a>receiving browsing context</a>, the <dfn>presentation
+          controllers promise</dfn>, which is initially set to
+          <code>null</code>, exposes the <a>presentation controllers
+          monitor</a> once the initial <a>presentation connection</a> is
+          established. The <a>presentation controllers promise</a> is
+          represented by a <a>Promise</a> that holds the <a>presentation
+          controllers monitor</a>.
+        </p>
       </section>
       <section>
         <h3>
@@ -1551,10 +1567,9 @@
             A <a>receiving user agent</a> <a>fires</a> a <a>trusted event</a>
             named <a for="PresentationConnectionList">connectionavailable</a>
             on a <a>PresentationReceiver</a> when an incoming connection is
-            created. It is fired at the <a>PresentationConnectionList</a>
-            instance associated with the <a>PresentationReceiver</a> instance,
-            using the <a>PresentationConnectionAvailableEvent</a> interface,
-            with the <a for=
+            created. It is fired at the <a>presentation controllers
+            monitor</a>, using the <a>PresentationConnectionAvailableEvent</a>
+            interface, with the <a for=
             "PresentationConnectionAvailableEvent">connection</a> attribute set
             to the <a><code>PresentationConnection</code></a> object that was
             created. The event is fired for all connections that are created
@@ -2318,33 +2333,34 @@
           <a>receiving user agent</a>.
         </p>
         <p>
-          When the <a>PresentationReceiver</a> object is created, a
-          <a>PresentationConnectionList</a> object is also created and
-          associated with that <a>PresentationReceiver</a> object.
-        </p>
-        <p>
           On getting, the <dfn for="PresentationReceiver">connectionList</dfn>
           attribute MUST return the result of running the following steps:
         </p>
         <ol>
-          <li>If there is already an unsettled <a>Promise</a> <var>P</var> from
-          a previous call to get the <a for=
-          "PresentationReceiver">connectionList</a> attribute for the same <a>
-            PresentationReceiver</a> object, return <var>P</var> and abort all
-            remaining steps.
+          <li>If the <a>presentation controllers promise</a> is not
+          <code>null</code>, return the <a>presentation controllers promise</a>
+          and abort all remaining steps.
           </li>
-          <li>Let <var>P</var> be a new <a>Promise</a>.
+          <li>Otherwise, let the <a>presentation controllers promise</a> be a
+          new <a>Promise</a>.
           </li>
-          <li>Return <var>P</var>, but continue running these steps <a>in
-          parallel</a>.
+          <li>Return the <a>presentation controllers promise</a>, but continue
+          running these steps <a>in parallel</a>.
           </li>
           <li>If the <a>set of presentation controllers</a> contains at least
-          one <a>presentation connection</a>, <a>resolve</a> <var>P</var> with
-          the <a>PresentationConnectionList</a> object associated with the <a>
-            PresentationReceiver</a> object.
+          one <a>presentation connection</a>, then run the following steps:
+            <ol>
+              <li>Let the <a>presentation controllers monitor</a> be a new <a>
+                PresentationConnectionList</a>.
+              </li>
+              <li>
+                <a>Resolve</a> the <a>presentation controllers promise</a> with
+                the <a>presentation controllers monitor</a>.
+              </li>
+            </ol>
           </li>
-          <li>Otherwise, <var>P</var> remains unsettled and associated with the
-          <a>PresentationReceiver</a> object.
+          <li>Otherwise, the <a>presentation controllers promise</a> remains
+          unsettled.
           </li>
         </ol>
         <section>
@@ -2488,24 +2504,31 @@
             </li>
             <li>Add <var>S</var> to the <a>set of presentation controllers</a>.
             </li>
-            <li>If there is an unsettled <a>Promise</a> <var>P</var> from a
-            previous call to get the <a for=
-            "PresentationReceiver">connectionList</a> attribute for the same
-            <a>PresentationReceiver</a> object, <a>resolve</a> <var>P</var>
-            with the <a>PresentationConnectionList</a> object associated with
-            the <a>PresentationReceiver</a> object and abort all remaining
-            steps.
+            <li>If the <a>presentation controllers promise</a> is
+            <code>null</code>, then abort all remaining steps.
             </li>
-            <li>
-              <a>Queue a task</a> to <a>fire</a> a <a>trusted event</a> with
-              the name <a for=
-              "PresentationConnectionList">connectionavailable</a>, that uses
-              the <a>PresentationConnectionAvailableEvent</a> interface, with
-              the <a for="PresentationConnectionAvailableEvent">connection</a>
-              attribute initialized to <var>S</var>, at the
-              <a>PresentationConnectionList</a> object associated with the
-              <a>PresentationReceiver</a> object. The event must not bubble,
-              must not be cancelable, and has no default action.
+            <li>Otherwise, if the <a>presentation controllers promise</a> is
+            unsettled, then run the following steps:
+              <ol>
+                <li>Let the <a>presentation controllers monitor</a> be a new
+                <a>PresentationConnectionList</a>.
+                </li>
+                <li>
+                  <a>Resolve</a> the <a>presentation controllers promise</a>
+                  with the <a>presentation controllers monitor</a>.
+                </li>
+                <li>Abort all remaining steps.
+                </li>
+              </ol>
+            </li>
+            <li>Otherwise, <a>queue a task</a> to <a>fire</a> a <a>trusted
+            event</a> with the name <a for=
+            "PresentationConnectionList">connectionavailable</a>, that uses the
+            <a>PresentationConnectionAvailableEvent</a> interface, with the
+            <a for="PresentationConnectionAvailableEvent">connection</a>
+            attribute initialized to <var>S</var>, at the <a>presentation
+            controllers monitor</a>. The event must not bubble, must not be
+            cancelable, and has no default action.
             </li>
           </ol>
           <p>

--- a/index.html
+++ b/index.html
@@ -1747,7 +1747,7 @@
           <ol>
             <li>Request connection of <var>presentationConnection</var> to the
             <a>receiving browsing context</a>. The <a>presentation
-            identifier</a> of <var>presentationConnection</var> must be sent
+            identifier</a> of <var>presentationConnection</var> MUST be sent
             with this request.
             </li>
             <li>If connection completes successfully, <a>queue a task</a> to

--- a/index.html
+++ b/index.html
@@ -1043,8 +1043,8 @@
             unique among all <a>presentation identifiers</a> for known
             <a>presentation connections</a> in the <a>set of controlled
             presentations</a>. To avoid fingerprinting, it is recommended that
-            the <a>presentation identifier</a> be generated as a <a>UUID</a>
-            following forms 4.4 or 4.5 of [[rfc4122]].
+            the <a>presentation identifier</a> be set to a <a>UUID</a>
+            generated following forms 4.4 or 4.5 of [[rfc4122]].
             </li>
             <li>Create a new <a>PresentationConnection</a> <var>S</var>.
             </li>
@@ -1745,9 +1745,10 @@
             </dd>
           </dl>
           <ol>
-            <li>Connect <var>presentationConnection</var> to the <a>receiving
-            browsing context</a>. The <a>presentation identifier</a> of
-            <var>presentationConnection</var> must be sent with this request.
+            <li>Request connection of <var>presentationConnection</var> to the
+            <a>receiving browsing context</a>. The <a>presentation
+            identifier</a> of <var>presentationConnection</var> must be sent
+            with this request.
             </li>
             <li>If connection completes successfully, <a>queue a task</a> to
             run the following steps:

--- a/index.html
+++ b/index.html
@@ -771,8 +771,8 @@
           <code>null</code>, provides the <a>presentation controllers
           monitor</a> once the initial <a>presentation connection</a> is
           established. The <a>presentation controllers promise</a> is
-          represented by a <a>Promise</a> that resolves with the <a>presentation
-          controllers monitor</a>.
+          represented by a <a>Promise</a> that resolves with the
+          <a>presentation controllers monitor</a>.
         </p>
       </section>
       <section>
@@ -2347,10 +2347,11 @@
           <li>Otherwise, let the <a>presentation controllers promise</a> be a
           new <a>Promise</a>.
           </li>
-          <li>Return the <a>presentation controllers promise</a>.</li>
-          <li>If the <a>presentation controllers monitor</a> is not <code>null</code>,
-            <a>resolve</a> the <a>presentation controllers promise</a> with the
-            <a>presentation controllers monitor</a>.
+          <li>Return the <a>presentation controllers promise</a>.
+          </li>
+          <li>If the <a>presentation controllers monitor</a> is not
+          <code>null</code>, <a>resolve</a> the <a>presentation controllers
+          promise</a> with the <a>presentation controllers monitor</a>.
           </li>
         </ol>
         <section>
@@ -2494,34 +2495,32 @@
             </li>
             <li>Add <var>S</var> to the <a>set of presentation controllers</a>.
             </li>
-            <li>If the <a>presentation controllers monitor</a> is <code>null</code>,
-              run the following steps <a>in parallel</a>.
+            <li>If the <a>presentation controllers monitor</a> is
+            <code>null</code>, run the following steps <a>in parallel</a>.
               <ol>
                 <li>Let the <a>presentation controllers monitor</a> be a new
-                  <a>PresentationConnectionList</a>.
+                <a>PresentationConnectionList</a>.
                 </li>
-                <li>
-                  Populate the <a>presentation controllers monitor</a> with the
-                  <a>set of presentation controllers</a>.
+                <li>Populate the <a>presentation controllers monitor</a> with
+                the <a>set of presentation controllers</a>.
                 </li>
-                <li>
-                  If the <a>presentation controllers promise</a> is not <code>null</code>,
-                  <a>resolve</a> the <a>presentation controllers promise</a>
-                  with the <a>presentation controllers monitor</a>.
+                <li>If the <a>presentation controllers promise</a> is not
+                <code>null</code>, <a>resolve</a> the <a>presentation
+                controllers promise</a> with the <a>presentation controllers
+                monitor</a>.
                 </li>
                 <li>Abort all remaining steps.
                 </li>
               </ol>
             </li>
-            <li>
-              Otherwise, <a>queue a task</a> to <a>fire</a> a <a>trusted
-                event</a> with the name <a for=
-                                           "PresentationConnectionList">connectionavailable</a>, that uses the
-              <a>PresentationConnectionAvailableEvent</a> interface, with the
-              <a for="PresentationConnectionAvailableEvent">connection</a>
-              attribute initialized to <var>S</var>, at the <a>presentation
-                controllers monitor</a>. The event must not bubble, must not be
-              cancelable, and has no default action.
+            <li>Otherwise, <a>queue a task</a> to <a>fire</a> a <a>trusted
+            event</a> with the name <a for=
+            "PresentationConnectionList">connectionavailable</a>, that uses the
+            <a>PresentationConnectionAvailableEvent</a> interface, with the
+            <a for="PresentationConnectionAvailableEvent">connection</a>
+            attribute initialized to <var>S</var>, at the <a>presentation
+            controllers monitor</a>. The event must not bubble, must not be
+            cancelable, and has no default action.
             </li>
           </ol>
           <p>

--- a/index.html
+++ b/index.html
@@ -97,6 +97,15 @@
               'YouTube'
             ],
             publisher: 'Netflix'
+          },
+          WEBIDL: {
+            title: 'Web IDL (Second Edition)',
+            href: 'https://heycam.github.io/webidl/',
+            status: 'ED',
+            authors: [
+              'Cameron McCormack',
+              'Boris Zbarsky'
+            ]
           }
         },
         issueBase: "https://www.github.com/w3c/presentation-api/issues/"
@@ -143,7 +152,7 @@
       </p>
     </section>
     <section id="sotd">
-       <p>
+      <p>
         Since publication as Working Draft on <a href=
         "https://www.w3.org/TR/2016/WD-presentation-api-20160211/">11 February
         2016</a>, the Working Group has further refined some of the procedures,
@@ -356,37 +365,45 @@
         ([[!WEBIDL]]). The terms <dfn><a href=
         "https://heycam.github.io/webidl/#idl-promise">Promise</a></dfn>,
         <dfn><a href=
-        "http://heycam.github.io/webidl/#idl-ArrayBuffer">ArrayBuffer</a></dfn>,
+        "https://heycam.github.io/webidl/#idl-ArrayBuffer">ArrayBuffer</a></dfn>,
         <dfn><a href=
-        "http://heycam.github.io/webidl/#idl-ArrayBufferView">ArrayBufferView</a></dfn>
+        "https://heycam.github.io/webidl/#idl-ArrayBufferView">ArrayBufferView</a></dfn>
         are defined in [[!WEBIDL]].
       </p>
       <p>
-        The <dfn>term</dfn> throw in this specification is used as defined in
-        [[!WEBIDL]]. The following exception names are defined by WebIDL and
-        used by this specification:
+        The term <dfn><a href=
+        "https://heycam.github.io/webidl/#dfn-throw">throw</a></dfn> in this
+        specification is used as defined in [[!WEBIDL]]. The following
+        exception names are defined by WebIDL and used by this specification:
       </p>
       <ul>
         <li>
-          <dfn><code>NotAllowedError</code></dfn>
+          <dfn><code><a href=
+          "https://heycam.github.io/webidl/#notallowederror">NotAllowedError</a></code></dfn>
         </li>
         <li>
-          <dfn><code>InvalidAccessError</code></dfn>
+          <dfn><code><a href=
+          "https://heycam.github.io/webidl/#invalidaccesserror">InvalidAccessError</a></code></dfn>
         </li>
         <li>
-          <dfn><code>NotFoundError</code></dfn>
+          <dfn><code><a href=
+          "https://heycam.github.io/webidl/#notfounderror">NotFoundError</a></code></dfn>
         </li>
         <li>
-          <dfn><code>NotSupportedError</code></dfn>
+          <dfn><code><a href=
+          "https://heycam.github.io/webidl/#notsupportederror">NotSupportedError</a></code></dfn>
         </li>
         <li>
-          <dfn><code>OperationError</code></dfn>
+          <dfn><code><a href=
+          "https://heycam.github.io/webidl/#operationerror">OperationError</a></code></dfn>
         </li>
         <li>
-          <dfn><code>SecurityError</code></dfn>
+          <dfn><code><a href=
+          "https://heycam.github.io/webidl/#securityerror">SecurityError</a></code></dfn>
         </li>
         <li>
-          <dfn><code>SyntaxError</code></dfn>
+          <dfn><code><a href=
+          "https://heycam.github.io/webidl/#syntaxerror">SyntaxError</a></code></dfn>
         </li>
       </ul>
       <p>
@@ -944,8 +961,8 @@
             by the entry <a>settings object</a>, and let
             <var>presentationUrl</var> be the resulting absolute URL, if any.
             </li>
-            <li>If the resolve a URL algorithm failed, then throw a
-            <a>SyntaxError</a> exception and abort the remaining steps.
+            <li>If the resolve a URL algorithm failed, then <a>throw</a> a <a>
+              SyntaxError</a> exception and abort the remaining steps.
             </li>
             <li>Construct a new <code>PresentationRequest</code> object with
             <var>presentationUrl</var> as the constructor argument and return
@@ -990,8 +1007,8 @@
             </li>
             <li>If the result of the algorithm is <code>"Prohibits Mixed
             Security Contexts"</code> and <var>presentationUrl</var> is an <a>
-            a priori unauthenticated URL</a>, then return a <a>Promise</a>
-            rejected with a <a>SecurityError</a> and abort these steps.
+              a priori unauthenticated URL</a>, then return a <a>Promise</a>
+              rejected with a <a>SecurityError</a> and abort these steps.
             </li>
             <li>If the document object's <a>active sandboxing flag set</a> has
             the <a>sandboxed presentation browsing context flag</a> set, then
@@ -1418,18 +1435,19 @@
           <ol>
             <li>If one of the following conditions is true:
               <ul>
-               <li>The result of running the <a>prohibits mixed security
+                <li>The result of running the <a>prohibits mixed security
                 contexts algorithm</a> on the document's <a>settings object</a>
-                is <code>"Prohibits Mixed Security Contexts"</code> and <var>
-                presentationUrl</var> is an <a>a priori unauthenticated URL</a>.
+                is <code>"Prohibits Mixed Security Contexts"</code> and
+                <var>presentationUrl</var> is an <a>a priori unauthenticated
+                URL</a>.
                 </li>
                 <li>The document object's <a>active sandboxing flag set</a> has
                 the <a>sandboxed presentation browsing context flag</a> set.
                 </li>
-              </ul>
-              Run the following substeps:
+              </ul>Run the following substeps:
               <ol>
-                <li>Return a <a>Promise</a> rejected with a <a>SecurityError</a>.
+                <li>Return a <a>Promise</a> rejected with a
+                <a>SecurityError</a>.
                 </li>
                 <li>Abort these steps.
                 </li>
@@ -1845,8 +1863,8 @@
           <ol link-for="PresentationConnection">
             <li>If the <a>state</a> property of
             <var>presentationConnection</var> is not <a for=
-            "PresentationConnectionState">connected</a>, throw an
-            <code>InvalidStateError</code> exception.
+            "PresentationConnectionState">connected</a>, <a>throw</a> an <code>
+              InvalidStateError</code> exception.
             </li>
             <li>If the <a>closing procedure</a> of
             <var>presentationConnection</var> has started, then abort these

--- a/index.html
+++ b/index.html
@@ -2283,8 +2283,9 @@
           <a>receiving user agent</a>.
         </p>
         <p>
-          A <a>PresentationReceiver</a> object is associated with a
-          <a>PresentationConnectionList</a> object when it is created.
+          When the <a>PresentationReceiver</a> object is created, a
+          <a>PresentationConnectionList</a> object is also created and
+          associated with that <a>PresentationReceiver</a> object.
         </p>
         <p>
           On getting, the <dfn for="PresentationReceiver">connectionList</dfn>
@@ -2307,10 +2308,8 @@
           the <a>PresentationConnectionList</a> object associated with the <a>
             PresentationReceiver</a> object.
           </li>
-          <li>Otherwise, <var>P</var> remains unsettled. It will be resolved
-          when the first <a>presentation connection</a> is added to the <a>set
-          of presentation controllers</a> as part of the <a>monitoring incoming
-          presentation connections</a> algorithm.
+          <li>Otherwise, <var>P</var> remains unsettled and associated with the
+          <a>PresentationReceiver</a> object.
           </li>
         </ol>
         <section>

--- a/index.html
+++ b/index.html
@@ -2513,14 +2513,23 @@
                 </li>
               </ol>
             </li>
-            <li>Otherwise, <a>queue a task</a> to <a>fire</a> a <a>trusted
-            event</a> with the name <a for=
-            "PresentationConnectionList">connectionavailable</a>, that uses the
-            <a>PresentationConnectionAvailableEvent</a> interface, with the
-            <a for="PresentationConnectionAvailableEvent">connection</a>
-            attribute initialized to <var>S</var>, at the <a>presentation
-            controllers monitor</a>. The event must not bubble, must not be
-            cancelable, and has no default action.
+            <li>Otherwise, run the following steps <a>in parallel</a>.
+              <ol>
+                <li>Populate the <a>presentation controllers monitor</a> with
+                the <a>set of presentation controllers</a>.
+                </li>
+                <li>
+                  <a>Queue a task</a> to <a>fire</a> a <a>trusted event</a>
+                  with the name <a for=
+                  "PresentationConnectionList">connectionavailable</a>, that
+                  uses the <a>PresentationConnectionAvailableEvent</a>
+                  interface, with the <a for=
+                  "PresentationConnectionAvailableEvent">connection</a>
+                  attribute initialized to <var>S</var>, at the <a>presentation
+                  controllers monitor</a>. The event must not bubble, must not
+                  be cancelable, and has no default action.
+                </li>
+              </ol>
             </li>
           </ol>
           <p>

--- a/index.html
+++ b/index.html
@@ -2283,6 +2283,10 @@
           <a>receiving user agent</a>.
         </p>
         <p>
+          A <a>PresentationReceiver</a> object is associated with a
+          <a>PresentationConnectionList</a> object when it is created.
+        </p>
+        <p>
           On getting, the <dfn for="PresentationReceiver">connectionList</dfn>
           attribute MUST return the result of running the following steps:
         </p>
@@ -2298,14 +2302,15 @@
           <li>Return <var>P</var>, but continue running these steps <a>in
           parallel</a>.
           </li>
-          <li>Let <var>list</var> be a new <a>PresentationConnectionList</a>.
+          <li>If the <a>set of presentation controllers</a> contains at least
+          one <a>presentation connection</a>, <a>resolve</a> <var>P</var> with
+          the <a>PresentationConnectionList</a> object associated with the <a>
+            PresentationReceiver</a> object.
           </li>
-          <li>Resolve <var>P</var> with <var>list</var>.
-          </li>
-          <li>If the <a>user agent</a> is not <a>monitoring incoming
-          presentation connections</a>, start <a>monitoring incoming
-          presentation connections</a> from <a>controlling browsing
-          contexts</a>.
+          <li>Otherwise, <var>P</var> remains unsettled. It will be resolved
+          when the first <a>presentation connection</a> is added to the <a>set
+          of presentation controllers</a> as part of the <a>monitoring incoming
+          presentation connections</a> algorithm.
           </li>
         </ol>
         <section>
@@ -2439,6 +2444,14 @@
             </li>
             <li>Add <var>S</var> to the <a>set of presentation controllers</a>.
             </li>
+            <li>If there is an unsettled <a>Promise</a> <var>P</var> from a
+            previous call to get the <a for=
+            "PresentationReceiver">connectionList</a> attribute for the same
+            <a>PresentationReceiver</a> object, <a>resolve</a> <var>P</var>
+            with the <a>PresentationConnectionList</a> object associated with
+            the <a>PresentationReceiver</a> object and abort all remaining
+            steps.
+            </li>
             <li>
               <a>Queue a task</a> to <a>fire</a> a <a>trusted event</a> with
               the name <a for=
@@ -2446,7 +2459,7 @@
               the <a>PresentationConnectionAvailableEvent</a> interface, with
               the <a for="PresentationConnectionAvailableEvent">connection</a>
               attribute initialized to <var>S</var>, at the
-              <a>PresentationConnectionList</a> instance associated with the
+              <a>PresentationConnectionList</a> object associated with the
               <a>PresentationReceiver</a> object. The event must not bubble,
               must not be cancelable, and has no default action.
             </li>

--- a/index.html
+++ b/index.html
@@ -1080,8 +1080,8 @@
             failure as <var>closeMessage</var>.
             </li>
             <li>Using an implementation specific mechanism, tell <var>U</var>
-            to <a>create a receiving browsing context</a> with <var>D</var> and
-            <var>presentationUrl</var> as parameters.
+            to <a>create a receiving browsing context</a> with <var>D</var>,
+            <var>presentationUrl</var>, and <var>I</var> as parameters.
             </li>
             <li>
               <a>Establish a presentation connection</a> with <var>S</var>.
@@ -2376,6 +2376,9 @@
             <dd>
               <var>presentationUrl</var>, the <a>presentation request URL</a>
             </dd>
+            <dd>
+              <var>presentationId</var>, the <a>presentation identifier</a>
+            </dd>
           </dl>
           <ol>
             <li>Create a new <a>top-level browsing context</a> <var>C</var>,
@@ -2408,7 +2411,7 @@
               <a>Navigate</a> <var>C</var> to <var>presentationUrl</var>.
             </li>
             <li>Start <a>monitoring incoming presentation connections</a> for
-            <var>C</var>.
+            <var>C</var> with <var>presentationId</var>.
             </li>
           </ol>
           <p>
@@ -2482,9 +2485,24 @@
             a <a>controlling browsing context</a>, the <a>receiving user
             agent</a> MUST run the following steps:
           </p>
+          <dl>
+            <dt>
+              Input
+            </dt>
+            <dd>
+              <var>I</var>, the <a>presentation identifier</a> passed by the
+              <a>controlling browsing context</a> with the incoming connection
+              request.
+            </dd>
+            <dd>
+              <var>presentationId</var>, the <a>presentation identifier</a>
+              used to <a data-lt="create a receiving browsing context">create
+              the receiving browsing context</a>.
+            </dd>
+          </dl>
           <ol>
-            <li>Let <var>I</var> be the <a>presentation identifier</a> sent by
-            the <a>controlling browsing context</a> in the incoming request.
+            <li>If <var>presentationId</var> and <var>I</var> are not equal,
+            refuse the connection and abort all remaining steps.
             </li>
             <li>Create a new <a>PresentationConnection</a> <var>S</var>.
             </li>

--- a/index.html
+++ b/index.html
@@ -598,7 +598,7 @@
         <pre class="example highlight">
 &lt;!-- controller.html --&gt;
 &lt;button id="disconnectBtn" style="display: none;"&gt;Disconnect&lt;/button&gt;
-&lt;button id="terminateBtn" style="display: none;"&gt;Stop&lt;/button&gt;
+&lt;button id="stopBtn" style="display: none;"&gt;Stop&lt;/button&gt;
 &lt;script&gt;
   var connection;
 

--- a/index.html
+++ b/index.html
@@ -789,18 +789,18 @@
             <code>defaultRequest</code> will have no effect.
           </div>
           <div class="note">
-            Some <a data-lt="controlling user agent">controlling user agents</a>
-            may allow the user to initiate a default <a>presentation
+            Some <a data-lt="controlling user agent">controlling user
+            agents</a> may allow the user to initiate a default <a>presentation
             connection</a> and select a <a>presentation display</a> with the
-            same user gesture.  For example, the browser chrome could allow the
-            user to pick a display from a menu, or allow the user to tap on
-            an <a href="https://nfc-forum.org/">Near Field Communications
+            same user gesture. For example, the browser chrome could allow the
+            user to pick a display from a menu, or allow the user to tap on an
+            <a href="https://nfc-forum.org/">Near Field Communications
             (NFC)</a> enabled display. In this case, when the <a>controlling
-            user agent</a> asks for permission while
-            <a data-lt="start a presentation">starting a presentation</a>, the
-            browser could offer that display as the default choice, or consider
-            the gesture as granting permission for the display and bypass
-            display selection entirely.
+            user agent</a> asks for permission while <a data-lt=
+            "start a presentation">starting a presentation</a>, the browser
+            could offer that display as the default choice, or consider the
+            gesture as granting permission for the display and bypass display
+            selection entirely.
           </div>
         </section>
         <section>
@@ -1031,6 +1031,9 @@
             </li>
             <li>
               <a>Navigate</a> <var>R</var> to <var>presentationUrl</var>.
+            </li>
+            <li>In <var>R</var>, begin <a>monitoring incoming presentation
+            connections</a>.
             </li>
             <li>
               <a>Establish a presentation connection</a> with <var>S</var>.
@@ -1379,6 +1382,17 @@
                 <li>
                   <a>Reject</a> <var>P</var> with a <a>NotSupportedError</a>
                   exception.
+                </li>
+                <li>Abort all the remaining steps.
+                </li>
+              </ol>
+            </li>
+            <li>If there exists a tuple <em>(<var>A</var>,
+            <var>presentationUrl</var>)</em> in the <a>set of availability
+            objects</a>, then:
+              <ol>
+                <li>
+                  <a>Resolve</a> <var>P</var> with <var>A</var>.
                 </li>
                 <li>Abort all the remaining steps.
                 </li>
@@ -1888,7 +1902,7 @@
 
             dictionary PresentationConnectionClosedEventInit : EventInit {
               required PresentationConnectionClosedReason reason;
-              DOMString message;
+              DOMString message = "";
             };
 
 

--- a/index.html
+++ b/index.html
@@ -797,9 +797,8 @@
         <p>
           The <dfn for="Navigator"><code>presentation</code></dfn> attribute is
           used to retrieve an instance of the <a><code>Presentation</code></a>
-          interface. If <a>presentation is disabled</a>, the attribute MUST
-          return null. Otherwise, it MUST return the
-          <a><code>Presentation</code></a> instance.
+          interface. It MUST return the <a><code>Presentation</code></a>
+          instance.
         </p>
         <section>
           <h4>
@@ -991,8 +990,13 @@
             </li>
             <li>If the result of the algorithm is <code>"Prohibits Mixed
             Security Contexts"</code> and <var>presentationUrl</var> is an <a>
-              a priori unauthenticated URL</a>, then return a <a>Promise</a>
-              rejected with a <a>SecurityError</a>.
+            a priori unauthenticated URL</a>, then return a <a>Promise</a>
+            rejected with a <a>SecurityError</a> and abort these steps.
+            </li>
+            <li>If the document object's <a>active sandboxing flag set</a> has
+            the <a>sandboxed presentation browsing context flag</a> set, then
+            return a <a>Promise</a> rejected with a <a>SecurityError</a> and
+            abort these steps.
             </li>
             <li>If there is already an unsettled <a>Promise</a> from a previous
             call to <code>start</code> for the same <a>controlling browsing
@@ -1136,15 +1140,21 @@
             </dd>
           </dl>
           <ol>
-            <li>Let <var>P</var> be a new <a>Promise</a>.
-            </li>
             <li>Using the document's <a>settings object</a>, run the
             <a>prohibits mixed security contexts algorithm</a>.
             </li>
             <li>If the result of the algorithm is <code>"Prohibits Mixed
             Security Contexts"</code> and the <a>presentation request URL</a>
             of <var>presentationRequest</var> is an <a>a priori unauthenticated
-            URL</a>, then reject <var>P</var> with a <a>SecurityError</a>.
+            URL</a>, then return a <a>Promise</a> rejected with a
+            <a>SecurityError</a> and abort these steps.
+            </li>
+            <li>If the document object's <a>active sandboxing flag set</a> has
+            the <a>sandboxed presentation browsing context flag</a> set, then
+            return a <a>Promise</a> rejected with a <a>SecurityError</a> and
+            abort these steps.
+            </li>
+            <li>Let <var>P</var> be a new <a>Promise</a>.
             </li>
             <li>Return <var>P</var>, but continue running these steps in
             parallel.
@@ -1406,6 +1416,25 @@
             </dd>
           </dl>
           <ol>
+            <li>If one of the following conditions is true:
+              <ul>
+               <li>The result of running the <a>prohibits mixed security
+                contexts algorithm</a> on the document's <a>settings object</a>
+                is <code>"Prohibits Mixed Security Contexts"</code> and <var>
+                presentationUrl</var> is an <a>a priori unauthenticated URL</a>.
+                </li>
+                <li>The document object's <a>active sandboxing flag set</a> has
+                the <a>sandboxed presentation browsing context flag</a> set.
+                </li>
+              </ul>
+              Run the following substeps:
+              <ol>
+                <li>Return a <a>Promise</a> rejected with a <a>SecurityError</a>.
+                </li>
+                <li>Abort these steps.
+                </li>
+              </ol>
+            </li>
             <li>Let <var>P</var> be a new <a>Promise</a>.
             </li>
             <li>Return <var>P</var>, but continue running these steps <a>in
@@ -2622,19 +2651,6 @@
           keyword.
           </li>
         </ul>
-        <p>
-          <dfn>Presentation is disabled</dfn> in a browsing context when the
-          document object's <a>active sandboxing flag set</a> does not have the
-          <a>sandboxed presentation browsing context flag</a> set.
-        </p>
-        <div class="note">
-          A <a>nested browsing context</a> created by an <code>iframe</code>
-          with its <code>sandbox</code> attribute set will act as if
-          <a>presentation is disabled</a>, unless that attribute includes the
-          <code>allow-presentation</code> keyword. This allows pages to embed
-          potentially untrustworthy content and deny it the ability to request
-          presentation from the user or query for screen availability.
-        </div>
       </section>
     </section>
     <section>

--- a/index.html
+++ b/index.html
@@ -420,6 +420,11 @@
         is defined in RFC 6265 [[COOKIES]].
       </p>
       <p>
+        The term <dfn><a href=
+        "https://tools.ietf.org/html/rfc4122">UUID</a></dfn> is defined in RFC
+        4122 [[rfc4122]].
+      </p>
+      <p>
         The terms <dfn data-lt="permission|permissions"><a href=
         "https://w3c.github.io/permissions/#idl-def-Permission">permission</a></dfn>
         and <dfn><a href=
@@ -698,11 +703,11 @@
           connection</dfn> is an object relating a <a>controlling browsing
           context</a> to its <a>receiving browsing context</a> and enables
           two-way-messaging between them. Each <a>presentation connection</a>
-          has a <dfn>presentation connection state</dfn>, a <dfn lt=
+          has a <dfn>presentation connection state</dfn>, a unique <dfn lt=
           "presentation identifier|presentation identifiers">presentation
           identifier</dfn> to distinguish it from other <a>presentations</a>,
           and a <dfn>presentation URL</dfn> that is a <a>URL</a> used to create
-          or resume the <a>presentation</a>. A <dfn>valid presentation
+          or reconnect to the <a>presentation</a>. A <dfn>valid presentation
           identifier</dfn> consists of alphanumeric ASCII characters only and
           is at least 16 characters long.
         </p>
@@ -1037,7 +1042,9 @@
             <li>Let <var>I</var> be a new <a>valid presentation identifier</a>
             unique among all <a>presentation identifiers</a> for known
             <a>presentation connections</a> in the <a>set of controlled
-            presentations</a>.
+            presentations</a>. To avoid fingerprinting, it is recommended that
+            the <a>presentation identifier</a> be generated as a <a>UUID</a>
+            following forms 4.4 or 4.5 of [[rfc4122]].
             </li>
             <li>Create a new <a>PresentationConnection</a> <var>S</var>.
             </li>
@@ -1123,7 +1130,7 @@
               "PresentationRequest">reconnect</a>()</code> was called on.
             </dd>
             <dd>
-              <var>presentationId</var>, a <a>presentation identifier</a>
+              <var>presentationId</var>, a valid <a>presentation identifier</a>
             </dd>
             <dt>
               Output
@@ -1739,7 +1746,8 @@
           </dl>
           <ol>
             <li>Connect <var>presentationConnection</var> to the <a>receiving
-            browsing context</a>.
+            browsing context</a>. The <a>presentation identifier</a> of
+            <var>presentationConnection</var> must be sent with this request.
             </li>
             <li>If connection completes successfully, <a>queue a task</a> to
             run the following steps:

--- a/index.html
+++ b/index.html
@@ -660,6 +660,9 @@
         <pre class="example highlight">
 &lt;!-- controller.html --&gt;
 &lt;script&gt;
+  connection.send("{string: '你好，世界!', lang: 'zh-CN'}");
+  connection.send("{string: 'こんにちは、世界!', lang: 'ja'}");
+  connection.send("{string: '안녕하세요, 세계!', lang: 'ko'}");
   connection.send("{string: 'Hello, world!', lang: 'en-US'}");
 &lt;/script&gt;
 

--- a/index.html
+++ b/index.html
@@ -765,10 +765,10 @@
         <p>
           In a <a>receiving browsing context</a>, the <dfn>presentation
           controllers promise</dfn>, which is initially set to
-          <code>null</code>, exposes the <a>presentation controllers
+          <code>null</code>, provides the <a>presentation controllers
           monitor</a> once the initial <a>presentation connection</a> is
           established. The <a>presentation controllers promise</a> is
-          represented by a <a>Promise</a> that holds the <a>presentation
+          represented by a <a>Promise</a> that resolves with the <a>presentation
           controllers monitor</a>.
         </p>
       </section>
@@ -2354,6 +2354,10 @@
                 PresentationConnectionList</a>.
               </li>
               <li>
+                Populate the <a>presentation controllers monitor</a> with the
+                current <a>set of presentation controllers<a>.
+              </li>
+              <li>
                 <a>Resolve</a> the <a>presentation controllers promise</a> with
                 the <a>presentation controllers monitor</a>.
               </li>
@@ -2507,11 +2511,17 @@
             <li>If the <a>presentation controllers promise</a> is
             <code>null</code>, then abort all remaining steps.
             </li>
-            <li>Otherwise, if the <a>presentation controllers promise</a> is
-            unsettled, then run the following steps:
+            <li>If the <a>presentation controllers promise</a> is <a>settled</a>,
+              then run the following steps:</li>
+            
+            <li>Otherwise, run the following steps:
               <ol>
                 <li>Let the <a>presentation controllers monitor</a> be a new
                 <a>PresentationConnectionList</a>.
+                </li>
+                <li>
+                  Populate the <a>presentation controllers monitor</a> with the
+                  current <a>set of presentation controllers<a>.
                 </li>
                 <li>
                   <a>Resolve</a> the <a>presentation controllers promise</a>

--- a/index.html
+++ b/index.html
@@ -2353,6 +2353,26 @@
             <a>databases</a> MUST be discarded and not used for any other
             <a>receiving browsing context</a>.
           </p>
+          <h4>Non-interactive versus interactive contexts</h4>
+          <p>
+            The <a>presentation display<a> rendering the <a>receiving browsing
+            context</a> may or may not have the ability to receive user input.
+            As such, the <a>receiving browsing context</a> should behave
+            reasonably when it knows that no user input is possible  That
+            implies that the following functions declared on <code>window</code>
+            should behave as no-ops:
+          </p>
+          <ul>
+            <li><code>alert(<var>message</var>)</code></li>
+            <li><code>confirm(<var>message</var>)</code></li>
+            <li><code>prompt(<var>message, default</var>)</code></li>
+            <li><code>print()</code></li>
+          </ul>
+          In addition, <code>PresentationRequest.start()</code>
+
+
+            
+
         </section>
       </section>
       <section>


### PR DESCRIPTION
This PR implements a proposed resolution for Issue #99; see https://github.com/w3c/presentation-api/issues/99#issuecomment-221434513

It adds a note to handle Window functions that require user input on the receiving user agent, especially when they block (i.e. alert())

