### PR TITLE
Make PresentationConnection.id mandatory.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1748,7 +1748,7 @@
           enum BinaryType { "blob", "arraybuffer" };
 
           interface PresentationConnection : EventTarget {
-            readonly attribute DOMString? id;
+            readonly attribute DOMString id;
             readonly attribute DOMString url;
             readonly attribute PresentationConnectionState state;
             void close();


### PR DESCRIPTION
Addresses Issue #325: PresentationConnection.url should be optional? 
See the comment there for the rationale for this change.

Since there is no way to get a usable PresentationConnection other than through the PresentationAPI, and the API sets the ID for all connections, I don't believe this change in semantics will affect any Web content.