### PR TITLE
Implements proposed resolution for Issue #303

### DIFF
--- a/index.html
+++ b/index.html
@@ -957,6 +957,10 @@
             context</a> is created. In any other <a>browsing context</a>, it
             MUST return <code>null</code>.
           </p>
+          <p class="note">
+            Web developers can use <code>Navigator.presentation.receiver</code>
+            to detect when a document is loaded as a presentation.
+          </p>
         </section>
       </section>
       <section>
@@ -1187,19 +1191,19 @@
             selection are left to the user agent; for example it may show the
             user a dialog and allow the user to select an available display
             (granting permission), or cancel the selection (denying
-            permission). Implementers are encouraged to show the user whether an
-            available display is currently in use, to facilitate presentations
-            that can make use of multiple displays.
+            permission). Implementers are encouraged to show the user whether
+            an available display is currently in use, to facilitate
+            presentations that can make use of multiple displays.
           </div>
           <div class="note">
             Receiving user agents are encouraged to advertise a user friendly
             name for the presentation display, e.g. &quot;Living Room TV&quot;,
-            to assist the user in selecting the intended display.  Implementers
-            of receiving user agents are also encouraged to advertise the locale
-            and intended text direction of the user friendly name.
+            to assist the user in selecting the intended display. Implementers
+            of receiving user agents are also encouraged to advertise the
+            locale and intended text direction of the user friendly name.
             Implementers of controlling user agents are encouraged to render a
-            user friendly name using its locale and text direction when they are
-            known.
+            user friendly name using its locale and text direction when they
+            are known.
           </div>
           <div class="note">
             The <var>presentationUrl</var> should name a resource accessible to


### PR DESCRIPTION
This addresses Issue #303: Define that "TV" should appear as token for UA-string when presentation API is used to render on TV.  It implements the proposed resolution: add a note about feature detection through the receiver attribute.