### PR TITLE
Addresses Issue #342: Update definition of available presentation display.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1469,7 +1469,7 @@
             presentation displays</dfn>. The <a>list of available presentation
             displays</a> is represented by a list of tuples
             <var>(availabilityUrl, display)</var>. An entry in this list means
-            that <var>display</var> is curently an <a>available presentation
+            that <var>display</var> is currently an <a>available presentation
             display</a> for <var>availabilityUrl</var>. This list of
             <a>presentation displays</a> may be used for starting new
             presentations, and is populated based on an implementation specific

--- a/index.html
+++ b/index.html
@@ -779,6 +779,17 @@
           is at least 16 characters long.
         </p>
         <p>
+          Some <a>presentation displays</a> may only be able to display a
+          subset of Web content because of functional, security or hardware
+          limitations. Examples are set-top boxes, smart TVs or networked
+          speakers capable of rendering only audio. We say that such a display
+          is an <dfn lt=
+          "available presentation display|available presentation displays">available
+          presentation display</dfn> for a URL if the <a>controlling user
+          agent</a> can reasonably guarantee that the presentation of the URL
+          on that display will succeed.
+        </p>
+        <p>
           A <dfn lt=
           "controlling browsing context|controlling browsing contexts">controlling
           browsing context</dfn> (or <dfn>controller</dfn> for short) is a
@@ -1112,7 +1123,7 @@
                 completed.
                 </li>
                 <li>No member in the <a>list of available presentation
-                displays</a> is a <a>compatible presentation display</a> for
+                displays</a> is an <a>available presentation display</a> for
                 any member of <var>presentationUrls</var>.
                 </li>
               </ol>Then run the following steps:
@@ -1394,7 +1405,7 @@
 </pre>
         <p>
           A <a><code>PresentationAvailability</code></a> object is associated
-          with available <a>presentation displays</a> and represents the
+          with <a>available presentation displays</a> and represents the
           <dfn>presentation display availability</dfn> for a presentation
           request. If the <a>controlling user agent</a> can <a>monitor the list
           of available presentation displays</a> in the background (without a
@@ -1446,13 +1457,13 @@
             presentation displays</dfn>. The <a>list of available presentation
             displays</a> is represented by a list of tuples
             <var>(availabilityUrl, display)</var>. An entry in this list means
-            that <var>display</var> is curently available to start a
-            presentation and is a <a>compatible presentation display</a> for
-            <var>availabilityUrl</var>. This list of <a>presentation
-            displays</a> may be used for starting new presentations, and is
-            populated based on an implementation specific discovery mechanism.
-            It is set to the most recent result of the algorithm to <a>monitor
-            the list of available presentation displays</a>.
+            that <var>display</var> is curently an <a>available presentation
+            display</a> for <var>availabilityUrl</var>. This list of
+            <a>presentation displays</a> may be used for starting new
+            presentations, and is populated based on an implementation specific
+            discovery mechanism. It is set to the most recent result of the
+            algorithm to <a>monitor the list of available presentation
+            displays</a>.
           </p>
           <p>
             While there are live <a>PresentationAvailability</a> objects, the
@@ -1481,16 +1492,6 @@
             foreground. Using this information, implementation specific
             discovery of <a>presentation displays</a> can be resumed or
             suspended.
-          </p>
-          <p>
-            Some <a>presentation displays</a> may only be able to display a
-            subset of Web content because of functional, security or hardware
-            limitations. Examples are set-top boxes, smart TVs or networked
-            speakers capable of rendering only audio. We say that such a
-            display is a <dfn>compatible presentation display</dfn> for a
-            <a>presentation request URL</a> if the <a>user agent</a> can
-            reasonably guarantee that the presentation of the URL on that
-            display will succeed.
           </p>
         </section>
         <section>
@@ -1588,7 +1589,7 @@
                   displays</a> is empty.
                 </li>
                 <li>
-                  <code>true</code> if there is at least one <a>compatible
+                  <code>true</code> if there is at least one <a>available
                   presentation display</a> for some member of
                   <var>presentationUrls</var>. That is, there is an entry
                   <var>(presentationUrl, display)</var> in the <a>list of
@@ -1627,7 +1628,7 @@
             <li>Set the <a>list of available presentation displays</a> to the
             empty list.
             </li>
-            <li>Retrieve available presentation displays (using an
+            <li>Retrieve <a>available presentation displays</a> (using an
             implementation specific mechanism) and let <var>newDisplays</var>
             be this list.
             </li>
@@ -1644,7 +1645,7 @@
                 <var>availabilityUrls</var>, run the following step:
                   <ol>
                     <li>For each <var>display</var> in <var>newDisplays</var>,
-                    if <var>display</var> is a <a>compatible presentation
+                    if <var>display</var> is an <a>available presentation
                     display</a> for <var>availabilityUrl</var>, then run the
                     following steps:
                       <ol>


### PR DESCRIPTION
This creates a definition of "available presentation display" to replace the use of "compatible presentation display" and updates references accordingly.  This addresses Issue #342: Presentation display availability is not clearly defined.