### PR TITLE
Remove [SameObject] from navigator.presentation.receiver

### DIFF
--- a/index.html
+++ b/index.html
@@ -981,7 +981,7 @@
           </p>
           <pre class="idl idl-receiving-ua">
             partial interface Presentation {
-              [SameObject] readonly attribute PresentationReceiver? receiver;
+              readonly attribute PresentationReceiver? receiver;
             };
           
 </pre>


### PR DESCRIPTION
Addresses #365: [SameObject] for receiver seems wrong