### PR TITLE
Fix typo in code for Example 7.

### DIFF
--- a/index.html
+++ b/index.html
@@ -741,7 +741,7 @@
 &lt;!-- presentation.html --&gt;
 &lt;script&gt;
   connection.onmessage = function (message) {
-    var messageObj = JSON.parse(message);
+    var messageObj = JSON.parse(message.data);
     var spanElt = document.createElement("SPAN");
     spanElt.lang = messageObj.lang;
     spanElt.textContent = messageObj.string;


### PR DESCRIPTION
I believe `message` should be an EventHandler, so the message itself should be `message.data` as in the previous examples.