### PR TITLE
Missing interface terms and reference to DOM standard added

### DIFF
--- a/index.html
+++ b/index.html
@@ -360,15 +360,28 @@
         sandboxed auxiliary navigation browsing context flag</a></dfn>,
         <dfn><a href=
         "http://www.w3.org/TR/html5/browsers.html#sandboxed-top-level-navigation-browsing-context-flag">
-        sandboxed top-level navigation browsing context flag</a></dfn>, and
+        sandboxed top-level navigation browsing context flag</a></dfn>,
         <dfn><a href=
         "http://www.w3.org/TR/html5/webappapis.html#settings-object">settings
-        object</a></dfn> are defined in [[!HTML5]].
+        object</a></dfn>, <dfn><code><a href=
+        "http://www.w3.org/TR/html5/webappapis.html#eventhandler">EventHandler</a></code></dfn>
+        and <dfn><code><a href=
+        "http://www.w3.org/TR/html5/webappapis.html#navigator">Navigator</a></code></dfn>
+        are defined in [[!HTML5]].
       </p>
       <p>
         The term <dfn><a href=
         "http://www.w3.org/TR/html51/infrastructure.html#in-parallel">in
         parallel</a></dfn> is defined in [[!HTML51]].
+      </p>
+      <p>
+        The terms <dfn><code><a href=
+        "https://dom.spec.whatwg.org/#eventtarget">EventTarget</a></code></dfn>,
+        <dfn><code><a href=
+        "https://dom.spec.whatwg.org/#event">Event</a></code></dfn>,
+        <dfn><code><a href=
+        "https://dom.spec.whatwg.org/#dictdef-eventinit">EventInit</a></code></dfn>
+        are defined in [[!DOM]].
       </p>
       <p>
         This document provides interface definitions using the Web IDL standard


### PR DESCRIPTION
Preparing the document for publication as Candidate Recommendation, I noticed that the spec did not reference the DOM standard, whereas it uses some of its interfaces.

This update completes the list in the terminology with (base) IDL terms that the specification references such as EventTarget, EventHandler, etc.

Note it is strongly recommended to sort out the list of normative references before publication as Candidate Recommendation (any change to the list of normative references is by definition "normative", and normative changes to a Candidate Recommendation normally require another publication as Candidate Recommendation).

@anssiko or @mfoltzgoogle, could you review this as soon as possible and merge? Thanks!