### PR TITLE
Allow termination via connections in a connecting state.

### DIFF
--- a/index.html
+++ b/index.html
@@ -2589,8 +2589,9 @@
           <ol>
             <li>If the <a>presentation connection state</a> of
             <var>connection</var> is not <a for="PresentationConnectionState">
-              connected</a> or <a for="PresentationConnectionState">
-              connecting</a>, then abort these steps.
+              connected</a> or <a for=
+              "PresentationConnectionState">connecting</a>, then abort these
+              steps.
             </li>
             <li>Otherwise, for each <var>known connection</var> in the <a>set
             of controlled presentations</a> in the <a>controlling user

--- a/index.html
+++ b/index.html
@@ -2589,7 +2589,8 @@
           <ol>
             <li>If the <a>presentation connection state</a> of
             <var>connection</var> is not <a for="PresentationConnectionState">
-              connected</a>, then abort these steps.
+              connected</a> or <a for="PresentationConnectionState">
+              connecting</a>, then abort these steps.
             </li>
             <li>Otherwise, for each <var>known connection</var> in the <a>set
             of controlled presentations</a> in the <a>controlling user
@@ -2599,7 +2600,8 @@
                 connection</var> and <var>connection</var> are equal, and the
                 <a>presentation connection state</a> of <var>known
                 connection</var> is <a for=
-                "PresentationConnectionState">connected</a>, then <a>queue a
+                "PresentationConnectionState">connected</a> or <a for=
+                "PresentationConnectionState">connecting</a>, then <a>queue a
                 task</a> to run the following steps:
                   <ol>
                     <li>Set the <a>presentation connection state</a> of
@@ -2714,7 +2716,8 @@
               <ol>
                 <li>If the <a>presentation connection state</a> of
                 <var>connection</var> is not <a for=
-                "PresentationConnectionState">connected</a>, then abort the
+                "PresentationConnectionState">connected</a> or <a for=
+                "PresentationConnectionState">connecting</a>, then abort the
                 following steps.
                 </li>
                 <li>Set the <a>presentation connection state</a> of


### PR DESCRIPTION
Addresses Issue #421: Relax `terminate` algorithm to deal with other states?

This allows termination of a presentation by a connection in the `connecting` state in a controlling browsing context.

Presumably if a connection has not been established to the presentation screen, then the connection can be aborted.  If the connection has been established and the presentation started, but the `connected` state change has not yet occurred, that connection can be used to abort or terminate the presentation.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/w3c/presentation-api/issue-421-terminate-reconnect.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/presentation-api/38f2399...e2c6d68.html)