### PR TITLE
Update Service Worker references

### DIFF
--- a/index.html
+++ b/index.html
@@ -610,20 +610,20 @@
       </p>
       <p>
         The terms <dfn data-lt="service worker|service workers"><a href=
-        "https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#dfn-service-worker">
-        service worker</a></dfn>, <dfn data-lt=
+        "https://www.w3.org/TR/service-workers-1/#dfn-service-worker">service
+        worker</a></dfn>, <dfn data-lt=
         "a list of registered service worker registrations|list of registered service worker registrations">
         <a href=
-        "https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#service-worker-registration-lifetime">
+        "https://www.w3.org/TR/service-workers-1/#service-worker-registration-lifetime">
         a list of registered service worker registrations</a></dfn>,
         <dfn><a href=
-        "https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#cache-objects">
-        caches</a></dfn>, <dfn data-lt="window client|window clients"><a href=
-        "https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#dfn-window-client">
-        window client</a></dfn> and <dfn data-lt=
+        "https://www.w3.org/TR/service-workers-1/#cache-objects">caches</a></dfn>,
+        <dfn data-lt="window client|window clients"><a href=
+        "https://www.w3.org/TR/service-workers-1/#dfn-window-client">window
+        client</a></dfn> and <dfn data-lt=
         "worker client|worker clients"><a href=
-        "https://slightlyoff.github.io/ServiceWorker/spec/service_worker/#dfn-worker-client">
-        worker client</a></dfn> are defined in [[!SERVICE-WORKERS]].
+        "https://www.w3.org/TR/service-workers-1/#dfn-worker-client">worker
+        client</a></dfn> are defined in [[!SERVICE-WORKERS]].
       </p>
       <p>
         The term <dfn><a href="http://www.dial-multiscreen.org/">DIAL</a></dfn>


### PR DESCRIPTION
This PR migrates Service Workers references from old Editor's Draft to [Service Workers 1 Working Draft](https://www.w3.org/TR/service-workers-1/).