### PR TITLE
Change SHOULD to MUST when closing or terminating connections.

### DIFF
--- a/index.html
+++ b/index.html
@@ -2137,7 +2137,7 @@
             closed) while the <a>presentation connection state</a> of
             <var>S</var> is <a for="PresentationConnectionState">connecting</a>
             or <a for="PresentationConnectionState">connected</a>, the <a>user
-            agent</a> SHOULD <a>start closing the presentation connection</a>
+            agent</a> MUST <a>start closing the presentation connection</a>
             <var>S</var> with <a for=
             "PresentationConnectionCloseReason">wentaway</a> as
             <var>closeReason</var> and an empty <var>closeMessage</var>.
@@ -2145,7 +2145,7 @@
           <p>
             If the <a>user agent</a> receives a signal from the <a>destination
             browsing context</a> that a <a>PresentationConnection</a>
-            <var>S</var> is to be closed, it SHOULD <a>close the presentation
+            <var>S</var> is to be closed, it MUST <a>close the presentation
             connection</a> <var>S</var> with <a for=
             "PresentationConnectionCloseReason">closed</a> or <a for=
             "PresentationConnectionCloseReason">wentaway</a> as
@@ -2377,11 +2377,11 @@
           <p>
             If the <a>user agent</a> encounters an unrecoverable error while
             <a data-lt="receive-algorithm">receiving a message</a> through
-            <var>presentationConnection</var>, it SHOULD abruptly <a>close the
+            <var>presentationConnection</var>, it MUST abruptly <a>close the
             presentation connection</a> <var>presentationConnection</var> with
             <a for="PresentationConnectionCloseReason">error</a> as
-            <var>closeReason</var>, and a human readable description of the
-            error encountered as <var>closeMessage</var>.
+            <var>closeReason</var>. It SHOULD use a human readable description
+            of the error encountered as <var>closeMessage</var>.
           </p>
         </section>
         <section>
@@ -2692,7 +2692,7 @@
             When a <a>receiving user agent</a> is to <dfn>send a termination
             confirmation</dfn> for a presentation <var>P</var>, and that
             confirmation was received by a <a>controlling user agent</a>, the
-            <a>controlling user agent</a> SHOULD run the following steps:
+            <a>controlling user agent</a> MUST run the following steps:
           </p>
           <ol>
             <li>For each <var>connection</var> in the <a>set of controlled


### PR DESCRIPTION
Addresses issue #422: Turn SHOULD into MUST for close/terminate messages handling? 

- A UA _must_ close a connection in response to a request from the destination browsing context (either because close() was called, or that context went away).

- A UA _must_ close its connection in response to an unrecoverable network or other error.

- A controlling UA _must_ terminate a connection in response to a termination by the receiving UA.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/w3c/presentation-api/issue-422-must.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/presentation-api/aa7c4e7...bd42352.html)