### PR TITLE
Issue #379: Adds sandboxing flag check to PresentationRequest ctor.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1043,6 +1043,10 @@
             </dd>
           </dl>
           <ol>
+            <li>If the document object's <a>active sandboxing flag set</a> has
+            the <a>sandboxed presentation browsing context flag</a> set, then
+            throw a <a>SecurityError</a> and abort these steps.
+            </li>
             <li>If <var>urls</var> is an empty sequence, then <a>throw</a> a
             <a>NotSupportedError</a> and abort all remaining steps.
             </li>


### PR DESCRIPTION
Addresses Issue #379: Investigate if sandboxing flag check can move to the PresentationRequest ctor.

For consistency, check the sandboxing flag in the `PresentationRequest` constructor.  Keep the checks in other functions the case the flag was unset at construction time and set later.

It may be that the sandboxing flag should be persistent, however, this does not seem to be implemented in Blink.  If that's true then we can remove the other checks later.
 