### PR TITLE
Clarifies the roles of objects for getting presentation display availability.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1624,10 +1624,10 @@
             <a for="PresentationAvailability">value</a> property of a
             <code>PresentationAvailability</code> object to offer presentation
             only when there are available displays. However, the <a>user
-            agent</a> may not support continuous availability monitoring; for
-            example, because of platform or power consumption restrictions. In
-            this case the <a>Promise</a> returned by <code><a for=
-            "PresentationRequest">getAvailability</a>()</code> is
+            agent</a> may not support continuous availability monitoring in the
+            background; for example, because of platform or power consumption
+            restrictions. In this case the <a>Promise</a> returned by
+            <code><a for="PresentationRequest">getAvailability</a>()</code> is
             <a data-lt="reject">rejected</a>, and the algorithm to <a>monitor
             the list of available presentation displays</a> will only run as
             part of the <a>select a presentation display</a> algorithm.
@@ -1785,11 +1785,12 @@
             Monitoring the list of available presentation displays
           </h4>
           <p>
-            If the <a>set of presentation availability objects</a> is non-empty,
-            or there is a pending request to <a for="PresentationRequest"
-            data-lt= "start">select a presentation display</a>, the <a>user
-            agent</a> MUST <dfn>monitor the list of available presentation
-            displays</dfn> by running the following steps.
+            If the <a>set of presentation availability objects</a> is
+            non-empty, or there is a pending request to <a for=
+            "PresentationRequest" data-lt="start">select a presentation
+            display</a>, the <a>user agent</a> MUST <dfn>monitor the list of
+            available presentation displays</dfn> by running the following
+            steps.
           </p>
           <ol link-for="PresentationAvailability">
             <li>Set the <a>list of available presentation displays</a> to the
@@ -1856,10 +1857,11 @@
             </li>
             <li>If the <a>set of presentation availability objects</a> is now
             empty and there is no pending request to <a for=
-            "PresentationRequest" data-lt="start">select a presentation display</a>,
-            cancel any pending task to <a>monitor the list of available
-            presentation displays</a> for power saving purposes, and set the
-            <a>list of available presentation displays</a> to the empty list.
+            "PresentationRequest" data-lt="start">select a presentation
+            display</a>, cancel any pending task to <a>monitor the list of
+            available presentation displays</a> for power saving purposes, and
+            set the <a>list of available presentation displays</a> to the empty
+            list.
             </li>
           </ol>
           <div class="note">

--- a/index.html
+++ b/index.html
@@ -1665,7 +1665,7 @@
             presentation availability objects</a>.
             </li>
             <li>Run the algorithm to <a>monitor the list of available
-            presentation displays</a>.
+            presentation displays</a> in parallel.
             </li>
             <li>
               <a>Resolve</a> <var>P</var> with <var>A</var>.

--- a/index.html
+++ b/index.html
@@ -1433,10 +1433,14 @@
 
 </pre>
         <p>
-          A <a><code>PresentationAvailability</code></a> object is associated
-          with <a>available presentation displays</a> and represents the
-          <dfn>presentation display availability</dfn> for a presentation
-          request. If the <a>controlling user agent</a> can <a>monitor the list
+          A <a><code>PresentationAvailability</code></a> object exposes the
+          <a>presentation display availability</a> for a presentation
+          request.             The <dfn>presentation display availability</dfn> for a <code>PresentationRequest</code>
+            stores whether there is currently any <a>available presentation
+            display</a> for at least one of the <a>presentation request URLs</a> of the request.
+        </p>
+        <p>
+ If the <a>controlling user agent</a> can <a>monitor the list
           of available presentation displays</a> in the background (without a
           pending request to <code><a for=
           "PresentationRequest">start</a>()</code>), the
@@ -1458,21 +1462,30 @@
             The set of availability objects
           </h4>
           <p>
-            The <a>user agent</a> MUST keep track of the <dfn>set of
-            availability objects</dfn> requested through the <code><a for=
+            Each <code>PresentationRequest</code> has a <a>presentation
+            availability promise</a> and a <a>presentation display availability</a>,
+            which are initially set to null.  The <dfn>presentation
+            availability promise</dfn> for a <code>PresentationRequest</code> is
+            a <code>Promise</code> object that <a data-lt="resolve">resolves</a> to a
+            the <a>presentation display availability</a> for the request.
+          </p>
+          <p>
+            The <a>user
+            agent</a> MUST keep track of the <dfn>set of presentation availability
+            objects</dfn> created by the <code><a for=
             "PresentationRequest">getAvailability</a>()</code> method. The
-            <a>set of availability objects</a> is represented as a set of
-            tuples <em>(<var>A</var>, <var>availabilityUrl[]</var>)</em>,
+            <a>set of presentation availability objects</a> is represented as a set of
+            tuples <em>(<var>A</var>, <var>availabilityUrls</var>)</em>,
             initially empty, where:
           </p>
           <ol>
             <li>
-              <var>A</var> is a live <a>PresentationAvailability</a> object;
+              <var>A</var> is a live <code>PresentationAvailability</code> object.
             </li>
             <li>
-              <var>availabilityUrl[]</var> is the list of <a>presentation
-              request URLs</a> when <code><a for=
-              "PresentationRequest">getAvailability</a>()</code> is called to
+              <var>availabilityUrls</var> is the list of <a>presentation
+              request URLs</a> for the <code>PresentationRequest</code> when <code><a for=
+              "PresentationRequest">getAvailability</a>()</code> was called on it to
               create <var>A</var>.
             </li>
           </ol>
@@ -1495,11 +1508,11 @@
             displays</a>.
           </p>
           <p>
-            While there are live <a>PresentationAvailability</a> objects, the
+            While the <a>set of presentation availability objects</a> is not empty, the
             <a>user agent</a> MAY <a>monitor the list of available presentation
             displays</a> continuously, so that pages can use the <a for=
             "PresentationAvailability">value</a> property of a
-            <a>PresentationAvailability</a> object to offer presentation only
+            <code>PresentationAvailability</code> object to offer presentation only
             when there are available displays. However, the <a>user agent</a>
             may not support continuous availability monitoring; for example,
             because of platform or power consumption restrictions. In this case
@@ -1510,17 +1523,16 @@
             part of the <a>start a presentation</a> algorithm.
           </p>
           <p>
-            When there are no live <a>PresentationAvailability</a> objects
-            (that is, the <a>set of availability objects</a> is empty), user
-            agents SHOULD NOT <a>monitor the list of available presentation
+            When the <a>set of presentation availability objects</a> is empty
+            (that is, there are no <var>availabilityUrls</var> being monitored),
+            user agents SHOULD NOT <a>monitor the list of available presentation
             displays</a> to satisfy the <a href=
             "https://github.com/w3c/presentation-api/blob/gh-pages/uc-req.md#nf-req01-power-saving-friendly">
             power saving non-functional requirement</a>. To further save power,
-            the <a>user agent</a> MAY also keep track of whether the page
-            holding a <a>PresentationAvailability</a> object is in the
-            foreground. Using this information, implementation specific
-            discovery of <a>presentation displays</a> can be resumed or
-            suspended.
+            the <a>user agent</a> MAY also keep track of whether a page holding
+            a <code>PresentationAvailability</code> object is in the foreground. Using
+            this information, implementation specific discovery
+            of <a>presentation displays</a> can be resumed or suspended.
           </p>
         </section>
         <section>
@@ -1537,14 +1549,13 @@
               Input
             </dt>
             <dd>
-              <var>presentationUrls</var>, a list of <a>presentation request
-              URLs</a>
+              <var>presentationRequest</var>, the <code>PresentationRequest</code> that <code>getAvailability()</code> was called on
             </dd>
             <dt>
               Output
             </dt>
             <dd>
-              <var>P</var>, a <a>Promise</a>
+              A <a>Promise</a>
             </dd>
           </dl>
           <ol>
@@ -1561,16 +1572,19 @@
                 </li>
               </ul>Run the following substeps:
               <ol>
-                <li>Return a <a>Promise</a> rejected with a
+                <li>Return a new <a>Promise</a> object <a data-lt="reject">rejected</a> with a
                 <a>SecurityError</a>.
                 </li>
                 <li>Abort these steps.
                 </li>
               </ol>
             </li>
-            <li>Let <var>P</var> be a new <a>Promise</a>.
+            <li>If the <a>presentation availability promise</a> for <code>presentationRequest</code> is not <code>null</code>,
+              return the <code>presentationRequest</code> object's <a>presentation availability promise</a> and abort these steps.
             </li>
-            <li>Return <var>P</var>, but continue running these steps <a>in
+            <li>Otherwise, set the <code>presentationRequest</code> object's <a>presentation availability promise</a> to a newly created <code>Promise</code> object and set <var>P</var> to this <code>Promise</code>.
+            </li>
+            <li>Return the the <code>presentationRequest</code> object's <a>presentation availability promise</a>, but continue running these steps <a>in
             parallel</a>.
             </li>
             <li>If the user agent is unable to <a>monitor the list of available
@@ -1579,7 +1593,7 @@
             disabled this feature), then:
               <ol>
                 <li>
-                  <a>Resolve</a> <var>P</var> with a new
+                  <a>Resolve</a> <var>P</var> with a newly created
                   <code>PresentationAvailability</code> object with its
                   <code>value</code> property set to <code>false</code>.
                 </li>
@@ -1588,8 +1602,9 @@
               </ol>
             </li>
             <li>If the user agent is unable to continuously <a>monitor the list
-            of available presentation displays</a> but can find presentation
-            displays in order to start a connection, then:
+            of available presentation displays</a> at the current time but can
+            later find presentation displays in order to start a connection,
+            then:
               <ol>
                 <li>
                   <a>Reject</a> <var>P</var> with a <a>NotSupportedError</a>
@@ -1599,19 +1614,18 @@
                 </li>
               </ol>
             </li>
-            <li>If there exists a tuple <em>(<var>A</var>,
-            <var>presentationUrls</var>)</em> in the <a>set of availability
-            objects</a>, then:
+            <li>If the <a>presentation display availability</a> for <var>presentationRequest</var> is not <code>null</code>, then:
               <ol>
                 <li>
-                  <a>Resolve</a> <var>P</var> with <var>A</var>.
+                  <a>Resolve</a> <var>P</var> with the request's <a>presentation display availability</a>.
                 </li>
                 <li>Abort all the remaining steps.
                 </li>
               </ol>
             </li>
-            <li>Let <var>A</var> be a new <code>PresentationAvailability</code>
-            object with its <code>value</code> property set as follows:
+            <li>Set the <a>presentation display availability</a> for <var>presentationRequest</var> to a
+              newly created <code>PresentationAvailability</code> object, and let <var>A</var> be that object.</li>
+            <li>Set the <code>value</code> property of <var>A</var> as follows:
               <ol>
                 <li>
                   <code>false</code> if the <a>list of available presentation
@@ -1632,7 +1646,7 @@
             </li>
             <li>Create a tuple <em>(<var>A</var>,
             <var>presentationUrls</var>)</em> and add it to the <a>set of
-            availability objects</a>.
+            presentation availability objects</a>.
             </li>
             <li>Run the algorithm to <a>monitor the list of available
             presentation displays</a>.
@@ -1647,7 +1661,7 @@
             Monitoring the list of available presentation displays
           </h4>
           <p>
-            If the <a>set of availability objects</a> is non-empty, or there is
+            If the <a>set of presentation availability objects</a> is non-empty, or there is
             a pending request to <a for="PresentationRequest" data-lt=
             "start">start a presentation</a>, the <a>user agent</a> MUST
             <dfn>monitor the list of available presentation displays</dfn> by
@@ -1662,7 +1676,7 @@
             be this list.
             </li>
             <li>For each member <em>(<var>A</var>,
-            <var>availabilityUrls</var>)</em> of the <a>set of availability
+            <var>availabilityUrls</var>)</em> of the <a>set of presentation availability
             objects</a>, run the following steps:
               <ol>
                 <li>Set <var>previousAvailability</var> to the value of
@@ -1713,10 +1727,10 @@
           </p>
           <ol>
             <li>Find and remove any entry <em>(<var>A</var>,
-            <var>availabilityUrl</var>)</em> in the <a>set of availability
+            <var>availabilityUrl</var>)</em> in the <a>set of presentation availability
             objects</a> for the newly deceased <var>A</var>.
             </li>
-            <li>If the <a>set of availability objects</a> is now empty and
+            <li>If the <a>set of presentation availability objects</a> is now empty and
             there is no pending request to <a for="PresentationRequest"
               data-lt="start">start a presentation</a>, cancel any pending task
               to <a>monitor the list of available presentation displays</a> for

--- a/index.html
+++ b/index.html
@@ -1434,14 +1434,15 @@
 </pre>
         <p>
           A <a><code>PresentationAvailability</code></a> object exposes the
-          <a>presentation display availability</a> for a presentation
-          request.             The <dfn>presentation display availability</dfn> for a <code>PresentationRequest</code>
-            stores whether there is currently any <a>available presentation
-            display</a> for at least one of the <a>presentation request URLs</a> of the request.
+          <a>presentation display availability</a> for a presentation request.
+          The <dfn>presentation display availability</dfn> for a
+          <code>PresentationRequest</code> stores whether there is currently
+          any <a>available presentation display</a> for at least one of the
+          <a>presentation request URLs</a> of the request.
         </p>
         <p>
- If the <a>controlling user agent</a> can <a>monitor the list
-          of available presentation displays</a> in the background (without a
+          If the <a>controlling user agent</a> can <a>monitor the list of
+          available presentation displays</a> in the background (without a
           pending request to <code><a for=
           "PresentationRequest">start</a>()</code>), the
           <a><code>PresentationAvailability</code></a> object MUST be
@@ -1463,30 +1464,31 @@
           </h4>
           <p>
             Each <code>PresentationRequest</code> has a <a>presentation
-            availability promise</a> and a <a>presentation display availability</a>,
-            which are initially set to null.  The <dfn>presentation
-            availability promise</dfn> for a <code>PresentationRequest</code> is
-            a <code>Promise</code> object that <a data-lt="resolve">resolves</a> to a
-            the <a>presentation display availability</a> for the request.
+            availability promise</a> and a <a>presentation display
+            availability</a>, which are initially set to null. The
+            <dfn>presentation availability promise</dfn> for a
+            <code>PresentationRequest</code> is a <code>Promise</code> object
+            that <a data-lt="resolve">resolves</a> to a the <a>presentation
+            display availability</a> for the request.
           </p>
           <p>
-            The <a>user
-            agent</a> MUST keep track of the <dfn>set of presentation availability
-            objects</dfn> created by the <code><a for=
-            "PresentationRequest">getAvailability</a>()</code> method. The
-            <a>set of presentation availability objects</a> is represented as a set of
-            tuples <em>(<var>A</var>, <var>availabilityUrls</var>)</em>,
-            initially empty, where:
+            The <a>user agent</a> MUST keep track of the <dfn>set of
+            presentation availability objects</dfn> created by the
+            <code><a for="PresentationRequest">getAvailability</a>()</code>
+            method. The <a>set of presentation availability objects</a> is
+            represented as a set of tuples <em>(<var>A</var>,
+            <var>availabilityUrls</var>)</em>, initially empty, where:
           </p>
           <ol>
             <li>
-              <var>A</var> is a live <code>PresentationAvailability</code> object.
+              <var>A</var> is a live <code>PresentationAvailability</code>
+              object.
             </li>
             <li>
               <var>availabilityUrls</var> is the list of <a>presentation
-              request URLs</a> for the <code>PresentationRequest</code> when <code><a for=
-              "PresentationRequest">getAvailability</a>()</code> was called on it to
-              create <var>A</var>.
+              request URLs</a> for the <code>PresentationRequest</code> when
+              <code><a for="PresentationRequest">getAvailability</a>()</code>
+              was called on it to create <var>A</var>.
             </li>
           </ol>
         </section>
@@ -1508,15 +1510,15 @@
             displays</a>.
           </p>
           <p>
-            While the <a>set of presentation availability objects</a> is not empty, the
-            <a>user agent</a> MAY <a>monitor the list of available presentation
-            displays</a> continuously, so that pages can use the <a for=
-            "PresentationAvailability">value</a> property of a
-            <code>PresentationAvailability</code> object to offer presentation only
-            when there are available displays. However, the <a>user agent</a>
-            may not support continuous availability monitoring; for example,
-            because of platform or power consumption restrictions. In this case
-            the <a>Promise</a> returned by <code><a for=
+            While the <a>set of presentation availability objects</a> is not
+            empty, the <a>user agent</a> MAY <a>monitor the list of available
+            presentation displays</a> continuously, so that pages can use the
+            <a for="PresentationAvailability">value</a> property of a
+            <code>PresentationAvailability</code> object to offer presentation
+            only when there are available displays. However, the <a>user
+            agent</a> may not support continuous availability monitoring; for
+            example, because of platform or power consumption restrictions. In
+            this case the <a>Promise</a> returned by <code><a for=
             "PresentationRequest">getAvailability</a>()</code> MUST be
             <a data-lt="reject">rejected</a> and the algorithm to <a>monitor
             the list of available presentation displays</a> will only run as
@@ -1524,15 +1526,16 @@
           </p>
           <p>
             When the <a>set of presentation availability objects</a> is empty
-            (that is, there are no <var>availabilityUrls</var> being monitored),
-            user agents SHOULD NOT <a>monitor the list of available presentation
-            displays</a> to satisfy the <a href=
+            (that is, there are no <var>availabilityUrls</var> being
+            monitored), user agents SHOULD NOT <a>monitor the list of available
+            presentation displays</a> to satisfy the <a href=
             "https://github.com/w3c/presentation-api/blob/gh-pages/uc-req.md#nf-req01-power-saving-friendly">
             power saving non-functional requirement</a>. To further save power,
             the <a>user agent</a> MAY also keep track of whether a page holding
-            a <code>PresentationAvailability</code> object is in the foreground. Using
-            this information, implementation specific discovery
-            of <a>presentation displays</a> can be resumed or suspended.
+            a <code>PresentationAvailability</code> object is in the
+            foreground. Using this information, implementation specific
+            discovery of <a>presentation displays</a> can be resumed or
+            suspended.
           </p>
         </section>
         <section>
@@ -1549,7 +1552,9 @@
               Input
             </dt>
             <dd>
-              <var>presentationRequest</var>, the <code>PresentationRequest</code> that <code>getAvailability()</code> was called on
+              <var>presentationRequest</var>, the
+              <code>PresentationRequest</code> that
+              <code>getAvailability()</code> was called on
             </dd>
             <dt>
               Output
@@ -1572,20 +1577,26 @@
                 </li>
               </ul>Run the following substeps:
               <ol>
-                <li>Return a new <a>Promise</a> object <a data-lt="reject">rejected</a> with a
-                <a>SecurityError</a>.
+                <li>Return a new <a>Promise</a> object <a data-lt=
+                "reject">rejected</a> with a <a>SecurityError</a>.
                 </li>
                 <li>Abort these steps.
                 </li>
               </ol>
             </li>
-            <li>If the <a>presentation availability promise</a> for <code>presentationRequest</code> is not <code>null</code>,
-              return the <code>presentationRequest</code> object's <a>presentation availability promise</a> and abort these steps.
+            <li>If the <a>presentation availability promise</a> for
+            <code>presentationRequest</code> is not <code>null</code>, return
+            the <code>presentationRequest</code> object's <a>presentation
+            availability promise</a> and abort these steps.
             </li>
-            <li>Otherwise, set the <code>presentationRequest</code> object's <a>presentation availability promise</a> to a newly created <code>Promise</code> object and set <var>P</var> to this <code>Promise</code>.
+            <li>Otherwise, set the <code>presentationRequest</code> object's
+            <a>presentation availability promise</a> to a newly created <code>
+              Promise</code> object and set <var>P</var> to this
+              <code>Promise</code>.
             </li>
-            <li>Return the the <code>presentationRequest</code> object's <a>presentation availability promise</a>, but continue running these steps <a>in
-            parallel</a>.
+            <li>Return the the <code>presentationRequest</code> object's
+            <a>presentation availability promise</a>, but continue running
+            these steps <a>in parallel</a>.
             </li>
             <li>If the user agent is unable to <a>monitor the list of available
             presentation displays</a> for the entire duration of the
@@ -1614,17 +1625,22 @@
                 </li>
               </ol>
             </li>
-            <li>If the <a>presentation display availability</a> for <var>presentationRequest</var> is not <code>null</code>, then:
+            <li>If the <a>presentation display availability</a> for
+            <var>presentationRequest</var> is not <code>null</code>, then:
               <ol>
                 <li>
-                  <a>Resolve</a> <var>P</var> with the request's <a>presentation display availability</a>.
+                  <a>Resolve</a> <var>P</var> with the request's
+                  <a>presentation display availability</a>.
                 </li>
                 <li>Abort all the remaining steps.
                 </li>
               </ol>
             </li>
-            <li>Set the <a>presentation display availability</a> for <var>presentationRequest</var> to a
-              newly created <code>PresentationAvailability</code> object, and let <var>A</var> be that object.</li>
+            <li>Set the <a>presentation display availability</a> for
+            <var>presentationRequest</var> to a newly created
+            <code>PresentationAvailability</code> object, and let <var>A</var>
+            be that object.
+            </li>
             <li>Set the <code>value</code> property of <var>A</var> as follows:
               <ol>
                 <li>
@@ -1661,11 +1677,11 @@
             Monitoring the list of available presentation displays
           </h4>
           <p>
-            If the <a>set of presentation availability objects</a> is non-empty, or there is
-            a pending request to <a for="PresentationRequest" data-lt=
-            "start">start a presentation</a>, the <a>user agent</a> MUST
-            <dfn>monitor the list of available presentation displays</dfn> by
-            running the following steps.
+            If the <a>set of presentation availability objects</a> is
+            non-empty, or there is a pending request to <a for=
+            "PresentationRequest" data-lt="start">start a presentation</a>, the
+            <a>user agent</a> MUST <dfn>monitor the list of available
+            presentation displays</dfn> by running the following steps.
           </p>
           <ol link-for="PresentationAvailability">
             <li>Set the <a>list of available presentation displays</a> to the
@@ -1676,8 +1692,8 @@
             be this list.
             </li>
             <li>For each member <em>(<var>A</var>,
-            <var>availabilityUrls</var>)</em> of the <a>set of presentation availability
-            objects</a>, run the following steps:
+            <var>availabilityUrls</var>)</em> of the <a>set of presentation
+            availability objects</a>, run the following steps:
               <ol>
                 <li>Set <var>previousAvailability</var> to the value of
                 <var>A</var>'s <a>value</a> property.
@@ -1727,15 +1743,15 @@
           </p>
           <ol>
             <li>Find and remove any entry <em>(<var>A</var>,
-            <var>availabilityUrl</var>)</em> in the <a>set of presentation availability
-            objects</a> for the newly deceased <var>A</var>.
+            <var>availabilityUrl</var>)</em> in the <a>set of presentation
+            availability objects</a> for the newly deceased <var>A</var>.
             </li>
-            <li>If the <a>set of presentation availability objects</a> is now empty and
-            there is no pending request to <a for="PresentationRequest"
-              data-lt="start">start a presentation</a>, cancel any pending task
-              to <a>monitor the list of available presentation displays</a> for
-              power saving purposes, and set the <a>list of available
-              presentation displays</a> to the empty list.
+            <li>If the <a>set of presentation availability objects</a> is now
+            empty and there is no pending request to <a for=
+            "PresentationRequest" data-lt="start">start a presentation</a>,
+            cancel any pending task to <a>monitor the list of available
+            presentation displays</a> for power saving purposes, and set the
+            <a>list of available presentation displays</a> to the empty list.
             </li>
           </ol>
           <div class="note">


### PR DESCRIPTION
This addresses Issue #335 by clarifying the roles of objects used by `getAvailability()`.

Specifically:
- Each `PresentationRequest` has at most one _presentation display availability_ and a _presentation availability promise_.
- The former is set to a `PresentationAvailability` object the first time it's needed.
- The latter is set to a new `Promise` the first time it's needed.

I did not use `[SameObject]` here as it did not seem appropriate per discussion in the other issue.

As far as I understand, with this clarification the example in https://github.com/w3c/presentation-api/issues/335#issue-173916158 should work by resolver order guarantees.
