### PR TITLE
Issue 387: Need to make sure we have a display list for start().

### DIFF
--- a/index.html
+++ b/index.html
@@ -1129,19 +1129,24 @@
             <li>Return <var>P</var>, but continue running these steps <a>in
             parallel</a>.
             </li>
-            <li>Let <var>availabilityObj</var> be <code>null</code>.</li>
-            <li>If the <a>presentation display availability</a>
-                for <var>presentationRequest</var> is <code>null</code>, run the
-                following substeps <a>in parallel</a>.
+            <li>Let <var>availabilityObj</var> be <code>null</code>.
+            </li>
+            <li>If the <a>presentation display availability</a> for
+            <var>presentationRequest</var> is <code>null</code>, run the
+            following substeps <a>in parallel</a>.
               <ol>
-                <li>Set the <a>presentation display availability</a>
-                  for <var>presentationRequest</var> to a newly
-                  created <code>PresentationAvailability</code> object, and
-                  let <var>availabilityObj</var> be that object.</li>
-                <li>Create a tuple (<var>availabilityObj</var>, <var>presentationUrls</var>) and
-                  add it to the <a>set of presentation availability objects</a>.
+                <li>Set the <a>presentation display availability</a> for <var>
+                  presentationRequest</var> to a newly created
+                  <code>PresentationAvailability</code> object, and let
+                  <var>availabilityObj</var> be that object.
                 </li>
-                <li>Run the steps to continuously <a>monitor the list of available presentation displays</a>.</li>
+                <li>Create a tuple (<var>availabilityObj</var>,
+                <var>presentationUrls</var>) and add it to the <a>set of
+                presentation availability objects</a>.
+                </li>
+                <li>Run the steps to continuously <a>monitor the list of
+                available presentation displays</a>.
+                </li>
               </ol>
             </li>
             <li>Request user permission for the use of a <a>presentation
@@ -1168,7 +1173,8 @@
               </ol>
             </li>
             <li>If the user <em>denies permission</em> to use a display, reject
-            <var>P</var> with an <a>NotAllowedError</a> exception, and go to the step named <var>Cleanup</var>.
+            <var>P</var> with an <a>NotAllowedError</a> exception, and go to
+            the step named <var>Cleanup</var>.
             </li>
             <li>Otherwise, the user <em>grants permission</em> to use a
             display; let <var>D</var> be that display.
@@ -1176,11 +1182,17 @@
             <li>Run the steps to <a>start a presentation connection</a> with
             <var>presentationRequest</var>, <var>D</var>, and <var>P</var>.
             </li>
-            <li><var>Cleanup</var>: If <var>availabilityObj</var> is not <code>null</code>, run the following substeps:
+            <li>
+              <var>Cleanup</var>: If <var>availabilityObj</var> is not
+              <code>null</code>, run the following substeps:
               <ol>
-                <li>Remove the tuple (<var>availabilityObj</var>, <var>presentationUrls</var>) from the <a>set of presentation availability objects</a>.</li>
-                <li>Set the <a>presentation display availability</a>
-                  for <var>presentationRequest</var> to <code>null</code>.</li>
+                <li>Remove the tuple (<var>availabilityObj</var>,
+                <var>presentationUrls</var>) from the <a>set of presentation
+                availability objects</a>.
+                </li>
+                <li>Set the <a>presentation display availability</a> for <var>
+                  presentationRequest</var> to <code>null</code>.
+                </li>
               </ol>
             </li>
           </ol>

--- a/index.html
+++ b/index.html
@@ -1129,11 +1129,20 @@
             <li>Return <var>P</var>, but continue running these steps <a>in
             parallel</a>.
             </li>
-            <li>If the <a>user agent</a> is not <a data-lt=
-            "monitor the list of available presentation displays">monitoring
-            the list of available presentation displays</a>, run the steps to
-            <a>monitor the list of available presentation displays</a> <a>in
-            parallel</a>.
+            <li>Let <var>availabilityObj</var> be <code>null</code>.</li>
+            <li>If the <a>presentation display availability</a>
+                for <var>presentationRequest</var> is <code>null</code>, run the
+                following substeps <a>in parallel</a>.
+              <ol>
+                <li>Set the <a>presentation display availability</a>
+                  for <var>presentationRequest</var> to a newly
+                  created <code>PresentationAvailability</code> object, and
+                  let <var>availabilityObj</var> be that object.</li>
+                <li>Create a tuple (<var>availabilityObj</var>, <var>presentationUrls</var>) and
+                  add it to the <a>set of presentation availability objects</a>.
+                </li>
+                <li>Run the steps to continuously <a>monitor the list of available presentation displays</a>.</li>
+              </ol>
             </li>
             <li>Request user permission for the use of a <a>presentation
             display</a> and selection of one presentation display.
@@ -1154,19 +1163,25 @@
                   <a>Reject</a> <var>P</var> with a <a>NotFoundError</a>
                   exception.
                 </li>
-                <li>Abort all remaining steps.
+                <li>Go to the step named <var>Cleanup</var>.
                 </li>
               </ol>
             </li>
             <li>If the user <em>denies permission</em> to use a display, reject
-            <var>P</var> with an <a>NotAllowedError</a> exception, and abort
-            all remaining steps.
+            <var>P</var> with an <a>NotAllowedError</a> exception, and go to the step named <var>Cleanup</var>.
             </li>
             <li>Otherwise, the user <em>grants permission</em> to use a
             display; let <var>D</var> be that display.
             </li>
             <li>Run the steps to <a>start a presentation connection</a> with
             <var>presentationRequest</var>, <var>D</var>, and <var>P</var>.
+            </li>
+            <li><var>Cleanup</var>: If <var>availabilityObj</var> is not <code>null</code>, run the following substeps:
+              <ol>
+                <li>Remove the tuple (<var>availabilityObj</var>, <var>presentationUrls</var>) from the <a>set of presentation availability objects</a>.</li>
+                <li>Set the <a>presentation display availability</a>
+                  for <var>presentationRequest</var> to <code>null</code>.</li>
+              </ol>
             </li>
           </ol>
           <div class="note">


### PR DESCRIPTION
Addresses issue #387: Filling out the list of available presentation displays for start.

If there is no existing _presentation display availability_ for the request, creates a temporary one and runs the steps to monitor.  The temporary one is removed at the end of `start()`.
