### PR TITLE
Tell ReSpec to use W3C Software and Document License for the spec

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,6 +27,7 @@
             note: 'until April 2015'
           }
         ],
+        license: "w3c-software-doc",
         previousMaturity: 'WD',
         previousPublishDate: '2016-05-10',
         otherLinks: [


### PR DESCRIPTION
The charter of the Second Screen WG is explicit that the group will use the W3C Software and Document License for all its deliverable:
http://www.w3.org/2014/secondscreen/charter-2016.html#licensing

Now, that seems to have fallen through the cracks until now as drafts have actually been published under the more restrictive W3C Document License.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/tidoust/presentation-api/fix-license.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/presentation-api/38f2399...tidoust:f27622b.html)