### PR TITLE
Clarifies restrictions on navigation in receiving browsing contexts.

### DIFF
--- a/index.html
+++ b/index.html
@@ -400,6 +400,11 @@
           "https://www.w3.org/TR/html51/browsers.html#navigated">navigate</a></dfn>
         </li>
         <li>
+          <dfn><a href=
+          "https://www.w3.org/TR/html51/browsers.html#navigating-to-a-fragment-identifier">
+          navigating to a fragment identifier</a></dfn>
+        </li>
+        <li>
           <a href=
           "https://www.w3.org/TR/html51/webappapis.html#navigator-navigator"><dfn>
           <code>Navigator</code></dfn></a>
@@ -2866,8 +2871,7 @@
             <li>Set the <a>session history</a> of <var>C</var> to be the empty
             list.
             </li>
-            <li>Set the <a>sandboxed top-level navigation browsing context
-            flag</a>, the <a>sandboxed modals flag</a>, and the <a>sandboxed
+            <li>Set the <a>sandboxed modals flag</a> and the <a>sandboxed
             auxiliary navigation browsing context flag</a> on <var>C</var>.
             </li>
             <li>If the <a>receiving user agent</a> implements [[!PERMISSIONS]],
@@ -2909,9 +2913,19 @@
             "creating a new browsing context">created</a> by the presented
             document, i.e. that have the <a>receiving browsing context</a> as
             their <a data-lt="top-level browsing context">top-level browsing
-            context</a>, MUST also have restrictions 2-4 above. All of these
-            <a>browsing contexts</a> MUST also share the same browsing state
-            (storage) for features 5-10 listed above.
+            context</a>, MUST also have restrictions 2-4 above. In addition,
+            they MUST have the <a>sandboxed top-level navigation browsing
+            context flag</a> set. All of these <a>browsing contexts</a> MUST
+            also share the same browsing state (storage) for features 5-10
+            listed above.
+          </p>
+          <p>
+            The <a>top-level browsing context</a> MUST NOT be allowed to
+            navigate itself, except by <a>navigating to a fragment
+            identifier</a>. This allows the user to grant permission based on
+            the presentation URL shown when <a data-lt=
+            "select a presentation display">selecting a presentation
+            display</a>.
           </p>
           <p>
             <a>Window clients</a> and <a>worker clients</a> associated with the


### PR DESCRIPTION
Addresses Issue #434: In receiver page, sandboxing flags do not fully block top-level navigation.

This adds two more specific requirements:
- Top level browsing context can't navigate itself to a different URL, except for fragment navigation.
- Nested browsing contexts can't navigate the top level browsing context by setting the _sandboxed top-level navigation browsing context flag_.

There might still be work to do here.  For example, this doesn't directly address server initiated navigation (HTTP redirects).  If we really want to restrict the scope of where the top level document can go, we may want to see if there are applicable mechanisms from Content Security Policy instead of (or in addition to) this language.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/w3c/presentation-api/issue-434-top-level-navigation.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/presentation-api/6c3a68f...8caaa9b.html)