### PR TITLE
Issue #387: Monitoring algo takes pending request to start into account

### DIFF
--- a/index.html
+++ b/index.html
@@ -1557,8 +1557,9 @@
         </p>
         <p>
           The <dfn for="PresentationAvailability">value</dfn> attribute MUST
-          return the last value it was set to. The value is updated by the
-          <a>monitor the list of available presentation displays</a> algorithm.
+          return the last value it was set to. The value is initialized and
+          updated by the <a>monitor the list of available presentation
+          displays</a> algorithm.
         </p>
         <p>
           The <dfn for="PresentationAvailability">onchange</dfn> attribute is
@@ -1712,9 +1713,6 @@
             <a>PresentationAvailability</a> object, and let <var>A</var> be
             that object.
             </li>
-            <li>Set the <code>value</code> property of <var>A</var> to
-            <code>false</code>.
-            </li>
             <li>Create a tuple <em>(<var>A</var>,
             <var>presentationUrls</var>)</em> and add it to the <a>set of
             presentation availability objects</a>.
@@ -1755,9 +1753,6 @@
               <ol>
                 <li>Let <var>A</var> be a newly created
                 <a>PresentationAvailability</a> object.
-                </li>
-                <li>Set the <var>value</var> property of <var>A</var> to <code>
-                  false</code>.
                 </li>
                 <li>Create a tuple <em>(<var>A</var>,
                 <var>presentationUrls</var>)</em> where
@@ -1808,23 +1803,26 @@
                     </li>
                   </ol>
                 </li>
+                <li>If <var>A</var>'s <a>value</a> property has not yet been
+                initialized, then set <var>A</var>'s <a>value</a> property to
+                <var>newAvailability</var> and skip the following step.
+                  <div class="note">
+                    The <a>value</a> property of a
+                    <a>PresentationAvailability</a> object becomes
+                    <em>initialized</em> when the above step sets it for the
+                    first time.
+                  </div>
+                </li>
                 <li>If <var>previousAvailability</var> is not equal to
-                <var>newAvailability</var>, then run the following steps:
+                <var>newAvailability</var>, then <a>queue a task</a> to run the
+                following steps:
                   <ol>
-                    <li>If <var>A</var> has already been exposed to ECMAScript
-                    code, then <a>queue a task</a> to run the following steps:
-                      <ol>
-                        <li>Set <var>A</var>'s <a>value</a> property to
-                        <var>newAvailability</var>.
-                        </li>
-                        <li>
-                          <a>Fire a simple event</a> named <a>change</a> at
-                          <var>A</var>.
-                        </li>
-                      </ol>
-                    </li>
-                    <li>Otherwise, set <var>A</var>'s <a>value</a> property to
+                    <li>Set <var>A</var>'s <a>value</a> property to
                     <var>newAvailability</var>.
+                    </li>
+                    <li>
+                      <a>Fire a simple event</a> named <a>change</a> at
+                      <var>A</var>.
                     </li>
                   </ol>
                 </li>
@@ -1837,8 +1835,10 @@
             calls to <a for="PresentationRequest">getAvailability</a> and
             <a for="PresentationRequest">start</a>. The <a>user agent</a> may
             run such requests in parallel, serialize them, or interrupt the
-            algorithm if it is before or at step 5 and run it again to group
-            requests.
+            algorithm if it is before or at step 5 and run it again to
+            aggregate requests. The <a>user agent</a> may also aggregate
+            monitoring activities across <a data-lt="browsing context">browsing
+            contexts</a>.
           </div>
           <p>
             When a <a>presentation display availability</a> object is no longer

--- a/index.html
+++ b/index.html
@@ -1720,8 +1720,9 @@
             <li>Run the algorithm to <a>monitor the list of available
             presentation displays</a>.
               <div class="note">
-                This algorithm needs to run even if it is already running to
-                pick up the tuple created in the previous step.
+                The monitoring algorithm must be run at least one more time
+                after the previous step to pick up the tuple that was added to
+                the <a>set of presentation availability objects</a>.
               </div>
             </li>
             <li>
@@ -1806,12 +1807,6 @@
                 <li>If <var>A</var>'s <a>value</a> property has not yet been
                 initialized, then set <var>A</var>'s <a>value</a> property to
                 <var>newAvailability</var> and skip the following step.
-                  <div class="note">
-                    The <a>value</a> property of a
-                    <a>PresentationAvailability</a> object becomes
-                    <em>initialized</em> when the above step sets it for the
-                    first time.
-                  </div>
                 </li>
                 <li>If <var>previousAvailability</var> is not equal to
                 <var>newAvailability</var>, then <a>queue a task</a> to run the
@@ -1830,20 +1825,17 @@
             </li>
           </ol>
           <div class="note">
-            Multiple requests to run the algorithm to <a>monitor the list of
-            available presentation displays</a> may occur at once, e.g., due to
-            calls to <a for="PresentationRequest">getAvailability</a> and
-            <a for="PresentationRequest">start</a>. The <a>user agent</a> may
-            run such requests in parallel, serialize them, or interrupt the
-            algorithm if it is before or at step 5 and run it again to
-            aggregate requests. The <a>user agent</a> may also aggregate
-            monitoring activities across <a data-lt="browsing context">browsing
-            contexts</a>.
+            The <a>controlling user agent</a> may choose how often to
+            <a>monitor the list of available presentation displays</a>,
+            including grouping requests from <a for=
+            "PresentationRequest">start</a> and <a for=
+            "PresentationRequest">getAvailability</a>, and aggregating them
+            across <a data-lt="browsing context">browsing contexts</a>.
           </div>
           <p>
-            When a <a>presentation display availability</a> object is no longer
-            alive (i.e., is eligible for garbage collection), the <a>user
-            agent</a> SHOULD run the following steps:
+            When a <a>presentation display availability</a> object is eligible
+            for garbage collection, the <a>user agent</a> SHOULD run the
+            following steps:
           </p>
           <ol>
             <li>Let <var>A</var> be the newly deceased

--- a/index.html
+++ b/index.html
@@ -1117,10 +1117,10 @@
             abort these steps.
             </li>
             <li>If there is already an unsettled <a>Promise</a> from a previous
-            call to <code>start</code> on any <code>PresentationRequest</code>
-            in the same <a>controlling browsing context</a>, return a new
-            <a>Promise</a> rejected with an <a>OperationError</a> exception and
-            abort all remaining steps.
+            call to <a for="PresentationRequest">start</a> on any
+            <a>PresentationRequest</a> in the same <a>controlling browsing
+            context</a>, return a new <a>Promise</a> rejected with an
+            <a>OperationError</a> exception and abort all remaining steps.
             </li>
             <li>Let <var>P</var> be a new <a>Promise</a>.
             </li>
@@ -1543,6 +1543,11 @@
           <a>presentation request URLs</a> of the request.
         </p>
         <p>
+          The <a>presentation display availability</a> for a presentation
+          request is eligible for garbage collection when no ECMASCript code
+          can observe the <code>PresentationAvailability</code> object.
+        </p>
+        <p>
           If the <a>controlling user agent</a> can <a>monitor the list of
           available presentation displays</a> in the background (without a
           pending request to <code><a for=
@@ -1564,15 +1569,6 @@
           <h4>
             The set of presentation availability objects
           </h4>
-          <p>
-            Each <code>PresentationRequest</code> has a <a>presentation
-            availability promise</a> and a <a>presentation display
-            availability</a>, which are initially set to <code>null</code>. The
-            <dfn>presentation availability promise</dfn> for a
-            <code>PresentationRequest</code> is a <code>Promise</code> object
-            that <a data-lt="resolve">resolves</a> to the <a>presentation
-            display availability</a> for the request.
-          </p>
           <p>
             The <a>user agent</a> MUST keep track of the <dfn>set of
             presentation availability objects</dfn> created by the
@@ -1677,19 +1673,15 @@
                 </li>
               </ol>
             </li>
-            <li>If the <a>presentation availability promise</a> for
-            <code>presentationRequest</code> is not <code>null</code>, return
-            the <code>presentationRequest</code> object's <a>presentation
-            availability promise</a> and abort these steps.
+            <li>If there is an unsettled <a>Promise</a> from a previous call to
+            <a for="PresentationRequest">getAvailability</a> on
+            <code>presentationRequest</code>, return that <a>Promise</a> and
+            abort these steps.
             </li>
-            <li>Otherwise, set the <code>presentationRequest</code> object's
-            <a>presentation availability promise</a> to a newly created <code>
-              Promise</code> object and set <var>P</var> to this
-              <code>Promise</code>.
+            <li>Otherwise, let <var>P</var> be a new <a>Promise</a>.
             </li>
-            <li>Return the <code>presentationRequest</code> object's
-            <a>presentation availability promise</a>, but continue running
-            these steps <a>in parallel</a>.
+            <li>Return <var>P</var>, but continue running these steps <a>in
+            parallel</a>.
             </li>
             <li>If the user agent is unable to continuously <a>monitor the list
             of available presentation displays</a> in the background, but can
@@ -1717,34 +1709,22 @@
             </li>
             <li>Set the <a>presentation display availability</a> for
             <var>presentationRequest</var> to a newly created
-            <code>PresentationAvailability</code> object, and let <var>A</var>
-            be that object.
+            <a>PresentationAvailability</a> object, and let <var>A</var> be
+            that object.
             </li>
-            <li>Set the <code>value</code> property of <var>A</var> as follows:
-              <ol>
-                <li>
-                  <code>false</code> if the <a>list of available presentation
-                  displays</a> is empty.
-                </li>
-                <li>
-                  <code>true</code> if there is at least one <a>available
-                  presentation display</a> for some member of
-                  <var>presentationUrls</var>. That is, there is an entry
-                  <var>(presentationUrl, display)</var> in the <a>list of
-                  available presentation displays</a> for some
-                  <var>presentationUrl</var> in <var>presentationUrls</var>.
-                </li>
-                <li>
-                  <code>false</code> otherwise.
-                </li>
-              </ol>
+            <li>Set the <code>value</code> property of <var>A</var> to
+            <code>false</code>.
             </li>
             <li>Create a tuple <em>(<var>A</var>,
             <var>presentationUrls</var>)</em> and add it to the <a>set of
             presentation availability objects</a>.
             </li>
             <li>Run the algorithm to <a>monitor the list of available
-            presentation displays</a> <a>in parallel</a>.
+            presentation displays</a>.
+              <div class="note">
+                This algorithm needs to run even if it is already running to
+                pick up the tuple created in the previous step.
+              </div>
             </li>
             <li>
               <a>Resolve</a> <var>P</var> with <var>A</var>.
@@ -1761,11 +1741,31 @@
             "PresentationRequest" data-lt="start">select a presentation
             display</a>, the <a>user agent</a> MUST <dfn>monitor the list of
             available presentation displays</dfn> by running the following
-            steps.
+            steps:
           </p>
           <ol link-for="PresentationAvailability">
-            <li>Set the <a>list of available presentation displays</a> to the
-            empty list.
+            <li>Let <var>availabilitySet</var> be a shallow copy of the <a>set
+            of presentation availability objects</a>.
+            </li>
+            <li>If there is a pending request to <a for="PresentationRequest"
+            data-lt="start">select a presentation display</a> for a
+            <a>PresentationRequest</a> and if the <a>PresentationRequest</a>'s
+            <a>presentation display availability</a> is <code>null</code>, then
+            run the following substeps:
+              <ol>
+                <li>Let <var>A</var> be a newly created
+                <a>PresentationAvailability</a> object.
+                </li>
+                <li>Set the <var>value</var> property of <var>A</var> to <code>
+                  false</code>.
+                </li>
+                <li>Create a tuple <em>(<var>A</var>,
+                <var>presentationUrls</var>)</em> where
+                <var>presentationUrls</var> is the <a>PresentationRequest</a>'s
+                <a>presentation request URLs</a> and add it to the <a>set of
+                presentation availability objects</a>.
+                </li>
+              </ol>
             </li>
             <li>Let <var>newDisplays</var> be an empty list.
             </li>
@@ -1775,6 +1775,9 @@
             </li>
             <li>Retrieve <a>presentation displays</a> (using an implementation
             specific mechanism) and set <var>newDisplays</var> to this list.
+            </li>
+            <li>Set the <a>list of available presentation displays</a> to the
+            empty list.
             </li>
             <li>For each member <em>(<var>A</var>,
             <var>availabilityUrls</var>)</em> of the <a>set of presentation
@@ -1806,30 +1809,49 @@
                   </ol>
                 </li>
                 <li>If <var>previousAvailability</var> is not equal to
-                <var>newAvailability</var>, then <a>queue a task</a> to run the
-                following steps:
+                <var>newAvailability</var>, then run the following steps:
                   <ol>
-                    <li>Set <var>A</var>'s <a>value</a> property to
-                    <var>newAvailability</var>.
+                    <li>If <var>A</var> has already been exposed to ECMAScript
+                    code, then <a>queue a task</a> to run the following steps:
+                      <ol>
+                        <li>Set <var>A</var>'s <a>value</a> property to
+                        <var>newAvailability</var>.
+                        </li>
+                        <li>
+                          <a>Fire a simple event</a> named <a>change</a> at
+                          <var>A</var>.
+                        </li>
+                      </ol>
                     </li>
-                    <li>
-                      <a>Fire a simple event</a> named <a>change</a> at
-                      <var>A</var>.
+                    <li>Otherwise, set <var>A</var>'s <a>value</a> property to
+                    <var>newAvailability</var>.
                     </li>
                   </ol>
                 </li>
               </ol>
             </li>
           </ol>
+          <div class="note">
+            Multiple requests to run the algorithm to <a>monitor the list of
+            available presentation displays</a> may occur at once, e.g., due to
+            calls to <a for="PresentationRequest">getAvailability</a> and
+            <a for="PresentationRequest">start</a>. The <a>user agent</a> may
+            run such requests in parallel, serialize them, or interrupt the
+            algorithm if it is before or at step 5 and run it again to group
+            requests.
+          </div>
           <p>
-            When a <a>PresentationAvailability</a> object is no longer alive
-            (i.e., is eligible for garbage collection), the <a>user agent</a>
-            SHOULD run the following steps:
+            When a <a>presentation display availability</a> object is no longer
+            alive (i.e., is eligible for garbage collection), the <a>user
+            agent</a> SHOULD run the following steps:
           </p>
           <ol>
+            <li>Let <var>A</var> be the newly deceased
+            <a>PresentationAvailability</a> object
+            </li>
             <li>Find and remove any entry <em>(<var>A</var>,
             <var>availabilityUrl</var>)</em> in the <a>set of presentation
-            availability objects</a> for the newly deceased <var>A</var>.
+            availability objects</a>.
             </li>
             <li>If the <a>set of presentation availability objects</a> is now
             empty and there is no pending request to <a for=

--- a/index.html
+++ b/index.html
@@ -1762,8 +1762,8 @@
                 <li>Create a tuple <em>(<var>A</var>,
                 <var>presentationUrls</var>)</em> where
                 <var>presentationUrls</var> is the <a>PresentationRequest</a>'s
-                <a>presentation request URLs</a> and add it to the <a>set of
-                presentation availability objects</a>.
+                <a>presentation request URLs</a> and add it to
+                <var>availabilitySet</var>.
                 </li>
               </ol>
             </li>
@@ -1780,8 +1780,8 @@
             empty list.
             </li>
             <li>For each member <em>(<var>A</var>,
-            <var>availabilityUrls</var>)</em> of the <a>set of presentation
-            availability objects</a>, run the following steps:
+            <var>availabilityUrls</var>)</em> of <var>availabilitySet</var>,
+            run the following steps:
               <ol>
                 <li>Set <var>previousAvailability</var> to the value of
                 <var>A</var>'s <a>value</a> property.


### PR DESCRIPTION
This PR is meant to replace PR #390. It implements the changes discussed there.

Main changes:

- Prose similar to that used in the Web Bluetooth spec used for the garbage collection note for the "presentation display availability" to clarify the intent. We may want to adjust this text in #391.
- Notion of "presentation availability promise" dropped. That promise is now referenced in `getAvailability` as "an unsettled Promise from a previous call to `getAvailability` on `presentationRequest`". This avoids having to be explicit about garbage collection rules.
- Step that instructs the UA to run the monitoring algorithm no longer runs "in parallel" (see #381)
- Note added next to that step to clarify that the monitoring algorithm needs to run again even if it is still running
- The monitoring algorithm now starts by making a shallow copy of the "set of presentation availability objects" which gets completed with the right tuple if there is a pending call to `start` (note there can be at most one such pending call per controlling browsing context)
- Steps that update the `value` property adjusted to set the value directly for `PresentationAvailability` objects that have not yet been exposed to ECMAScript object. This is triggered by the following (new) problem: the `getAvailibility` promise gets resolved with a `PresentationAvailability` object as soon as the
monitoring algorithm is done running, but the monitoring algorithm "queued a task" to update the `value` property of `PresentationAvailability` objects. The `value` property of the returned `PresentationAvailability` object would always have been the initial value (`false` in most cases), even if the monitoring algorithm had found an available display. Also, we probably do not want to fire `change` events for properties that JS code has not yet been given any chance to read. Here as well, we may want to adjust this text in #391.
- The initial `value` of newly created `PresentationAvailability` objects is now always `false`. There should be no need to set it to `true` given that the monitoring algorithm refreshes that value right after that (and given the previous fix).
- I added a note next to the monitoring algorithm to clarify that a user agent may interrupt and re-run the algorithm to group requests, which seems like a possible optimization.