### PR TITLE
Remove closed connections from the set of presentation controllers.

### DIFF
--- a/index.html
+++ b/index.html
@@ -2548,6 +2548,19 @@
                 "PresentationConnectionState">closed</a>, set it to <a for=
                 "PresentationConnectionState">closed</a>.
                 </li>
+                <li>If the <var>presentationConnection</var> was created as a
+                result of <a>monitoring incoming presentation connections</a>
+                in a <a>receiving browsing context</a>, run the following
+                sub-steps.
+                  <ol>
+                    <li>Remove <var>presentationConnection</var> from the
+                    <a>set of presentation controllers</a>.
+                    </li>
+                    <li>Populate the <a>presentation controllers monitor</a>
+                    with the <a>set of presentation controllers</a>.
+                    </li>
+                  </ol>
+                </li>
                 <li>
                   <a>Fire</a> a <a>trusted event</a> with the name <a for=
                   "PresentationConnectionEvent">close</a>, that uses the


### PR DESCRIPTION
Addresses Issue #419: Behavior of a receiving user agent in reconnecting.

When a `PresentationConnection` is closed, remove it from the set of presentation controllers (and thus the `PresentationConnectionList`).


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/w3c/presentation-api/issue-419-discard-closed.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/presentation-api/aa7c4e7...68ab7d4.html)