### PR TITLE
Added change log section with list of changes since first CR

### DIFF
--- a/index.html
+++ b/index.html
@@ -144,16 +144,15 @@
     </section>
     <section id="sotd">
       <p>
-        Since publication as Working Draft on <a href=
-        "http://www.w3.org/TR/2016/WD-presentation-api-20160510/">10 May
-        2016</a>, the Working Group has added a new URL fallback mechanism for
-        requests to initiate or reconnect to a presentation, re-written the
-        algorithm to create a receiving browsing context, clarified
-        interactions between iframes and the sandboxing flag, and resolved to
-        postpone new features currently mentioned in the <a href=
-        "https://github.com/w3c/presentation-api/issues">group's issue
-        tracker</a> to a possible future version. The Working Group also made
-        further progress on the test suite.
+        Since publication as Candidate Recommendation on <a href=
+        "http://www.w3.org/TR/2016/CR-presentation-api-20160714/">14 July
+        2016</a>, the Working Group updated most algorithms in the spec to fix
+        issues identified through testing and implementation feedback.
+        Interfaces defined in this document did not change, except
+        <code>PresentationConnectionClosedReason</code> and
+        <code>PresentationConnectionClosedEvent</code>, which were renamed to
+        improve consistency with the rest of the Web platform. See the <a href=
+        "#changes-since-14-july-2016">list of changes</a> for details.
       </p>
       <p>
         No feature has been identified as being <strong>at risk</strong>.
@@ -495,7 +494,8 @@
       </p>
       <p>
         The terms <dfn><a href=
-        "https://heycam.github.io/webidl/#dfn-throw">throw</a></dfn>, <dfn><a href=
+        "https://heycam.github.io/webidl/#dfn-throw">throw</a></dfn>,
+        <dfn><a href=
         "https://heycam.github.io/webidl/#idl-promise">Promise</a></dfn>,
         <dfn><a href=
         "https://heycam.github.io/webidl/#idl-ArrayBuffer">ArrayBuffer</a></dfn>,
@@ -3378,6 +3378,135 @@
           </ol>
         </dd>
       </dl>
+    </section>
+    <section class="appendix informative">
+      <h2>
+        Change log
+      </h2>
+      <p>
+        This section lists changes made to the spec since it was first
+        published as Candidate Recommendation in July 2016, with links to
+        related issues on the group's issue tracker.
+      </p>
+      <section>
+        <h3>
+          Changes since 14 July 2016
+        </h3>
+        <ul>
+          <li>Moved sandboxing flag checks to PresentationRequest constructor
+          (<a href=
+          "https://github.com/w3c/presentation-api/issues/#379">#379</a>,
+          <a href=
+          "https://github.com/w3c/presentation-api/issues/#398">#398</a>)
+          </li>
+          <li>Updated normative references to target stable specifications
+          (<a href=
+          "https://github.com/w3c/presentation-api/issues/#295">#295</a>,
+          <a href=
+          "https://github.com/w3c/presentation-api/issues/#396">#396</a>)
+          </li>
+          <li>Made display selection algorithm reject in ancestor and
+          descendant browsing context (<a href=
+          "https://github.com/w3c/presentation-api/issues/#394">#394</a>)
+          </li>
+          <li>Renamed PresentationConnectionClosedReason to
+          PresentationConnectionCloseReason (<a href=
+          "https://github.com/w3c/presentation-api/issues/#393">#393</a>)
+          </li>
+          <li>Fixed getAvailability and monitoring algorithms (<a href=
+          "https://github.com/w3c/presentation-api/issues/#335">#335</a>,
+          <a href=
+          "https://github.com/w3c/presentation-api/issues/#381">#381</a>,
+          <a href=
+          "https://github.com/w3c/presentation-api/issues/#382">#382</a>,
+          <a href=
+          "https://github.com/w3c/presentation-api/issues/#383">#383</a>,
+          <a href=
+          "https://github.com/w3c/presentation-api/issues/#387">#387</a>,
+          <a href=
+          "https://github.com/w3c/presentation-api/issues/#388">#388</a>,
+          <a href=
+          "https://github.com/w3c/presentation-api/issues/#392">#392</a>)
+          </li>
+          <li>Assigned correct JavaScript realm to re-used objects (<a href=
+          "https://github.com/w3c/presentation-api/issues/#391">#391</a>)
+          </li>
+          <li>Clarified display of insecure contexts in UX guidelines
+            (<a href="https://github.com/w3c/presentation-api/issues/#380">#380</a>)
+          </li>
+          <li>Set the state of receiving presentation connections to terminated
+          before unload (<a href=
+          "https://github.com/w3c/presentation-api/issues/#374">#374</a>)
+          </li>
+          <li>Defined environment for nested contexts of the receiving browsing
+          context (<a href=
+          "https://github.com/w3c/presentation-api/issues/#367">#367</a>)
+          </li>
+          <li>Removed [SameObject] for receiver (<a href=
+          "https://github.com/w3c/presentation-api/issues/#365">#365</a>)
+          </li>
+          <li>Replaced DOMString with USVString for PresentationRequest URLs
+          (<a href=
+          "https://github.com/w3c/presentation-api/issues/#361">#361</a>)
+          </li>
+          <li>Added a presentation task source for events (<a href=
+          "https://github.com/w3c/presentation-api/issues/#360">#360</a>)
+          </li>
+          <li>Changed normative language around UUID generation (<a href=
+          "https://github.com/w3c/presentation-api/issues/#346">#346</a>)
+          </li>
+          <li>Added failure reason to close message (<a href=
+          "https://github.com/w3c/presentation-api/issues/#344">#344</a>)
+          </li>
+          <li>Added error handling to establish a presentation connection
+          algorithm (<a href=
+          "https://github.com/w3c/presentation-api/issues/#343">#343</a>)
+          </li>
+          <li>Made navigator.presentation mandatory (<a href=
+          "https://github.com/w3c/presentation-api/issues/#341">#341</a>)
+          </li>
+          <li>Used current settings object in steps that require a settings
+          object (<a href=
+          "https://github.com/w3c/presentation-api/issues/#336">#336</a>)
+          </li>
+          <li>Updated security check step to handle multiple URLs case
+            (<a href="https://github.com/w3c/presentation-api/issues/#329">#329</a>)
+          </li>
+          <li>Made PresentationConnection.id mandatory (<a href=
+          "https://github.com/w3c/presentation-api/issues/#325">#325</a>)
+          </li>
+          <li>Renamed PresentationConnectionClosedEvent to
+          PresentationConnectionCloseEvent (<a href=
+          "https://github.com/w3c/presentation-api/issues/#324">#324</a>)
+          </li>
+          <li>Added an implementation note for advertising and rendering a user
+          friendly display name (<a href=
+          "https://github.com/w3c/presentation-api/issues/#315">#315</a>)
+          </li>
+          <li>Added note for presentation detection (<a href=
+          "https://github.com/w3c/presentation-api/issues/#303">#303</a>)
+          </li>
+          <li>Various editorial updates (<a href=
+          "https://github.com/w3c/presentation-api/issues/#334">#334</a>,
+          <a href=
+          "https://github.com/w3c/presentation-api/issues/#337">#337</a>,
+          <a href=
+          "https://github.com/w3c/presentation-api/issues/#339">#339</a>,
+          <a href=
+          "https://github.com/w3c/presentation-api/issues/#340">#340</a>,
+          <a href=
+          "https://github.com/w3c/presentation-api/issues/#342">#342</a>,
+          <a href=
+          "https://github.com/w3c/presentation-api/issues/#359">#359</a>,
+          <a href=
+          "https://github.com/w3c/presentation-api/issues/#363">#363</a>,
+          <a href=
+          "https://github.com/w3c/presentation-api/issues/#366">#366</a>,
+          <a href=
+          "https://github.com/w3c/presentation-api/issues/#397">#397</a>)
+          </li>
+        </ul>
+      </section>
     </section>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -3395,115 +3395,115 @@
         <ul>
           <li>Moved sandboxing flag checks to PresentationRequest constructor
           (<a href=
-          "https://github.com/w3c/presentation-api/issues/#379">#379</a>,
+          "https://github.com/w3c/presentation-api/issues/379">#379</a>,
           <a href=
-          "https://github.com/w3c/presentation-api/issues/#398">#398</a>)
+          "https://github.com/w3c/presentation-api/issues/398">#398</a>)
           </li>
           <li>Updated normative references to target stable specifications
           (<a href=
-          "https://github.com/w3c/presentation-api/issues/#295">#295</a>,
+          "https://github.com/w3c/presentation-api/issues/295">#295</a>,
           <a href=
-          "https://github.com/w3c/presentation-api/issues/#396">#396</a>)
+          "https://github.com/w3c/presentation-api/issues/396">#396</a>)
           </li>
           <li>Made display selection algorithm reject in ancestor and
           descendant browsing context (<a href=
-          "https://github.com/w3c/presentation-api/issues/#394">#394</a>)
+          "https://github.com/w3c/presentation-api/issues/394">#394</a>)
           </li>
           <li>Renamed PresentationConnectionClosedReason to
           PresentationConnectionCloseReason (<a href=
-          "https://github.com/w3c/presentation-api/issues/#393">#393</a>)
+          "https://github.com/w3c/presentation-api/issues/393">#393</a>)
           </li>
           <li>Fixed getAvailability and monitoring algorithms (<a href=
-          "https://github.com/w3c/presentation-api/issues/#335">#335</a>,
+          "https://github.com/w3c/presentation-api/issues/335">#335</a>,
           <a href=
-          "https://github.com/w3c/presentation-api/issues/#381">#381</a>,
+          "https://github.com/w3c/presentation-api/issues/381">#381</a>,
           <a href=
-          "https://github.com/w3c/presentation-api/issues/#382">#382</a>,
+          "https://github.com/w3c/presentation-api/issues/382">#382</a>,
           <a href=
-          "https://github.com/w3c/presentation-api/issues/#383">#383</a>,
+          "https://github.com/w3c/presentation-api/issues/383">#383</a>,
           <a href=
-          "https://github.com/w3c/presentation-api/issues/#387">#387</a>,
+          "https://github.com/w3c/presentation-api/issues/387">#387</a>,
           <a href=
-          "https://github.com/w3c/presentation-api/issues/#388">#388</a>,
+          "https://github.com/w3c/presentation-api/issues/388">#388</a>,
           <a href=
-          "https://github.com/w3c/presentation-api/issues/#392">#392</a>)
+          "https://github.com/w3c/presentation-api/issues/392">#392</a>)
           </li>
           <li>Assigned correct JavaScript realm to re-used objects (<a href=
-          "https://github.com/w3c/presentation-api/issues/#391">#391</a>)
+          "https://github.com/w3c/presentation-api/issues/391">#391</a>)
           </li>
           <li>Clarified display of insecure contexts in UX guidelines
-            (<a href="https://github.com/w3c/presentation-api/issues/#380">#380</a>)
+            (<a href="https://github.com/w3c/presentation-api/issues/380">#380</a>)
           </li>
           <li>Set the state of receiving presentation connections to terminated
           before unload (<a href=
-          "https://github.com/w3c/presentation-api/issues/#374">#374</a>)
+          "https://github.com/w3c/presentation-api/issues/374">#374</a>)
           </li>
           <li>Defined environment for nested contexts of the receiving browsing
           context (<a href=
-          "https://github.com/w3c/presentation-api/issues/#367">#367</a>)
+          "https://github.com/w3c/presentation-api/issues/367">#367</a>)
           </li>
           <li>Removed [SameObject] for receiver (<a href=
-          "https://github.com/w3c/presentation-api/issues/#365">#365</a>)
+          "https://github.com/w3c/presentation-api/issues/365">#365</a>)
           </li>
           <li>Replaced DOMString with USVString for PresentationRequest URLs
           (<a href=
-          "https://github.com/w3c/presentation-api/issues/#361">#361</a>)
+          "https://github.com/w3c/presentation-api/issues/361">#361</a>)
           </li>
           <li>Added a presentation task source for events (<a href=
-          "https://github.com/w3c/presentation-api/issues/#360">#360</a>)
+          "https://github.com/w3c/presentation-api/issues/360">#360</a>)
           </li>
           <li>Changed normative language around UUID generation (<a href=
-          "https://github.com/w3c/presentation-api/issues/#346">#346</a>)
+          "https://github.com/w3c/presentation-api/issues/346">#346</a>)
           </li>
           <li>Added failure reason to close message (<a href=
-          "https://github.com/w3c/presentation-api/issues/#344">#344</a>)
+          "https://github.com/w3c/presentation-api/issues/344">#344</a>)
           </li>
           <li>Added error handling to establish a presentation connection
           algorithm (<a href=
-          "https://github.com/w3c/presentation-api/issues/#343">#343</a>)
+          "https://github.com/w3c/presentation-api/issues/343">#343</a>)
           </li>
           <li>Made navigator.presentation mandatory (<a href=
-          "https://github.com/w3c/presentation-api/issues/#341">#341</a>)
+          "https://github.com/w3c/presentation-api/issues/341">#341</a>)
           </li>
           <li>Used current settings object in steps that require a settings
           object (<a href=
-          "https://github.com/w3c/presentation-api/issues/#336">#336</a>)
+          "https://github.com/w3c/presentation-api/issues/336">#336</a>)
           </li>
           <li>Updated security check step to handle multiple URLs case
-            (<a href="https://github.com/w3c/presentation-api/issues/#329">#329</a>)
+            (<a href="https://github.com/w3c/presentation-api/issues/329">#329</a>)
           </li>
           <li>Made PresentationConnection.id mandatory (<a href=
-          "https://github.com/w3c/presentation-api/issues/#325">#325</a>)
+          "https://github.com/w3c/presentation-api/issues/325">#325</a>)
           </li>
           <li>Renamed PresentationConnectionClosedEvent to
           PresentationConnectionCloseEvent (<a href=
-          "https://github.com/w3c/presentation-api/issues/#324">#324</a>)
+          "https://github.com/w3c/presentation-api/issues/324">#324</a>)
           </li>
           <li>Added an implementation note for advertising and rendering a user
           friendly display name (<a href=
-          "https://github.com/w3c/presentation-api/issues/#315">#315</a>)
+          "https://github.com/w3c/presentation-api/issues/315">#315</a>)
           </li>
           <li>Added note for presentation detection (<a href=
-          "https://github.com/w3c/presentation-api/issues/#303">#303</a>)
+          "https://github.com/w3c/presentation-api/issues/303">#303</a>)
           </li>
           <li>Various editorial updates (<a href=
-          "https://github.com/w3c/presentation-api/issues/#334">#334</a>,
+          "https://github.com/w3c/presentation-api/issues/334">#334</a>,
           <a href=
-          "https://github.com/w3c/presentation-api/issues/#337">#337</a>,
+          "https://github.com/w3c/presentation-api/issues/337">#337</a>,
           <a href=
-          "https://github.com/w3c/presentation-api/issues/#339">#339</a>,
+          "https://github.com/w3c/presentation-api/issues/339">#339</a>,
           <a href=
-          "https://github.com/w3c/presentation-api/issues/#340">#340</a>,
+          "https://github.com/w3c/presentation-api/issues/340">#340</a>,
           <a href=
-          "https://github.com/w3c/presentation-api/issues/#342">#342</a>,
+          "https://github.com/w3c/presentation-api/issues/342">#342</a>,
           <a href=
-          "https://github.com/w3c/presentation-api/issues/#359">#359</a>,
+          "https://github.com/w3c/presentation-api/issues/359">#359</a>,
           <a href=
-          "https://github.com/w3c/presentation-api/issues/#363">#363</a>,
+          "https://github.com/w3c/presentation-api/issues/363">#363</a>,
           <a href=
-          "https://github.com/w3c/presentation-api/issues/#366">#366</a>,
+          "https://github.com/w3c/presentation-api/issues/366">#366</a>,
           <a href=
-          "https://github.com/w3c/presentation-api/issues/#397">#397</a>)
+          "https://github.com/w3c/presentation-api/issues/397">#397</a>)
           </li>
         </ul>
       </section>


### PR DESCRIPTION
Publication rules require us to document changes since previous version. We've made a number of changes since publication as Candidate Recommendation in July 2016 and the list of issues and the list of commits are somewhat hard to review. I propose to add a change log section with links to issues, and to slightly update the Status of This Document section to link to it.

