### PR TITLE
A couple of small fixes to the example code

### DIFF
--- a/index.html
+++ b/index.html
@@ -442,16 +442,15 @@
         a Promise</a></dfn> are used as explained in [[!PROMGUIDE]].
       </p>
       <p>
-        The term <dfn><a href=
-        "https://url.spec.whatwg.org/#url">URL</a></dfn> is defined in the
-        WHATWG URL standard [[!URL]].
+        The term <dfn><a href="https://url.spec.whatwg.org/#url">URL</a></dfn>
+        is defined in the WHATWG URL standard [[!URL]].
       </p>
       <p>
         The terms <dfn><a href=
         "https://html.spec.whatwg.org/multipage/webappapis.html#current-settings-object">
         current settings object</a></dfn> and <dfn><a href=
-        "https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object">relevant
-        settings object</a></dfn> are defined in [[HTML]].
+        "https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object">
+        relevant settings object</a></dfn> are defined in [[HTML]].
       </p>
       <p>
         The term <dfn><a href=
@@ -628,6 +627,7 @@
   // On navigation of the controller, reconnect automatically.
   document.addEventListener("DOMContentLoaded", reconnect);
   // Or allow manual reconnection.
+  const reconnectBtn = document.querySelector("#reconnectBtn");
   reconnectBtn.onclick = reconnect;
 &lt;/script&gt;
 </pre>
@@ -658,26 +658,24 @@
 &lt;!-- controller.html --&gt;
 &lt;button id="disconnectBtn" style="display: none;"&gt;Disconnect&lt;/button&gt;
 &lt;button id="stopBtn" style="display: none;"&gt;Stop&lt;/button&gt;
-&lt;button id="reconnectBtn" style="display: none;"&gt;Reconnect&lt;/button&gt;
 &lt;script&gt;
   let connection;
 
   // The Disconnect and Stop buttons are visible if there is a connected presentation
   const stopBtn = document.querySelector("#stopBtn");
-  const reconnectBtn = document.querySelector("#reconnectBtn");
   const disconnectBtn = document.querySelector("#disconnectBtn");
 
-  stopBtn.onclick = _ => {
+  stopBtn.onclick = _ =&gt; {
     connection &amp;&amp; connection.terminate();
   };
 
-  disconnectBtn.onclick = _ => {
+  disconnectBtn.onclick = _ =&gt; {
     connection &amp;&amp; connection.close();
   };
 
   function setConnection(newConnection) {
     // Disconnect from existing presentation, if not attempting to reconnect
-    if (connection &amp;&amp; connection != newConnection && connection.state != 'closed') {
+    if (connection &amp;&amp; connection != newConnection &amp;&amp; connection.state != 'closed') {
       connection.onclosed = undefined;
       connection.close();
     }
@@ -700,11 +698,11 @@
     }
 
     // Monitor the connection state
-    connection.onconnect = _ => {
+    connection.onconnect = _ =&gt; {
       showConnectedUI();
 
       // Register message handler
-      connection.onmessage = message => {
+      connection.onmessage = message =&gt; {
         console.log(`Received message: ${message.data}`);
       };
 
@@ -712,12 +710,12 @@
       connection.send("Say hello");
     };
 
-    connection.onclose = _ => {
+    connection.onclose = _ =&gt; {
       connection = null;
       showDisconnectedUI();
     };
 
-    connection.onterminate = _ => {
+    connection.onterminate = _ =&gt; {
       // Remove presId from localStorage if exists
       delete localStorage["presId"];
       connection = null;


### PR DESCRIPTION
To close out #339, this fixes &&, >,  and also moves the declaration of `reconnectBtn` to Example 3 (reconnect presentation example).
