### PR TITLE
Update Blob reference

### DIFF
--- a/index.html
+++ b/index.html
@@ -566,7 +566,7 @@
       </p>
       <p>
         The term <a href=
-        "http://dev.w3.org/2006/webapi/FileAPI/#blob"><dfn><code>Blob</code></dfn></a>
+        "http://dev.w3.org/2006/webapi/FileAPI/#dfn-Blob"><dfn><code>Blob</code></dfn></a>
         is defined in the File API specification [[!FILEAPI]].
       </p>
       <p>


### PR DESCRIPTION
This updates the `Blob` reference to match the latest in the File API spec.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
[Preview](https://s3.amazonaws.com/pr-preview/w3c/presentation-api/blob-ref.html) | [Diff](https://s3.amazonaws.com/pr-preview/w3c/presentation-api/b29f405...9e89a15.html)