### PR TITLE
Clarify the default presentation request mechanism?

### DIFF
--- a/index.html
+++ b/index.html
@@ -850,7 +850,7 @@
           In a <a>controlling browsing context</a>, the <dfn>default
           presentation request</dfn>, which is initially set to
           <code>null</code>, represents the request to use when the user wishes
-          to initiate a <a>presentation connection</a> from the browser chrome.
+          to initiate a <a>presentation connection</a> from the browser.
         </p>
       </section>
       <section>
@@ -876,6 +876,10 @@
           <h4>
             Controlling user agent
           </h4>
+          <p>
+            <a data-lt="controlling user agent">Controlling user agents</a>
+            MUST implement the following partial interface:
+          </p>
           <pre class="idl idl-controlling-ua">
             partial interface Presentation {
               attribute PresentationRequest? defaultRequest;
@@ -883,19 +887,10 @@
           
 </pre>
           <p>
-            In a <a>controlling user agent</a>, the <dfn for=
-            "Presentation"><code>defaultRequest</code></dfn> attribute MUST
-            return the <a>default presentation request</a> if any,
-            <code>null</code> otherwise. On setting, the <a>default
+            The <dfn for="Presentation"><code>defaultRequest</code></dfn>
+            attribute MUST return the <a>default presentation request</a> if
+            any, <code>null</code> otherwise. On setting, the <a>default
             presentation request</a> MUST be set to the new value.
-          </p>
-          <p>
-            In a user agent that is a <a>receiving user agent</a> but not a
-            <a>controlling user agent</a>, the <a for=
-            "Presentation">defaultRequest</a> attribute MUST always return
-            <code>null</code>, and setting the <a for=
-            "Presentation">defaultRequest</a> attribute MUST be treated as a
-            no-op.
           </p>
           <p>
             The <a>controlling user agent</a> SHOULD initiate presentation
@@ -918,11 +913,11 @@
           </div>
           <p>
             Support for the initiation of a <a>presentation connection</a> from
-            the browser chrome is OPTIONAL.
+            the browser is OPTIONAL.
           </p>
           <div class="note">
             If a <a>controlling user agent</a> does not support initiation of a
-            <a>presentation connection</a> from the browser chrome, setting
+            <a>presentation connection</a> from the browser, setting
             <code>defaultRequest</code> will have no effect.
           </div>
           <div class="note">
@@ -944,6 +939,10 @@
           <h4>
             Receiving user agent
           </h4>
+          <p>
+            <a data-lt="Receiving user agent">Receiving user agents</a> MUST
+            implement the following partial interface:
+          </p>
           <pre class="idl idl-receiving-ua">
             partial interface Presentation {
               [SameObject] readonly attribute PresentationReceiver? receiver;
@@ -951,18 +950,12 @@
           
 </pre>
           <p>
-            In a <a>receiving user agent</a>, the <dfn for=
-            "Presentation"><code>receiver</code></dfn> attribute MUST return
-            the <a><code>PresentationReceiver</code></a> instance associated
-            with the <a>receiving browsing context</a> and created by the
-            <a>receiving user agent</a> when the <a>receiving browsing
+            The <dfn for="Presentation"><code>receiver</code></dfn> attribute
+            MUST return the <a><code>PresentationReceiver</code></a> instance
+            associated with the <a>receiving browsing context</a> and created
+            by the <a>receiving user agent</a> when the <a>receiving browsing
             context</a> is created. In any other <a>browsing context</a>, it
             MUST return <code>null</code>.
-          </p>
-          <p>
-            A user agent that is a <a>controlling user agent</a> but not a
-            <a>receiving user agent</a> MUST always return <code>null</code>
-            for the <a for="Presentation">receiver</a> attribute.
           </p>
         </section>
       </section>

--- a/index.html
+++ b/index.html
@@ -846,6 +846,12 @@
           represented by a <a>Promise</a> that resolves with the
           <a>presentation controllers monitor</a>.
         </p>
+        <p>
+          In a <a>controlling browsing context</a>, the <dfn>default
+          presentation request</dfn>, which is initially set to
+          <code>null</code>, represents the request to use when the user wishes
+          to initiate a <a>presentation connection</a> from the browser chrome.
+        </p>
       </section>
       <section>
         <h3>
@@ -880,29 +886,39 @@
             In a <a>controlling user agent</a>, the <dfn for=
             "Presentation"><code>defaultRequest</code></dfn> attribute MUST
             return the <a>default presentation request</a> if any,
-            <code>null</code> otherwise. In a <a>receiving browsing
-            context</a>, it MUST return <code>null</code>.
+            <code>null</code> otherwise. On setting, the <a>default
+            presentation request</a> MUST be set to the new value.
           </p>
           <p>
-            If set by the <a>controller</a>, the value of the <a for=
-            "Presentation">defaultRequest</a> attribute SHOULD be used by the
-            <a>controlling user agent</a> as the <dfn>default presentation
-            request</dfn> for that <a>controlling browsing context</a>. If the
-            the document object's <a>active sandboxing flag set</a> has the
-            <a>sandboxed presentation browsing context flag</a> set, the
-            <a>controlling user agent</a> SHOULD consider the <a>default
-            presentation request</a> for that browsing context to be
-            <code>null</code>. When the <a>controlling user agent</a> wishes to
-            initiate a <a>PresentationConnection</a> on the behalf of that
-            browsing context, it MUST <a>start a presentation</a> using the
-            <a>default presentation request</a> for the <a>controller</a> (as
-            if the controller had called <code>defaultRequest.start()</code>).
+            In a user agent that is a <a>receiving user agent</a> but not a
+            <a>controlling user agent</a>, the <a for=
+            "Presentation">defaultRequest</a> attribute MUST always return
+            <code>null</code>, and setting the <a for=
+            "Presentation">defaultRequest</a> attribute MUST be treated as a
+            no-op.
           </p>
           <p>
             The <a>controlling user agent</a> SHOULD initiate presentation
             using the <a>default presentation request</a> only when the user
             has expressed an intention to do so via a user gesture, for example
             by clicking a button in the browser.
+          </p>
+          <p>
+            To initiate presentation using the <a>default presentation
+            request</a>, the <a>controlling user agent</a> MUST <a>start a
+            presentation</a> using the <a>default presentation request</a> (as
+            if the controller had called <code>defaultRequest.start()</code>),
+            skipping the first step of that algorithm.
+          </p>
+          <div class="note">
+            Subsequent security steps of the <a>start a presentation</a>
+            algorithm apply. For instance, the request will fail if the
+            document object's <a>active sandboxing flag set</a> has the
+            <a>sandboxed presentation browsing context flag</a> set.
+          </div>
+          <p>
+            Support for the initiation of a <a>presentation connection</a> from
+            the browser chrome is OPTIONAL.
           </p>
           <div class="note">
             If a <a>controlling user agent</a> does not support initiation of a
@@ -942,13 +958,6 @@
             <a>receiving user agent</a> when the <a>receiving browsing
             context</a> is created. In any other <a>browsing context</a>, it
             MUST return <code>null</code>.
-          </p>
-          <p>
-            A user agent that is a <a>receiving user agent</a> but not a
-            <a>controlling user agent</a> MUST always return <code>null</code>
-            for the <a for="Presentation">defaultRequest</a> attribute. It MUST
-            treat setting the <a for="Presentation">defaultRequest</a>
-            attribute as a no-op.
           </p>
           <p>
             A user agent that is a <a>controlling user agent</a> but not a


### PR DESCRIPTION
I find the section that defines and specifies the behavior of the default presentation request somewhat unclear in [6.2.1 Controlling user agent](https://w3c.github.io/presentation-api/#controlling-user-agent). More precisely:

1. There is no proper definition as to what the "default presentation request" represents.
2. I am unclear whether the initial value for the attribute is always `null`. I think it is, but the spec only specifies behavior when the attribute is "set by the controller". Can the attribute be set by the controlling user agent? I suppose not (at least that does not seem to make sense).
3. The text explicitly covers the case when the sandboxed presentation browsing context flag is set, but since that check is part of the "start a presentation" algorithm that gets called to initiate the presentation, this should not be needed.
4. Similarly, stricto senso, the "start a presentation" algorithm won't be allowed to show a popup in that case, so calling it should fail right away, which is obviously not the intended behavior.
5. The spec only explicitly says that support for this feature in controlling user agents is optional in an editorial note.
6. I do not understand the use of `SHOULD` in the second paragraph. I suppose it's meant to convey the fact that controlling user agents may not support that feature, but it seems better to be explicit that the feature is `OPTIONAL`, or phrase things with a conditional `MUST`, as in "if [feature supported], the controlling user agent MUST [behavior]". Or is there a good reason not to follow these statements, which would indeed justify the `SHOULD` level? (note that comment only applies to the paragraph that starts with "If set by the controller", the use of `SHOULD` for user gestures looks good).

I propose a rewrite in this pull request. Note that this is not meant to introduce any change of behavior, but rather to clarify the intent and behavior of the default presentation request mechanism. Main proposed changes:

1. I added a definition for "default presentation request" in the "Common Idioms" section.
2. The text is now explicit that support for the default presentation request mechanism is optional.
3. The text is now clear that step 1. of the "start a presentation" algorithm is to be skipped, and that other security checks apply (I kept the sandboxing flag as an example in a note)

