### PR TITLE
Updates PresentationRequest to take multiple URLs

### DIFF
--- a/index.html
+++ b/index.html
@@ -929,8 +929,8 @@
           Interface <a><code>PresentationRequest</code></a>
         </h3>
         <pre class="idl">
-          [Constructor(DOMString url)]
-          [Constructor(DOMString[] urls)]
+          [Constructor(DOMString url),
+           Constructor(DOMString[] urls)]
           interface PresentationRequest : EventTarget {
             Promise&lt;PresentationConnection&gt; start();
             Promise&lt;PresentationConnection&gt; reconnect(DOMString presentationId);
@@ -980,9 +980,8 @@
             </dd>
           </dl>
           <ol>
-            <li>If the constructor that take a single <var>url</var> was
-            invoked, let <var>urls</var> be a one item list with <var>url</var>
-            as its only member.
+            <li>If a single <var>url</var> was provided, let <var>urls</var> be
+            a one item array containing <var>url</var>.
             </li>
             <li>Let <var>presentationUrls</var> be an empty list of URLs.
             </li>
@@ -998,8 +997,8 @@
               </ol>
             </li>
             <li>Construct a new <code>PresentationRequest</code> object with
-            <var>presentationUrls</var> as the constructor argument and return
-            it.
+            <var>presentationUrls</var> as its <a>presentation request URLs</a>
+            and return it.
             </li>
           </ol>
         </section>

--- a/index.html
+++ b/index.html
@@ -940,7 +940,7 @@
         <p>
           When a <a><code>PresentationRequest</code></a> is constructed, the
           given <code>urls</code> MUST be used as the list of <dfn data-lt=
-          "presentation request URL|presentation request URLs">presentation
+          "presentation request URL">presentation
           request URLs</dfn> which are each a possible <a>presentation URL</a>
           for the <a><code>PresentationRequest</code></a> instance.
         </p>
@@ -1090,9 +1090,14 @@
             <li>Set the <a>presentation identifier</a> of <var>S</var> to <var>
               I</var>.
             </li>
-            <li>Set the <a>presentation URL</a> of <var>S</var> to the
-            <var>presentationUrl</var> for <var>D</var> in the <a>list of
-            available presentation displays</a>.
+            <li>For each <var>presentationUrl</var> in <var>presentationUrls</var> in order, run the following step:
+              <ol>
+                <li>
+                  If there is an entry <var>(presentationUrl, D)</var> in
+                  the <a>list of available presentation displays</a>, then set the <a>presentation URL</a> for <var>S</var> to
+                  <var>presentationUrl</var> and stop iterating.
+                </li>
+              </ol>
             </li>
             <li>Set the <a>presentation connection state</a> of <var>S</var> to
             <a for="PresentationConnectionState">connecting</a>.
@@ -1245,7 +1250,7 @@
                 <var>presentationId</var>.
                 </li>
                 <li>Set the <a>presentation URL</a> of <var>S</var> to the <a>
-                  presentation request URL</a> of <var>E</var>.
+                  presentation URL</a> of <var>E</var>.
                 </li>
                 <li>Set the <a>presentation connection state</a> of
                 <var>S</var> to <a for=
@@ -1377,7 +1382,12 @@
           </h4>
           <p>
             The <a>user agent</a> MUST keep a <dfn>list of available
-            presentation displays</dfn>. This current list of <a>presentation
+            presentation displays</dfn>. The <a>list of available presentation
+            displays</a> is represented by a list of
+            tuples <var>(availabilityUrl, display)</var>.  An entry in this list
+            means that <var>display</var> is curently available to start a
+            presentation and is a <a>compatible presentation display</a>
+            for <var>availabilityUrl.</var>  This list of <a>presentation
             displays</a> may be used for starting new presentations, and is
             populated based on an implementation specific discovery mechanism.
             It is set to the most recent result of the algorithm to <a>monitor
@@ -1510,10 +1520,18 @@
               </ol>
             </li>
             <li>Let <var>A</var> be a new <code>PresentationAvailability</code>
-            object with its <code>value</code> property set to
-            <code>false</code> if the <a>list of available presentation
-            displays</a> is empty or none of them is a <a>compatible
-            presentation display</a>, <code>true</code> otherwise.
+              object with its <code>value</code> property set as follows:
+              <ol>
+                <li><code>false</code> if the <a>list of available presentation
+                    displays</a> is empty.
+                <li><code>true</code> if there is at least one <a>compatible
+                presentation display</a> for some member of
+                of <var>presentationUrls</var>.  That is, there is an
+                entry <var>(availabilityUrl, display)</var> in the
+                  <a>list of available presentation displays</a> where <var>availabiltyUrl</var> is a member of <var>presentationUrls</var>.
+                </li>
+                <li><code>false</code> otherwise.</li>
+                </ol>
             </li>
             <li>Create a tuple <em>(<var>A</var>,
             <var>presentationUrls</var>)</em> and add it to the <a>set of
@@ -1539,23 +1557,36 @@
             running the following steps.
           </p>
           <ol link-for="PresentationAvailability">
+            <li>
+              Set the <a>list of available presentation displays</a> to the empty list.
+            </li>
             <li>Retrieve available presentation displays (using an
             implementation specific mechanism) and let <var>newDisplays</var>
             be this list.
             </li>
             <li>For each member <em>(<var>A</var>,
             <var>availabilityUrls</var>)</em> of the <a>set of availability
-            objects</a>:
+            objects</a>, run the following steps:
               <ol>
                 <li>Set <var>previousAvailability</var> to the value of
-                <var>A</var>'s <a>value</a> property.
+                  <var>A</var>'s <a>value</a> property.
                 </li>
-                <li>Let <var>newAvailability</var> be <code>true</code> if
-                <var>newDisplays</var> is not empty and at least one display in
-                <var>newDisplays</var> is a <a>compatible presentation
-                display</a> for at least one member of
-                <var>availabilityUrls</var>. Otherwise, set
-                <var>newAvailability</var> to <code>false</code>.
+                <li>Let <var>newAvailability</var> be <code>false</code>.</li>
+                <li>For each <var>availabilityUrl</var> in <var>availabilityUrls</var>, run the following steps:
+                  <ol>
+                    <li>
+                      For each <var>display</var> in <var>newDisplays</var>, if <var>display</var> is a
+                      <a>compatible presentation display</a> for <var>availabilityUrl</var>, then
+                      run the following steps:
+                      <ol>
+                        <li>Insert a tuple <var>(availabilityUrl, display)</var>
+                          into the <a>list of available presentation
+                          displays</a> (if no identical tuple already
+                          exists).</li>
+                        <li>Set <var>newAvailability</var> to <code>true</code>.</li>
+                      </ol>
+                    </li>
+                  </ol>
                 </li>
                 <li>If <var>previousAvailability</var> is not equal to
                 <var>newAvailability</var>, then <a>queue a task</a> to run the
@@ -1572,9 +1603,6 @@
                 </li>
               </ol>
             </li>
-            <li>Set the <a>list of available presentation displays</a> to the
-            value of <var>newDisplays</var>.
-            </li>
           </ol>
           <p>
             When a <a>PresentationAvailability</a> object is no longer alive
@@ -1586,11 +1614,12 @@
             <var>availabilityUrl</var>)</em> in the <a>set of availability
             objects</a> for the newly deceased <var>A</var>.
             </li>
-            <li>If the <a>set of availability objects</a> is now empty and
-            there is no pending request to <a for="PresentationRequest"
-              data-lt="start">start a presentation</a>, cancel any pending task
-              to <a>monitor the list of available presentation displays</a> for
-              power saving purposes.
+            <li>If the <a>set of availability objects</a> is now empty and there
+            is no pending request to <a for="PresentationRequest"
+            data-lt="start">start a presentation</a>, cancel any pending task
+            to <a>monitor the list of available presentation displays</a> for
+            power saving purposes, and set the <a>list of available presentation
+            displays</a> to the empty list.
             </li>
           </ol>
           <div class="note">
@@ -1661,6 +1690,7 @@
 
           interface PresentationConnection : EventTarget {
             readonly attribute DOMString? id;
+            readonly attribute DOMString url;
             readonly attribute PresentationConnectionState state;
             void close();
             void terminate();
@@ -1683,6 +1713,10 @@
           <p>
             The <dfn><code>id</code></dfn> attribute specifies the
             <a>presentation connection</a>'s <a>presentation identifier</a>.
+          </p>
+          <p>
+            The <dfn><code>url</code></dfn> attribute specifies the
+            <a>presentation connection</a>'s <a>presentation URL</a>.
           </p>
           <p>
             The <dfn><code>state</code></dfn> attribute represents the
@@ -2470,7 +2504,7 @@
               <a>Navigate</a> <var>C</var> to <var>presentationUrl</var>.
             </li>
             <li>Start <a>monitoring incoming presentation connections</a> for
-            <var>C</var> with <var>presentationId</var>.
+            <var>C</var> with <var>presentationId</var> and <var>presentationUrl</var>.
             </li>
           </ol>
           <p>
@@ -2546,6 +2580,11 @@
               used to <a data-lt="create a receiving browsing context">create
               the receiving browsing context</a>.
             </dd>
+            <dd>
+              <var>presentationUrl</var>, the <a>presentation request URL</a>
+              used to <a data-lt="create a receiving browsing context">create
+              the receiving browsing context</a>.
+            </dd>
           </dl>
           <ol>
             <li>If <var>presentationId</var> and <var>I</var> are not equal,
@@ -2555,6 +2594,9 @@
             </li>
             <li>Set the <a>presentation identifier</a> of <var>S</var> to <var>
               I</var>.
+            </li>
+            <li>
+              Set the <a>presentation URL</a> of <var>S</var> to <var>presentationUrl</var>.
             </li>
             <li>Establish the connection between the controlling and
             <a>receiving browsing contexts</a> using an implementation specific

--- a/index.html
+++ b/index.html
@@ -511,14 +511,15 @@
   // The Present button is visible if at least one presentation display is available
   var presentBtn = document.getElementById("presentBtn");
   // It is also possible to use relative presentation URL e.g. "presentation.html"
-  var presUrl = "http://example.com/presentation.html";
+  var presUrls = ["http://example.com/presentation.html",
+                  "http://another.com/alternate.html"];
   // show or hide present button depending on display availability
   var handleAvailabilityChange = function(available) {
     presentBtn.style.display = available ? "inline" : "none";
   };
   // Promise is resolved as soon as the presentation display availability is
   // known.
-  var request = new PresentationRequest(presUrl);
+  var request = new PresentationRequest(presUrls);
   request.getAvailability().then(function(availability) {
     // availability.value may be kept up-to-date by the controlling UA as long
     // as the availability object is alive. It is advised for the web developers
@@ -591,7 +592,7 @@
      PresentationRequest to use when the controlling UA initiates a
      presentation. --&gt;
 &lt;script&gt;
-  navigator.presentation.defaultRequest = new PresentationRequest(defaultUrl);
+  navigator.presentation.defaultRequest = new PresentationRequest(presUrls);
   navigator.presentation.defaultRequest.onconnectionavailable = function(evt) {
     setConnection(evt.connection);
   };
@@ -662,7 +663,7 @@
           Monitor available connection(s) and say hello
         </h3>
         <pre class="example highlight">
-&lt;!-- receiver.html --&gt;
+&lt;!-- presentation.html --&gt;
 &lt;script&gt;
   var addConnection = function(connection) {
     connection.onconnect = function () {
@@ -697,7 +698,7 @@
   connection.send("{string: 'Hello, world!', lang: 'en-US'}");
 &lt;/script&gt;
 
-&lt;!-- receiver.html --&gt;
+&lt;!-- presentation.html --&gt;
 &lt;script&gt;
   connection.onmessage = function (message) {
     var messageObj = JSON.parse(message);
@@ -917,7 +918,7 @@
           Interface <a><code>PresentationRequest</code></a>
         </h3>
         <pre class="idl">
-          [Constructor(DOMString url)]
+          [Constructor(DOMString[] urls)]
           interface PresentationRequest : EventTarget {
             Promise&lt;PresentationConnection&gt; start();
             Promise&lt;PresentationConnection&gt; reconnect(DOMString presentationId);
@@ -938,8 +939,10 @@
         </p>
         <p>
           When a <a><code>PresentationRequest</code></a> is constructed, the
-          given <code>url</code> MUST be used as the <dfn>presentation request
-          URL</dfn> which is the <a>presentation URL</a> for the
+          given <code>urls</code> MUST be used as the list
+          of <dfn data-lt="presentation request URL|presentation request
+          URLs">presentation request URLs</dfn> which are each a
+          possible <a>presentation URL</a> for the
           <a><code>PresentationRequest</code></a> instance.
         </p>
         <section>
@@ -955,7 +958,7 @@
               Input
             </dt>
             <dd>
-              <var>url</var>, the <a>presentation request URL</a>
+              <var>urls</var>, the list of <a>presentation request URLs</a>
             </dd>
             <dt>
               Output
@@ -965,15 +968,22 @@
             </dd>
           </dl>
           <ol>
-            <li>Resolve <var>url</var> relative to the API base URL specified
-            by the entry <a>settings object</a>, and let
-            <var>presentationUrl</var> be the resulting absolute URL, if any.
-            </li>
-            <li>If the resolve a URL algorithm failed, then <a>throw</a> a <a>
-              SyntaxError</a> exception and abort the remaining steps.
+            <li>Let <var>presentationUrls</var> be an empty list of URLs.</li>
+            <li>For each URL <var>url</var> in <var>urls</var>:
+              <ol>
+                <li>Resolve <var>url</var> relative to the API base URL
+                  specified by the entry <a>settings object</a>, and add the
+                  resulting absolute URL (if any) to
+                  <var>presentationUrls</var>.
+                </li>
+                <li>
+                  If the resolve a URL algorithm failed, then <a>throw</a> a <a>
+                  SyntaxError</a> exception and abort all remaining steps.
+                </li>
+              </ol>
             </li>
             <li>Construct a new <code>PresentationRequest</code> object with
-            <var>presentationUrl</var> as the constructor argument and return
+            <var>presentationUrls</var> as the constructor argument and return
             it.
             </li>
           </ol>
@@ -996,7 +1006,7 @@
               <code>PresentationRequest</code> object
             </dd>
             <dd>
-              <var>presentationUrl</var>, the <a>presentation request URL</a>
+              <var>presentationUrls</var>, the <a>presentation request URLs</a>
             </dd>
             <dt>
               Output
@@ -1049,8 +1059,8 @@
                 completed.
                 </li>
                 <li>No member in the <a>list of available presentation
-                displays</a> is a <a>compatible presentation display</a> for
-                <var>presentationUrl</var>.
+                    displays</a> is a <a>compatible presentation display</a> for any
+                  member of <var>presentationUrls</var>.
                 </li>
               </ol>Then run the following steps:
               <ol>
@@ -1082,8 +1092,9 @@
             <li>Set the <a>presentation identifier</a> of <var>S</var> to <var>
               I</var>.
             </li>
-            <li>Set the <a>presentation URL</a> of <var>S</var> to
-            <var>presentationUrl</var>.
+            <li>Set the <a>presentation URL</a> of <var>S</var> to the
+              <var>presentationUrl</var> for <var>D</var> in the <a>list of
+                available presentation displays</a>.
             </li>
             <li>Set the <a>presentation connection state</a> of <var>S</var> to
             <a for="PresentationConnectionState">connecting</a>.
@@ -1189,8 +1200,8 @@
             its <a>controlling browsing context</a> is the current <a>browsing
             context</a>, its <a>presentation connection state</a> is not
               <a for="PresentationConnectionState">terminated</a>, its
-              <a>presentation URL</a> is equal to the <a>presentation request
-              URL</a> of <var>presentationRequest</var>, and its
+              <a>presentation URL</a> is equal to one of the <a>presentation request
+              URLs</a> of <var>presentationRequest</var>, and its
               <a>presentation identifier</a> is equal to
               <var>presentationId</var>.
             </li>
@@ -1222,12 +1233,12 @@
             <a>PresentationConnection</a> that meets the following criteria:
             its <a>presentation connection state</a> is not <a for=
             "PresentationConnectionState">terminated</a>, its <a>presentation
-            URL</a> is equal to the <a>presentation request URL</a> of
+            URL</a> is equal to one of the <a>presentation request URLs</a> of
             <var>presentationRequest</var>, and its <a>presentation
             identifier</a> is equal to <var>presentationId</var>.
             </li>
-            <li>If such a <a>PresentationConnection</a> exists, run the
-            following steps:
+            <li>If such a <a>PresentationConnection</a> exists, let <var>E</var>
+            be that <a>PresentationConnection</a>, and run the following steps:
               <ol>
                 <li>Create a new <a>PresentationConnection</a> <var>S</var>.
                 </li>
@@ -1235,8 +1246,7 @@
                 <var>presentationId</var>.
                 </li>
                 <li>Set the <a>presentation URL</a> of <var>S</var> to the <a>
-                  presentation request URL</a> of
-                  <var>presentationRequest</var>.
+                  presentation request URL</a> of <var>E</var>.
                 </li>
                 <li>Set the <a>presentation connection state</a> of
                 <var>S</var> to <a for=
@@ -1347,7 +1357,7 @@
             availability objects</dfn> requested through the <code><a for=
             "PresentationRequest">getAvailability</a>()</code> method. The
             <a>set of availability objects</a> is represented as a set of
-            tuples <em>(<var>A</var>, <var>availabilityUrl</var>)</em>,
+            tuples <em>(<var>A</var>, <var>availabilityUrl[]</var>)</em>,
             initially empty, where:
           </p>
           <ol>
@@ -1355,10 +1365,10 @@
               <var>A</var> is a live <a>PresentationAvailability</a> object;
             </li>
             <li>
-              <var>availabilityUrl</var> is the <a>presentation request URL</a>
+              <var>availabilityUrl[]</var> is the list of <a>presentation request URLs</a>
               when <code><a for=
               "PresentationRequest">getAvailability</a>()</code> is called to
-              create <var>A</var>.
+              create <var>A</var>;
             </li>
           </ol>
         </section>
@@ -1427,7 +1437,7 @@
               Input
             </dt>
             <dd>
-              <var>presentationUrl</var>, the <a>presentation request URL</a>
+              <var>presentationUrls</var>, a list of <a>presentation request URLs</a>
             </dd>
             <dt>
               Output
@@ -1489,7 +1499,7 @@
               </ol>
             </li>
             <li>If there exists a tuple <em>(<var>A</var>,
-            <var>presentationUrl</var>)</em> in the <a>set of availability
+            <var>presentationUrls</var>)</em> in the <a>set of availability
             objects</a>, then:
               <ol>
                 <li>
@@ -1506,7 +1516,7 @@
             presentation display</a>, <code>true</code> otherwise.
             </li>
             <li>Create a tuple <em>(<var>A</var>,
-            <var>presentationUrl</var>)</em> and add it to the <a>set of
+            <var>presentationUrls</var>)</em> and add it to the <a>set of
             availability objects</a>.
             </li>
             <li>Run the algorithm to <a>monitor the list of available
@@ -1534,7 +1544,7 @@
             be this list.
             </li>
             <li>For each member <em>(<var>A</var>,
-            <var>availabilityUrl</var>)</em> of the <a>set of availability
+            <var>availabilityUrls</var>)</em> of the <a>set of availability
             objects</a>:
               <ol>
                 <li>Set <var>previousAvailability</var> to the value of
@@ -1543,7 +1553,8 @@
                 <li>Let <var>newAvailability</var> be <code>true</code> if
                 <var>newDisplays</var> is not empty and at least one display in
                 <var>newDisplays</var> is a <a>compatible presentation
-                display</a> for <var>availabilityUrl</var>. Otherwise, set
+                display</a> for at least one member
+                of <var>availabilityUrls</var>. Otherwise, set
                 <var>newAvailability</var> to <code>false</code>.
                 </li>
                 <li>If <var>previousAvailability</var> is not equal to

--- a/index.html
+++ b/index.html
@@ -939,11 +939,10 @@
         </p>
         <p>
           When a <a><code>PresentationRequest</code></a> is constructed, the
-          given <code>urls</code> MUST be used as the list
-          of <dfn data-lt="presentation request URL|presentation request
-          URLs">presentation request URLs</dfn> which are each a
-          possible <a>presentation URL</a> for the
-          <a><code>PresentationRequest</code></a> instance.
+          given <code>urls</code> MUST be used as the list of <dfn data-lt=
+          "presentation request URL|presentation request URLs">presentation
+          request URLs</dfn> which are each a possible <a>presentation URL</a>
+          for the <a><code>PresentationRequest</code></a> instance.
         </p>
         <section>
           <h4>
@@ -968,17 +967,16 @@
             </dd>
           </dl>
           <ol>
-            <li>Let <var>presentationUrls</var> be an empty list of URLs.</li>
+            <li>Let <var>presentationUrls</var> be an empty list of URLs.
+            </li>
             <li>For each URL <var>url</var> in <var>urls</var>:
               <ol>
                 <li>Resolve <var>url</var> relative to the API base URL
-                  specified by the entry <a>settings object</a>, and add the
-                  resulting absolute URL (if any) to
-                  <var>presentationUrls</var>.
+                specified by the entry <a>settings object</a>, and add the
+                resulting absolute URL (if any) to <var>presentationUrls</var>.
                 </li>
-                <li>
-                  If the resolve a URL algorithm failed, then <a>throw</a> a <a>
-                  SyntaxError</a> exception and abort all remaining steps.
+                <li>If the resolve a URL algorithm failed, then <a>throw</a> a
+                <a>SyntaxError</a> exception and abort all remaining steps.
                 </li>
               </ol>
             </li>
@@ -1059,8 +1057,8 @@
                 completed.
                 </li>
                 <li>No member in the <a>list of available presentation
-                    displays</a> is a <a>compatible presentation display</a> for any
-                  member of <var>presentationUrls</var>.
+                displays</a> is a <a>compatible presentation display</a> for
+                any member of <var>presentationUrls</var>.
                 </li>
               </ol>Then run the following steps:
               <ol>
@@ -1093,8 +1091,8 @@
               I</var>.
             </li>
             <li>Set the <a>presentation URL</a> of <var>S</var> to the
-              <var>presentationUrl</var> for <var>D</var> in the <a>list of
-                available presentation displays</a>.
+            <var>presentationUrl</var> for <var>D</var> in the <a>list of
+            available presentation displays</a>.
             </li>
             <li>Set the <a>presentation connection state</a> of <var>S</var> to
             <a for="PresentationConnectionState">connecting</a>.
@@ -1200,8 +1198,8 @@
             its <a>controlling browsing context</a> is the current <a>browsing
             context</a>, its <a>presentation connection state</a> is not
               <a for="PresentationConnectionState">terminated</a>, its
-              <a>presentation URL</a> is equal to one of the <a>presentation request
-              URLs</a> of <var>presentationRequest</var>, and its
+              <a>presentation URL</a> is equal to one of the <a>presentation
+              request URLs</a> of <var>presentationRequest</var>, and its
               <a>presentation identifier</a> is equal to
               <var>presentationId</var>.
             </li>
@@ -1237,8 +1235,9 @@
             <var>presentationRequest</var>, and its <a>presentation
             identifier</a> is equal to <var>presentationId</var>.
             </li>
-            <li>If such a <a>PresentationConnection</a> exists, let <var>E</var>
-            be that <a>PresentationConnection</a>, and run the following steps:
+            <li>If such a <a>PresentationConnection</a> exists, let
+            <var>E</var> be that <a>PresentationConnection</a>, and run the
+            following steps:
               <ol>
                 <li>Create a new <a>PresentationConnection</a> <var>S</var>.
                 </li>
@@ -1365,8 +1364,8 @@
               <var>A</var> is a live <a>PresentationAvailability</a> object;
             </li>
             <li>
-              <var>availabilityUrl[]</var> is the list of <a>presentation request URLs</a>
-              when <code><a for=
+              <var>availabilityUrl[]</var> is the list of <a>presentation
+              request URLs</a> when <code><a for=
               "PresentationRequest">getAvailability</a>()</code> is called to
               create <var>A</var>;
             </li>
@@ -1437,7 +1436,8 @@
               Input
             </dt>
             <dd>
-              <var>presentationUrls</var>, a list of <a>presentation request URLs</a>
+              <var>presentationUrls</var>, a list of <a>presentation request
+              URLs</a>
             </dd>
             <dt>
               Output
@@ -1553,8 +1553,8 @@
                 <li>Let <var>newAvailability</var> be <code>true</code> if
                 <var>newDisplays</var> is not empty and at least one display in
                 <var>newDisplays</var> is a <a>compatible presentation
-                display</a> for at least one member
-                of <var>availabilityUrls</var>. Otherwise, set
+                display</a> for at least one member of
+                <var>availabilityUrls</var>. Otherwise, set
                 <var>newAvailability</var> to <code>false</code>.
                 </li>
                 <li>If <var>previousAvailability</var> is not equal to
@@ -2492,11 +2492,11 @@
             <a>receiving browsing context</a>.
           </p>
           <p class="note">
-            Given the operating context of the <a>presentation display</a>, some
-            APIs will not work by design (for example, by requiring user input)
-            or will be obsolete (for example, by attempting window management);
-            the <a>receiving user agent</a> should be aware of this.
-            Furthermore, any modal user interface will need to be handled
+            Given the operating context of the <a>presentation display</a>,
+            some APIs will not work by design (for example, by requiring user
+            input) or will be obsolete (for example, by attempting window
+            management); the <a>receiving user agent</a> should be aware of
+            this. Furthermore, any modal user interface will need to be handled
             carefully.
           </p>
         </section>
@@ -2560,12 +2560,12 @@
             <a>receiving browsing contexts</a> using an implementation specific
             mechanism.
             </li>
-            <li>If connection establishment completes successfully, set the
-            <a>presentation connection state</a> of <var>S</var> to
-            <a for="PresentationConnectionState">connected</a>. Otherwise, set
-            the <a>presentation connection state</a> of <var>S</var> to
-            <a for="PresentationConnectionState">closed</a> and abort all
-            remaining steps.
+            <li>If connection establishment completes successfully, set the <a>
+              presentation connection state</a> of <var>S</var> to <a for=
+              "PresentationConnectionState">connected</a>. Otherwise, set the
+              <a>presentation connection state</a> of <var>S</var> to <a for=
+              "PresentationConnectionState">closed</a> and abort all remaining
+              steps.
             </li>
             <li>Add <var>S</var> to the <a>set of presentation controllers</a>.
             </li>
@@ -2862,16 +2862,15 @@
         Acknowledgments
       </h2>
       <p>
-        Thanks to Addison Phillips, Anne Van Kesteren, Anssi Kostiainen,
-        Anton Vayvod, Chris Needham, Christine Runnegar, Daniel Davis,
-        Domenic Denicola, Erik Wilde, François Daoust, 闵洪波 (Hongbo Min),
-        Hongki CHA, Hubert Sablonnière, Hyojin Song, Hyun June Kim,
-        Jean-Claude Dufourd, Joanmarie Diggs, Jonas Sicking, Louay Bassbouss,
-        Mark Watson, Martin Dürst, Matt Hammond, Mike West, Mounir Lamouri,
-        Nick Doty, Oleg Beletski, Philip Jägenstedt, Richard Ishida,
-        Shih-Chiang Chien, Takeshi Kanai, Tobie Langel, Tomoyuki Shimizu,
-        Travis Leithead, and Wayne Carr for help with editing, reviews and
-        feedback to this draft.
+        Thanks to Addison Phillips, Anne Van Kesteren, Anssi Kostiainen, Anton
+        Vayvod, Chris Needham, Christine Runnegar, Daniel Davis, Domenic
+        Denicola, Erik Wilde, François Daoust, 闵洪波 (Hongbo Min), Hongki CHA,
+        Hubert Sablonnière, Hyojin Song, Hyun June Kim, Jean-Claude Dufourd,
+        Joanmarie Diggs, Jonas Sicking, Louay Bassbouss, Mark Watson, Martin
+        Dürst, Matt Hammond, Mike West, Mounir Lamouri, Nick Doty, Oleg
+        Beletski, Philip Jägenstedt, Richard Ishida, Shih-Chiang Chien, Takeshi
+        Kanai, Tobie Langel, Tomoyuki Shimizu, Travis Leithead, and Wayne Carr
+        for help with editing, reviews and feedback to this draft.
       </p>
     </section>
     <section class="appendix">

--- a/index.html
+++ b/index.html
@@ -519,7 +519,7 @@
   var presentBtn = document.getElementById("presentBtn");
   // It is also possible to use relative presentation URL e.g. "presentation.html"
   var presUrls = ["http://example.com/presentation.html",
-                  "http://another.com/alternate.html"];
+                  "http://example.net/alternate.html"];
   // show or hide present button depending on display availability
   var handleAvailabilityChange = function(available) {
     presentBtn.style.display = available ? "inline" : "none";
@@ -854,16 +854,16 @@
             If set by the <a>controller</a>, the value of the <a for=
             "Presentation">defaultRequest</a> attribute SHOULD be used by the
             <a>controlling user agent</a> as the <dfn>default presentation
-            request</dfn> for that <a>controlling browsing context</a>.  If the
-            the document object's <a>active sandboxing flag set</a> has
-            the <a>sandboxed presentation browsing context flag</a> set,
-            the <a>controlling user agent</a> SHOULD act as if the default
-            request is not set for that browsing context.  When
-            the <a>controlling user agent</a> wishes to initiate a
-            <a>PresentationConnection</a> on the behalf of that browsing
-            context, it MUST <a>start a presentation</a> using the <a>default
-            presentation request</a> for the <a>controller</a> (as if the
-            controller had called <code>defaultRequest.start()</code>).
+            request</dfn> for that <a>controlling browsing context</a>. If the
+            the document object's <a>active sandboxing flag set</a> has the
+            <a>sandboxed presentation browsing context flag</a> set, the
+            <a>controlling user agent</a> SHOULD act as if the default request
+            is not set for that browsing context. When the <a>controlling user
+            agent</a> wishes to initiate a <a>PresentationConnection</a> on the
+            behalf of that browsing context, it MUST <a>start a
+            presentation</a> using the <a>default presentation request</a> for
+            the <a>controller</a> (as if the controller had called
+            <code>defaultRequest.start()</code>).
           </p>
           <p>
             The <a>controlling user agent</a> SHOULD initiate presentation
@@ -929,6 +929,7 @@
           Interface <a><code>PresentationRequest</code></a>
         </h3>
         <pre class="idl">
+          [Constructor(DOMString url)]
           [Constructor(DOMString[] urls)]
           interface PresentationRequest : EventTarget {
             Promise&lt;PresentationConnection&gt; start();
@@ -968,7 +969,8 @@
               Input
             </dt>
             <dd>
-              <var>urls</var>, the list of <a>presentation request URLs</a>
+              <var>url</var> or <var>urls</var>, the <a>presentation request
+              URLs</a>
             </dd>
             <dt>
               Output
@@ -978,13 +980,17 @@
             </dd>
           </dl>
           <ol>
+            <li>If the constructor that take a single <var>url</var> was
+            invoked, let <var>urls</var> be a one item list with <var>url</var>
+            as its only member.
+            </li>
             <li>Let <var>presentationUrls</var> be an empty list of URLs.
             </li>
-            <li>For each URL <var>url</var> in <var>urls</var>:
+            <li>For each URL <var>U</var> in <var>urls</var>:
               <ol>
-                <li>Resolve <var>url</var> relative to the API base URL
-                specified by the entry <a>settings object</a>, and add the
-                resulting absolute URL (if any) to <var>presentationUrls</var>.
+                <li>Resolve <var>U</var> relative to the API base URL specified
+                by the entry <a>settings object</a>, and add the resulting
+                absolute URL (if any) to <var>presentationUrls</var>.
                 </li>
                 <li>If the resolve a URL algorithm failed, then <a>throw</a> a
                 <a>SyntaxError</a> exception and abort all remaining steps.
@@ -1101,15 +1107,10 @@
             <li>Set the <a>presentation identifier</a> of <var>S</var> to <var>
               I</var>.
             </li>
-            <li>For each <var>presentationUrl</var> in
-            <var>presentationUrls</var> in order, run the following step:
-              <ol>
-                <li>If there is an entry <var>(presentationUrl, D)</var> in the
-                <a>list of available presentation displays</a>, then set the
-                <a>presentation URL</a> for <var>S</var> to
-                <var>presentationUrl</var> and stop iterating.
-                </li>
-              </ol>
+            <li>Set the <a>presentation URL</a> for <var>S</var> to the first
+            <var>presentationUrl</var> in <var>presentationUrls</var> for which
+            there exists an entry <var>(presentationUrl, D)</var> in the
+            <a>list of available presentation displays</a>.
             </li>
             <li>Set the <a>presentation connection state</a> of <var>S</var> to
             <a for="PresentationConnectionState">connecting</a>.
@@ -1540,7 +1541,7 @@
                 </li>
                 <li>
                   <code>true</code> if there is at least one <a>compatible
-                  presentation display</a> for some member of of
+                  presentation display</a> for some member of
                   <var>presentationUrls</var>. That is, there is an entry
                   <var>(presentationUrl, display)</var> in the <a>list of
                   available presentation displays</a> for some
@@ -1791,8 +1792,8 @@
             When the <code>terminate()</code> method is called on a
             <a>PresentationConnection</a> <var>S</var> in a <a>receiving
             browsing context</a>, the <a>user agent</a> MUST run the algorithm
-            to <a>terminate a presentation in a receiving browsing
-            context</a> using <var>S</var>.
+            to <a>terminate a presentation in a receiving browsing context</a>
+            using <var>S</var>.
           </p>
           <p>
             When a <a>PresentationConnection</a> object is created, its

--- a/index.html
+++ b/index.html
@@ -940,9 +940,9 @@
         <p>
           When a <a><code>PresentationRequest</code></a> is constructed, the
           given <code>urls</code> MUST be used as the list of <dfn data-lt=
-          "presentation request URL">presentation
-          request URLs</dfn> which are each a possible <a>presentation URL</a>
-          for the <a><code>PresentationRequest</code></a> instance.
+          "presentation request URL">presentation request URLs</dfn> which are
+          each a possible <a>presentation URL</a> for the
+          <a><code>PresentationRequest</code></a> instance.
         </p>
         <section>
           <h4>
@@ -1090,12 +1090,13 @@
             <li>Set the <a>presentation identifier</a> of <var>S</var> to <var>
               I</var>.
             </li>
-            <li>For each <var>presentationUrl</var> in <var>presentationUrls</var> in order, run the following step:
+            <li>For each <var>presentationUrl</var> in
+            <var>presentationUrls</var> in order, run the following step:
               <ol>
-                <li>
-                  If there is an entry <var>(presentationUrl, D)</var> in
-                  the <a>list of available presentation displays</a>, then set the <a>presentation URL</a> for <var>S</var> to
-                  <var>presentationUrl</var> and stop iterating.
+                <li>If there is an entry <var>(presentationUrl, D)</var> in the
+                <a>list of available presentation displays</a>, then set the
+                <a>presentation URL</a> for <var>S</var> to
+                <var>presentationUrl</var> and stop iterating.
                 </li>
               </ol>
             </li>
@@ -1383,11 +1384,11 @@
           <p>
             The <a>user agent</a> MUST keep a <dfn>list of available
             presentation displays</dfn>. The <a>list of available presentation
-            displays</a> is represented by a list of
-            tuples <var>(availabilityUrl, display)</var>.  An entry in this list
-            means that <var>display</var> is curently available to start a
-            presentation and is a <a>compatible presentation display</a>
-            for <var>availabilityUrl.</var>  This list of <a>presentation
+            displays</a> is represented by a list of tuples
+            <var>(availabilityUrl, display)</var>. An entry in this list means
+            that <var>display</var> is curently available to start a
+            presentation and is a <a>compatible presentation display</a> for
+            <var>availabilityUrl.</var> This list of <a>presentation
             displays</a> may be used for starting new presentations, and is
             populated based on an implementation specific discovery mechanism.
             It is set to the most recent result of the algorithm to <a>monitor
@@ -1520,18 +1521,25 @@
               </ol>
             </li>
             <li>Let <var>A</var> be a new <code>PresentationAvailability</code>
-              object with its <code>value</code> property set as follows:
+            object with its <code>value</code> property set as follows:
               <ol>
-                <li><code>false</code> if the <a>list of available presentation
-                    displays</a> is empty.
-                <li><code>true</code> if there is at least one <a>compatible
-                presentation display</a> for some member of
-                of <var>presentationUrls</var>.  That is, there is an
-                entry <var>(availabilityUrl, display)</var> in the
-                  <a>list of available presentation displays</a> where <var>availabiltyUrl</var> is a member of <var>presentationUrls</var>.
+                <li>
+                  <code>false</code> if the <a>list of available presentation
+                  displays</a> is empty.
                 </li>
-                <li><code>false</code> otherwise.</li>
-                </ol>
+                <li>
+                  <code>true</code> if there is at least one <a>compatible
+                  presentation display</a> for some member of of
+                  <var>presentationUrls</var>. That is, there is an entry
+                  <var>(availabilityUrl, display)</var> in the <a>list of
+                  available presentation displays</a> where
+                  <var>availabiltyUrl</var> is a member of
+                  <var>presentationUrls</var>.
+                </li>
+                <li>
+                  <code>false</code> otherwise.
+                </li>
+              </ol>
             </li>
             <li>Create a tuple <em>(<var>A</var>,
             <var>presentationUrls</var>)</em> and add it to the <a>set of
@@ -1557,8 +1565,8 @@
             running the following steps.
           </p>
           <ol link-for="PresentationAvailability">
-            <li>
-              Set the <a>list of available presentation displays</a> to the empty list.
+            <li>Set the <a>list of available presentation displays</a> to the
+            empty list.
             </li>
             <li>Retrieve available presentation displays (using an
             implementation specific mechanism) and let <var>newDisplays</var>
@@ -1569,21 +1577,26 @@
             objects</a>, run the following steps:
               <ol>
                 <li>Set <var>previousAvailability</var> to the value of
-                  <var>A</var>'s <a>value</a> property.
+                <var>A</var>'s <a>value</a> property.
                 </li>
-                <li>Let <var>newAvailability</var> be <code>false</code>.</li>
-                <li>For each <var>availabilityUrl</var> in <var>availabilityUrls</var>, run the following steps:
+                <li>Let <var>newAvailability</var> be <code>false</code>.
+                </li>
+                <li>For each <var>availabilityUrl</var> in
+                <var>availabilityUrls</var>, run the following steps:
                   <ol>
-                    <li>
-                      For each <var>display</var> in <var>newDisplays</var>, if <var>display</var> is a
-                      <a>compatible presentation display</a> for <var>availabilityUrl</var>, then
-                      run the following steps:
+                    <li>For each <var>display</var> in <var>newDisplays</var>,
+                    if <var>display</var> is a <a>compatible presentation
+                    display</a> for <var>availabilityUrl</var>, then run the
+                    following steps:
                       <ol>
-                        <li>Insert a tuple <var>(availabilityUrl, display)</var>
-                          into the <a>list of available presentation
-                          displays</a> (if no identical tuple already
-                          exists).</li>
-                        <li>Set <var>newAvailability</var> to <code>true</code>.</li>
+                        <li>Insert a tuple <var>(availabilityUrl,
+                        display)</var> into the <a>list of available
+                        presentation displays</a> (if no identical tuple
+                        already exists).
+                        </li>
+                        <li>Set <var>newAvailability</var> to
+                        <code>true</code>.
+                        </li>
                       </ol>
                     </li>
                   </ol>
@@ -1614,12 +1627,12 @@
             <var>availabilityUrl</var>)</em> in the <a>set of availability
             objects</a> for the newly deceased <var>A</var>.
             </li>
-            <li>If the <a>set of availability objects</a> is now empty and there
-            is no pending request to <a for="PresentationRequest"
-            data-lt="start">start a presentation</a>, cancel any pending task
-            to <a>monitor the list of available presentation displays</a> for
-            power saving purposes, and set the <a>list of available presentation
-            displays</a> to the empty list.
+            <li>If the <a>set of availability objects</a> is now empty and
+            there is no pending request to <a for="PresentationRequest"
+              data-lt="start">start a presentation</a>, cancel any pending task
+              to <a>monitor the list of available presentation displays</a> for
+              power saving purposes, and set the <a>list of available
+              presentation displays</a> to the empty list.
             </li>
           </ol>
           <div class="note">
@@ -2504,7 +2517,8 @@
               <a>Navigate</a> <var>C</var> to <var>presentationUrl</var>.
             </li>
             <li>Start <a>monitoring incoming presentation connections</a> for
-            <var>C</var> with <var>presentationId</var> and <var>presentationUrl</var>.
+            <var>C</var> with <var>presentationId</var> and
+            <var>presentationUrl</var>.
             </li>
           </ol>
           <p>
@@ -2595,8 +2609,8 @@
             <li>Set the <a>presentation identifier</a> of <var>S</var> to <var>
               I</var>.
             </li>
-            <li>
-              Set the <a>presentation URL</a> of <var>S</var> to <var>presentationUrl</var>.
+            <li>Set the <a>presentation URL</a> of <var>S</var> to
+            <var>presentationUrl</var>.
             </li>
             <li>Establish the connection between the controlling and
             <a>receiving browsing contexts</a> using an implementation specific

--- a/index.html
+++ b/index.html
@@ -1373,7 +1373,7 @@
               <var>availabilityUrl[]</var> is the list of <a>presentation
               request URLs</a> when <code><a for=
               "PresentationRequest">getAvailability</a>()</code> is called to
-              create <var>A</var>;
+              create <var>A</var>.
             </li>
           </ol>
         </section>
@@ -1388,7 +1388,7 @@
             <var>(availabilityUrl, display)</var>. An entry in this list means
             that <var>display</var> is curently available to start a
             presentation and is a <a>compatible presentation display</a> for
-            <var>availabilityUrl.</var> This list of <a>presentation
+            <var>availabilityUrl</var>. This list of <a>presentation
             displays</a> may be used for starting new presentations, and is
             populated based on an implementation specific discovery mechanism.
             It is set to the most recent result of the algorithm to <a>monitor
@@ -1531,10 +1531,9 @@
                   <code>true</code> if there is at least one <a>compatible
                   presentation display</a> for some member of of
                   <var>presentationUrls</var>. That is, there is an entry
-                  <var>(availabilityUrl, display)</var> in the <a>list of
-                  available presentation displays</a> where
-                  <var>availabiltyUrl</var> is a member of
-                  <var>presentationUrls</var>.
+                  <var>(presentationUrl, display)</var> in the <a>list of
+                  available presentation displays</a> for some
+                  <var>presentationUrl</var> in <var>presentationUrls</var>.
                 </li>
                 <li>
                   <code>false</code> otherwise.
@@ -1582,7 +1581,7 @@
                 <li>Let <var>newAvailability</var> be <code>false</code>.
                 </li>
                 <li>For each <var>availabilityUrl</var> in
-                <var>availabilityUrls</var>, run the following steps:
+                <var>availabilityUrls</var>, run the following step:
                   <ol>
                     <li>For each <var>display</var> in <var>newDisplays</var>,
                     if <var>display</var> is a <a>compatible presentation
@@ -1591,8 +1590,8 @@
                       <ol>
                         <li>Insert a tuple <var>(availabilityUrl,
                         display)</var> into the <a>list of available
-                        presentation displays</a> (if no identical tuple
-                        already exists).
+                        presentation displays</a>, if no identical tuple
+                        already exists.
                         </li>
                         <li>Set <var>newAvailability</var> to
                         <code>true</code>.


### PR DESCRIPTION
This PR addresses Issue #311 (Add presentation request URL fallback mechanism).  It modifies the PresentationRequest constructor to take an array of URLs each of which will be considered in order when starting or connecting to a presentation.

This necessitated several changes, including:
- Updating example code
- Updating interfaces, including adding a `url` property to PresentationConnection so the caller knows what is being presented
- Updating the set of availability objects to have a list of URLs per object
- Updating the list (set?) of available presentation displays to keep track of which displays are compatible with which URLs so the start algorithm can choose the appropriate URL for the chosen display
- Various other algorithm and wording updates

@mounirlamouri @tidoust @sicking @schien Please take a look.