### PR TITLE
CR Exit criteria

### DIFF
--- a/index.html
+++ b/index.html
@@ -2876,26 +2876,26 @@
       </p>
       <dl>
         <dt>
-          independent
+          Independent
         </dt>
         <dd>
-          each implementation must be developed by a different party, and
+          Each implementation must be developed by a different party, and
           cannot share, reuse, or derive from code used by another qualifying
           implementation. Sections of code that have no bearing on the
           implementation of this specification are exempt from this
           requirement.
         </dd>
         <dt>
-          interoperable
+          Interoperable
         </dt>
         <dd>
-          passing the respective test case(s) in the official test suite.
+          Passing the respective test case(s) in the official test suite.
         </dd>
         <dt>
-          implementation
+          Implementation
         </dt>
         <dd>
-          a user agent which:
+          A user agent which:
           <ol>
             <li>implements one of the conformance classes of the specification.
             </li>

--- a/index.html
+++ b/index.html
@@ -169,6 +169,17 @@
         and made initial progress on the test suite. Wide reviews of this
         document are encouraged.
       </p>
+      <p>
+        The Second Screen Presentation Working Group will complete the <a href=
+        "http://w3c-test.org/presentation-api/">test suite</a> for the
+        Presentation API during the Candidate Recommendation period and prepare
+        an <a href=
+        "https://www.w3.org/wiki/Second_Screen/Implementation_Status#Tests">implementation
+        report</a>. For this specification to advance to Proposed
+        Recommendation, two independent, interoperable implementations of each
+        feature must be demonstrated, as detailed in the <a href=
+        "#h-cr-exit-criteria">CR exit criteria</a> section.
+      </p>
     </section>
     <section class="informative">
       <h2>
@@ -2843,6 +2854,64 @@
         Travis Leithead, and Wayne Carr for help with editing, reviews and
         feedback to this draft.
       </p>
+    </section>
+    <section class="appendix">
+      <h2>
+        CR exit criteria
+      </h2>
+      <p>
+        For this specification to be advanced to Proposed Recommendation, there
+        must be, for each of the conformance classes it defines (<a>controlling
+        user agent</a> and <a>receiving user agent</a>), at least two
+        independent, interoperable implementations of each feature. Each
+        feature may be implemented by a different set of products, there is no
+        requirement that all features be implemented by a single product.
+        Additionally, implementations of the receiving user agent conformance
+        class must include at least one implementation of the <a href=
+        "#1-ua">1-UA</a> mode and one implementation of the <a href=
+        "#2-ua">2-UA</a> mode.
+      </p>
+      <p>
+        For the purposes of these criteria, we define the following terms:
+      </p>
+      <dl>
+        <dt>
+          independent
+        </dt>
+        <dd>
+          each implementation must be developed by a different party, and
+          cannot share, reuse, or derive from code used by another qualifying
+          implementation. Sections of code that have no bearing on the
+          implementation of this specification are exempt from this
+          requirement.
+        </dd>
+        <dt>
+          interoperable
+        </dt>
+        <dd>
+          passing the respective test case(s) in the official test suite.
+        </dd>
+        <dt>
+          implementation
+        </dt>
+        <dd>
+          a user agent which:
+          <ol>
+            <li>implements one of the conformance classes of the specification.
+            </li>
+            <li>is available to the general public. The implementation may be a
+            shipping product or other publicly available version (i.e., beta
+            version, preview release, or "nightly build"). Non-shipping product
+            releases must have implemented the feature(s) for a period of at
+            least one month in order to demonstrate stability.
+            </li>
+            <li>is not experimental (i.e. a version specifically designed to
+            pass the test suite and not intended for normal usage going
+            forward).
+            </li>
+          </ol>
+        </dd>
+      </dl>
     </section>
   </body>
 </html>


### PR DESCRIPTION
As discussed during the F2F, the working group needs to agree on exit criteria for the Candidate Recommendation phase before it may publish the spec as Candidate Recommendation. I took an action at the F2F to craft such criteria:
http://www.w3.org/2016/05/24-webscreens-minutes.html#action09

The usual criteria (also defined in our charter) are to have, for each conformance class, two independent interoperable implementations of each feature.

On top of that, I propose to add the need to demonstrate that there are implementations of the 1-UA mode and of the 2-UA mode for receiving user agents, because we expect to see both modes supported in practice.

This pull request introduces a "CR exit criteria" appendix that details these criteria. The wording is based on other specs, e.g.:
- CSS flexbox: http://www.w3.org/TR/css-flexbox-1/#cr-exit-criteria
- HTML5: https://dev.w3.org/html5/decision-policy/public-permissive-exit-criteria.html

Note other specs do not detail what they mean by "independent", "interoperable" and "implementation" but I think that it's a good idea to be explicit.

The pull request also updates the Status of This Document (SoTD) section to reference the exit criteria. Note further edits of the SoTD will be needed prior to publication as Candidate Recommendation.