### PR TITLE
Add error handling to establish a presentation connection algorithm.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1168,9 +1168,9 @@
               The event must not bubble, must not be cancelable, and has no
               default action.
             </li>
-            <li>If any of the following steps fails, abort all remaining steps
-            and <a>close the presentation connection</a> <var>S</var> with
-            <a for="PresentationConnectionClosedReason">error</a> as
+            <li>If the next step fails, abort all remaining steps and <a>close
+            the presentation connection</a> <var>S</var> with <a for=
+            "PresentationConnectionClosedReason">error</a> as
             <var>closeReason</var>, and a human readable message describing the
             failure as <var>closeMessage</var>.
             </li>
@@ -1187,19 +1187,19 @@
             selection are left to the user agent; for example it may show the
             user a dialog and allow the user to select an available display
             (granting permission), or cancel the selection (denying
-            permission). Implementers are encouraged to show the user whether an
-            available display is currently in use, to facilitate presentations
-            that can make use of multiple displays.
+            permission). Implementers are encouraged to show the user whether
+            an available display is currently in use, to facilitate
+            presentations that can make use of multiple displays.
           </div>
           <div class="note">
             Receiving user agents are encouraged to advertise a user friendly
             name for the presentation display, e.g. &quot;Living Room TV&quot;,
-            to assist the user in selecting the intended display.  Implementers
-            of receiving user agents are also encouraged to advertise the locale
-            and intended text direction of the user friendly name.
+            to assist the user in selecting the intended display. Implementers
+            of receiving user agents are also encouraged to advertise the
+            locale and intended text direction of the user friendly name.
             Implementers of controlling user agents are encouraged to render a
-            user friendly name using its locale and text direction when they are
-            known.
+            user friendly name using its locale and text direction when they
+            are known.
           </div>
           <div class="note">
             The <var>presentationUrl</var> should name a resource accessible to
@@ -1928,6 +1928,12 @@
                 </li>
               </ol>
             </li>
+            <li>If the connection cannot be completed, <a>close the
+            presentation connection</a> <var>S</var> with <a for=
+            "PresentationConnectionClosedReason">error</a> as
+            <var>closeReason</var>, and a human readable message describing the
+            failure as <var>closeMessage</var>.
+            </li>
           </ol>
           <div class="note">
             The mechanism that is used to present on the remote display and
@@ -1937,11 +1943,6 @@
             carrying <code>DOMString</code> payloads in a reliable and in-order
             fashion as described in the <a>Send a Message</a> and <a>Receive a
             Message</a> steps below.
-          </div>
-          <div class="note">
-            If the connection step does not complete successfully, the user
-            agent may choose to re-execute the Presentation Connection
-            algorithm at a later time.
           </div>
         </section>
         <section>


### PR DESCRIPTION
Addresses Issue #343: Establishing a presentation connection steps do not handle failures.  This adds an error handling case to the establish a connection algorithm.  It also removes the note about the UA later reconnecting, so that error is a terminal state.

Implements proposed resolution: For #343, move error handling steps from the start algorithm to the establish a connection algorithm, and remove the note in 6.5.1 about retrying connection establishment.