### PR TITLE
Addresses Issue 387

### DIFF
--- a/index.html
+++ b/index.html
@@ -331,11 +331,9 @@
       <p>
         The terms <dfn><a href=
         "https://www.w3.org/TR/html5/browsers.html#application-cache">application
-        cache</a></dfn>, <dfn><a href=
+        cache</a></dfn>, <dfn data-lt="browsing context|browsing contexts"><a href=
         "http://www.w3.org/TR/html5/browsers.html#browsing-context">browsing
         context</a></dfn>, <dfn><a href=
-        "https://www.w3.org/TR/html5/browsers.html#nested-browsing-contexts">nested
-        browsing context</a></dfn>, <dfn><a href=
         "http://www.w3.org/TR/html5/webappapis.html#event-handlers">event
         handler</a></dfn>, <dfn><a href=
         "http://www.w3.org/TR/html5/webappapis.html#event-handler-event-type">event
@@ -380,7 +378,9 @@
         "http://www.w3.org/TR/html51/infrastructure.html#in-parallel">in
         parallel</a></dfn> and <dfn><a href=
         "https://www.w3.org/TR/html51/webappapis.html#task-source">task
-        source</a></dfn> are defined in [[!HTML51]].
+        source</a></dfn>, <dfn><a href="https://www.w3.org/TR/html51/browsers.html#ancestor-browsing-context">ancestor browsing context</a></dfn>, <dfn><a href=
+        "https://www.w3.org/TR/html5/browsers.html#nested-browsing-contexts">nested
+        browsing context</a></dfn>, and <dfn><a href="https://www.w3.org/TR/html51/browsers.html#list-of-the-descendant-browsing-contexts">list of descendent browsing contexts</a></dfn>, and <dfn><a href="https://www.w3.org/TR/html51/browsers.html#creating-a-new-browsing-context">creating a new browsing context</a></dfn> are defined in [[!HTML51]].
       </p>
       <p>
         The terms <dfn><code><a href=
@@ -974,10 +974,12 @@
           <p>
             The <dfn for="Presentation"><code>receiver</code></dfn> attribute
             MUST return the <a><code>PresentationReceiver</code></a> instance
-            associated with the <a>receiving browsing context</a> and created
-            by the <a>receiving user agent</a> when the <a>receiving browsing
-            context</a> is created. In any other <a>browsing context</a>, it
-            MUST return <code>null</code>.
+            associated with the <a>receiving browsing context</a> and created by
+            the <a>receiving user agent</a> when the <a>receiving browsing
+            context</a> is <a data-lt="create a receiving browsing
+            context">created</a>. In any other <a>browsing context</a>
+            (including <a data-lt="nested browsing context">nested browsing contexts</a> of the <a>receiving
+            browsing context</a>) it MUST return <code>null</code>.
           </p>
           <p class="note">
             Web developers can use <code>Navigator.presentation.receiver</code>
@@ -2704,7 +2706,7 @@
             </dd>
           </dl>
           <ol>
-            <li>Create a new <a>top-level browsing context</a> <var>C</var>,
+            <li><a data-lt="creating a new browsing context">Create</a> a new <a>top-level browsing context</a> <var>C</var>,
             set to display content on <var>D</var>.
             </li>
             <li>Set the <a>session history</a> of <var>C</var> to be the empty
@@ -2713,6 +2715,10 @@
             <li>Set the <a>sandboxed auxiliary navigation browsing context
             flag</a> on <var>C</var>.
             </li>
+            <li>If the <a>receiving user agent</a> implements [[!PERMISSIONS]],
+            set the <a>permission state</a> of all <a>Permissions</a> for <var>
+              C</var> to <code>"denied"</code>.
+            </li>
             <li>Create a new empty <a>cookie store</a> for <var>C</var>.
             </li>
             <li>Create a new empty store for <var>C</var> to hold <a>HTTP
@@ -2720,10 +2726,6 @@
             </li>
             <li>Create a new empty <a>application cache</a> storage for
             <var>C</var>.
-            </li>
-            <li>If the <a>receiving user agent</a> implements [[!PERMISSIONS]],
-            set the <a>permission state</a> of all <a>Permissions</a> for <var>
-              C</var> to <code>"denied"</code>.
             </li>
             <li>If the <a>receiving user agent</a> implements [[!INDEXEDDB]],
             create a new empty storage for IndexedDB <a>databases</a> for <var>
@@ -2747,21 +2749,33 @@
             </li>
           </ol>
           <p>
+            All <a data-lt="nested browsing context">nested browsing
+            contexts</a> <a data-lt="creating a new browsing context">created</a> by
+            the presented document, i.e. that have the <a>receiving browsing
+            context</a> as their <a data-lt="ancestor browsing
+            context">top-level ancestor</a>, MUST also have restrictions 2-4
+            above.  All of these <a>browsing contexts</a> MUST also share the same
+            browsing state (storage) for features 5-10 listed above.
+          </p>
+          <p>
             <a>Window clients</a> and <a>worker clients</a> associated with the
-            <a>receiving browsing context</a> and the other <a>browsing
-            context</a> must not be exposed to <a>service workers</a>
+            <a>receiving browsing context</a> and its <a>list of descendent
+            browsing contexts</a> must not be exposed to <a>service workers</a>
             associated with each other.
           </p>
           <p>
-            When the <a>receiving browsing context</a> is closed, any
-            associated <a>service workers</a> MUST be unregistered and
-            terminated, and any associated browsing state, including <a>session
-            history</a>, the <a>cookie store</a>, any <a>HTTP
-            authentication</a> state, the <a>application cache</a>, any
+            When the <a>receiving browsing context</a> is closed, any <a>service
+            workers</a> associated with it and the <a>browsing contexts</a> in
+            its <a>list of descendent browsing contexts</a> MUST be unregistered
+            and terminated.  Any browsing state associated with the <a>receiving
+            browsing context</a> and the <a>browsing contexts</a> in its <a>list of descendent
+            browsing contexts</a>, including <a>session history</a>,
+            the <a>cookie store</a>, any <a>HTTP authentication</a> state,
+            the <a>application cache</a>, any
             <a>databases</a>, the <a>session storage areas</a>, the <a>local
             storage areas</a>, the <a>list of registered service worker
             registrations</a> and the <a>caches</a> MUST be discarded and not
-            used for any other <a>receiving browsing context</a>.
+            used for any other <a>browsing context</a>.
           </p>
           <p class="note">
             This algorithm is intended to create a well defined environment to

--- a/index.html
+++ b/index.html
@@ -380,12 +380,10 @@
         parallel</a></dfn> and <dfn><a href=
         "https://www.w3.org/TR/html51/webappapis.html#task-source">task
         source</a></dfn>, <dfn><a href=
-        "https://www.w3.org/TR/html51/browsers.html#ancestor-browsing-context">ancestor
-        browsing context</a></dfn>, <dfn><a href=
         "https://www.w3.org/TR/html5/browsers.html#nested-browsing-contexts">nested
         browsing context</a></dfn>, and <dfn><a href=
         "https://www.w3.org/TR/html51/browsers.html#list-of-the-descendant-browsing-contexts">
-        list of descendent browsing contexts</a></dfn>, and <dfn><a href=
+        list of descendant browsing contexts</a></dfn>, and <dfn><a href=
         "https://www.w3.org/TR/html51/browsers.html#creating-a-new-browsing-context">
         creating a new browsing context</a></dfn> are defined in [[!HTML51]].
       </p>
@@ -2764,24 +2762,24 @@
             contexts</a> <a data-lt=
             "creating a new browsing context">created</a> by the presented
             document, i.e. that have the <a>receiving browsing context</a> as
-            their <a data-lt="ancestor browsing context">top-level
-            ancestor</a>, MUST also have restrictions 2-4 above. All of these
+            their <a data-lt="top-level browsing context">top-level browsing
+            context</a>, MUST also have restrictions 2-4 above. All of these
             <a>browsing contexts</a> MUST also share the same browsing state
             (storage) for features 5-10 listed above.
           </p>
           <p>
             <a>Window clients</a> and <a>worker clients</a> associated with the
-            <a>receiving browsing context</a> and its <a>list of descendent
+            <a>receiving browsing context</a> and its <a>list of descendant
             browsing contexts</a> must not be exposed to <a>service workers</a>
             associated with each other.
           </p>
           <p>
             When the <a>receiving browsing context</a> is closed, any
             <a>service workers</a> associated with it and the <a>browsing
-            contexts</a> in its <a>list of descendent browsing contexts</a>
+            contexts</a> in its <a>list of descendant browsing contexts</a>
             MUST be unregistered and terminated. Any browsing state associated
             with the <a>receiving browsing context</a> and the <a>browsing
-            contexts</a> in its <a>list of descendent browsing contexts</a>,
+            contexts</a> in its <a>list of descendant browsing contexts</a>,
             including <a>session history</a>, the <a>cookie store</a>, any
             <a>HTTP authentication</a> state, the <a>application cache</a>, any
             <a>databases</a>, the <a>session storage areas</a>, the <a>local

--- a/index.html
+++ b/index.html
@@ -331,7 +331,8 @@
       <p>
         The terms <dfn><a href=
         "https://www.w3.org/TR/html5/browsers.html#application-cache">application
-        cache</a></dfn>, <dfn data-lt="browsing context|browsing contexts"><a href=
+        cache</a></dfn>, <dfn data-lt=
+        "browsing context|browsing contexts"><a href=
         "http://www.w3.org/TR/html5/browsers.html#browsing-context">browsing
         context</a></dfn>, <dfn><a href=
         "http://www.w3.org/TR/html5/webappapis.html#event-handlers">event
@@ -378,9 +379,15 @@
         "http://www.w3.org/TR/html51/infrastructure.html#in-parallel">in
         parallel</a></dfn> and <dfn><a href=
         "https://www.w3.org/TR/html51/webappapis.html#task-source">task
-        source</a></dfn>, <dfn><a href="https://www.w3.org/TR/html51/browsers.html#ancestor-browsing-context">ancestor browsing context</a></dfn>, <dfn><a href=
+        source</a></dfn>, <dfn><a href=
+        "https://www.w3.org/TR/html51/browsers.html#ancestor-browsing-context">ancestor
+        browsing context</a></dfn>, <dfn><a href=
         "https://www.w3.org/TR/html5/browsers.html#nested-browsing-contexts">nested
-        browsing context</a></dfn>, and <dfn><a href="https://www.w3.org/TR/html51/browsers.html#list-of-the-descendant-browsing-contexts">list of descendent browsing contexts</a></dfn>, and <dfn><a href="https://www.w3.org/TR/html51/browsers.html#creating-a-new-browsing-context">creating a new browsing context</a></dfn> are defined in [[!HTML51]].
+        browsing context</a></dfn>, and <dfn><a href=
+        "https://www.w3.org/TR/html51/browsers.html#list-of-the-descendant-browsing-contexts">
+        list of descendent browsing contexts</a></dfn>, and <dfn><a href=
+        "https://www.w3.org/TR/html51/browsers.html#creating-a-new-browsing-context">
+        creating a new browsing context</a></dfn> are defined in [[!HTML51]].
       </p>
       <p>
         The terms <dfn><code><a href=
@@ -974,12 +981,14 @@
           <p>
             The <dfn for="Presentation"><code>receiver</code></dfn> attribute
             MUST return the <a><code>PresentationReceiver</code></a> instance
-            associated with the <a>receiving browsing context</a> and created by
-            the <a>receiving user agent</a> when the <a>receiving browsing
-            context</a> is <a data-lt="create a receiving browsing
-            context">created</a>. In any other <a>browsing context</a>
-            (including <a data-lt="nested browsing context">nested browsing contexts</a> of the <a>receiving
-            browsing context</a>) it MUST return <code>null</code>.
+            associated with the <a>receiving browsing context</a> and created
+            by the <a>receiving user agent</a> when the <a>receiving browsing
+            context</a> is <a data-lt=
+            "create a receiving browsing context">created</a>. In any other
+            <a>browsing context</a> (including <a data-lt=
+            "nested browsing context">nested browsing contexts</a> of the
+            <a>receiving browsing context</a>) it MUST return
+            <code>null</code>.
           </p>
           <p class="note">
             Web developers can use <code>Navigator.presentation.receiver</code>
@@ -2706,8 +2715,10 @@
             </dd>
           </dl>
           <ol>
-            <li><a data-lt="creating a new browsing context">Create</a> a new <a>top-level browsing context</a> <var>C</var>,
-            set to display content on <var>D</var>.
+            <li>
+              <a data-lt="creating a new browsing context">Create</a> a new
+              <a>top-level browsing context</a> <var>C</var>, set to display
+              content on <var>D</var>.
             </li>
             <li>Set the <a>session history</a> of <var>C</var> to be the empty
             list.
@@ -2750,12 +2761,13 @@
           </ol>
           <p>
             All <a data-lt="nested browsing context">nested browsing
-            contexts</a> <a data-lt="creating a new browsing context">created</a> by
-            the presented document, i.e. that have the <a>receiving browsing
-            context</a> as their <a data-lt="ancestor browsing
-            context">top-level ancestor</a>, MUST also have restrictions 2-4
-            above.  All of these <a>browsing contexts</a> MUST also share the same
-            browsing state (storage) for features 5-10 listed above.
+            contexts</a> <a data-lt=
+            "creating a new browsing context">created</a> by the presented
+            document, i.e. that have the <a>receiving browsing context</a> as
+            their <a data-lt="ancestor browsing context">top-level
+            ancestor</a>, MUST also have restrictions 2-4 above. All of these
+            <a>browsing contexts</a> MUST also share the same browsing state
+            (storage) for features 5-10 listed above.
           </p>
           <p>
             <a>Window clients</a> and <a>worker clients</a> associated with the
@@ -2764,14 +2776,14 @@
             associated with each other.
           </p>
           <p>
-            When the <a>receiving browsing context</a> is closed, any <a>service
-            workers</a> associated with it and the <a>browsing contexts</a> in
-            its <a>list of descendent browsing contexts</a> MUST be unregistered
-            and terminated.  Any browsing state associated with the <a>receiving
-            browsing context</a> and the <a>browsing contexts</a> in its <a>list of descendent
-            browsing contexts</a>, including <a>session history</a>,
-            the <a>cookie store</a>, any <a>HTTP authentication</a> state,
-            the <a>application cache</a>, any
+            When the <a>receiving browsing context</a> is closed, any
+            <a>service workers</a> associated with it and the <a>browsing
+            contexts</a> in its <a>list of descendent browsing contexts</a>
+            MUST be unregistered and terminated. Any browsing state associated
+            with the <a>receiving browsing context</a> and the <a>browsing
+            contexts</a> in its <a>list of descendent browsing contexts</a>,
+            including <a>session history</a>, the <a>cookie store</a>, any
+            <a>HTTP authentication</a> state, the <a>application cache</a>, any
             <a>databases</a>, the <a>session storage areas</a>, the <a>local
             storage areas</a>, the <a>list of registered service worker
             registrations</a> and the <a>caches</a> MUST be discarded and not


### PR DESCRIPTION
Addresses Issue #387: Well defined environment for nested contexts of the receiving browsing context?

This applies the restrictions placed on the receiving browsing context to child browsing contexts of that context.   It also clarifies that `navigator.presentation.receiver` should be `null` in those contexts.

Please check my terminology :)
