### PR TITLE
Relaxed CR exit criteria to match known implementation plans

### DIFF
--- a/index.html
+++ b/index.html
@@ -3328,10 +3328,21 @@
         independent, interoperable implementations of each feature. Each
         feature may be implemented by a different set of products, there is no
         requirement that all features be implemented by a single product.
-        Additionally, implementations of the receiving user agent conformance
-        class must include at least one implementation of the <a href=
-        "#1-ua">1-UA</a> mode and one implementation of the <a href=
-        "#2-ua">2-UA</a> mode.
+        Additionally, implementations of the <a>controlling user agent</a>
+        conformance class must include at least one implementation of the
+        <a href="#1-ua">1-UA mode</a>, and one implementation of the <a href=
+        "#2-ua">2-UA mode</a>. <a href="#2-ua">2-UA mode</a> implementations
+        may only support non http/https presentation URLs. Implementations of
+        the <a>receiving user agent</a> conformance class may not include
+        implementations of the <a href="#2-ua">2-UA mode</a>.
+      </p>
+      <p>
+        The API was recently restricted to secure contexts. Deprecation of the
+        API in non secure contexts in early implementations takes time. The
+        group may request transition to Proposed Recommendation with
+        implementations that still expose the API in non secure contexts,
+        provided there exists a timeline to restrict these implementations in
+        the future.
       </p>
       <p>
         For the purposes of these criteria, we define the following terms:
@@ -3389,6 +3400,10 @@
           Changes since 14 July 2016
         </h3>
         <ul>
+          <li>Relaxed exit criteria to match known implementations plans
+          (<a href=
+          "https://github.com/w3c/presentation-api/issues/406">#406</a>)
+          </li>
           <li>The sandboxed top-level navigation browsing context flag and the
           sandboxed modals flag are now set on the receiving browsing context
           to prevent top-level navigation and the ability to spawn new browsing


### PR DESCRIPTION
See related discussion in: https://github.com/w3c/presentation-api/issues/406


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/tidoust/presentation-api/exit-criteria.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/presentation-api/32e1adb...tidoust:0b314ed.html)