### PR TITLE
Adds an implementation note for advertising and rendering a user friendly display name

### DIFF
--- a/index.html
+++ b/index.html
@@ -1185,9 +1185,19 @@
             selection are left to the user agent; for example it may show the
             user a dialog and allow the user to select an available display
             (granting permission), or cancel the selection (denying
-            permission). Implementers are encouraged to show the user whether
-            an available display is currently in use, to facilitate
-            presentations that can make use of multiple displays.
+            permission). Implementers are encouraged to show the user whether an
+            available display is currently in use, to facilitate presentations
+            that can make use of multiple displays.
+          </div>
+          <div class="note">
+            Receiving user agents are encouraged to advertise a user friendly
+            name for the presentation display, e.g. &quot;Living Room TV&quot;,
+            to assist the user in selecting the intended display.  Implementers
+            of receiving user agents are also encouraged to advertise the locale
+            and intended text direction of the user friendly name.
+            Implementers of controlling user agents are encouraged to render a
+            user friendly name using its locale and text direction when they are
+            known.
           </div>
           <div class="note">
             The <var>presentationUrl</var> should name a resource accessible to


### PR DESCRIPTION
Addresses Issue #315: list of displays: should it address display name, language, etc.?

This adds an implementation note suggesting that receiving user agents advertise a user friendly display name with a locale and text direction, and controlling user agents render it using that information.
