### PR TITLE
Issue #228: Remove GitHub issue code.

### DIFF
--- a/index.html
+++ b/index.html
@@ -108,9 +108,6 @@
             ]
           }
         },
-        issueBase: "https://www.github.com/w3c/presentation-api/issues/"
-        // TODO: Uncomment when https://github.com/w3c/presentation-api/issues/228 is fixed
-        // githubAPI: "https://api.github.com/repos/w3c/presentation-api"
       };
     </script>
     <style>


### PR DESCRIPTION
Resolves Issue #228: GitHub API failing, which leads to ReSpec failures.  We have no more GitHub issues referenced in the spec, so we don't need this any more :-)
