### PR TITLE
Fix group name and update changelog

### DIFF
--- a/index.html
+++ b/index.html
@@ -76,7 +76,7 @@
           }
         ],
         sotdAfterWGinfo: true,
-        wg: 'Second Screen Presentation Working Group',
+        wg: 'Second Screen Working Group',
         wgURI: 'https://www.w3.org/2014/secondscreen/',
         wgPublicList: 'public-secondscreen',
         wgPatentURI: 'https://www.w3.org/2004/01/pp-impl/74168/status',
@@ -159,7 +159,7 @@
         No feature has been identified as being <strong>at risk</strong>.
       </p>
       <p>
-        The Second Screen Presentation Working Group will complete the <a href=
+        The Second Screen Working Group will refine the <a href=
         "http://w3c-test.org/presentation-api/">test suite</a> for the
         Presentation API during the Candidate Recommendation period and update
         the <a href=
@@ -3406,6 +3406,15 @@
           Changes since 14 July 2016
         </h3>
         <ul>
+          <li>Fixed document license (<a href=
+          "https://github.com/w3c/presentation-api/pull/428">#428</a>)
+          </li>
+          <li>Updated termination algorithm to also discard the receiving
+          browsing context and allow termination in a connecting state
+            (<a href="https://github.com/w3c/presentation-api/issues/421">#421</a>,
+            <a href=
+            "https://github.com/w3c/presentation-api/issues/423">#423</a>)
+          </li>
           <li>Dropped sandboxing section, now integrated in HTML (<a href=
           "https://github.com/w3c/html/issues/437">#437</a> in the Web Platform
           Working Group issue tracker)
@@ -3526,6 +3535,8 @@
           "https://github.com/w3c/presentation-api/issues/340">#340</a>,
           <a href=
           "https://github.com/w3c/presentation-api/issues/342">#342</a>,
+          <a href=
+          "https://github.com/w3c/presentation-api/issues/345">#345</a>,
           <a href=
           "https://github.com/w3c/presentation-api/issues/359">#359</a>,
           <a href=


### PR DESCRIPTION
Working Group is now officially named "Second Screen Working Group".


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/tidoust/presentation-api/fix-groupname.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/presentation-api/ba660b0...tidoust:579e6fe.html)