### PR TITLE
Ignore a URL with an unsupported scheme

### DIFF
--- a/index.html
+++ b/index.html
@@ -424,6 +424,11 @@
         </li>
         <li>
           <dfn><a href=
+          "https://www.w3.org/TR/html51/infrastructure.html#reparsed">parse a
+          URL</a></dfn>
+        </li>
+        <li>
+          <dfn><a href=
           "https://www.w3.org/TR/html51/webappapis.html#queuing">queue a
           task</a></dfn>
         </li>
@@ -1182,12 +1187,18 @@
               <ol>
                 <li>Resolve <var>U</var> relative to the API base URL specified
                 by the <a>current settings object</a>, and add the resulting
-                absolute URL (if any) to <var>presentationUrls</var>.
+                absolute URL (if any, and if the resulting scheme is supported
+                by the <a>controlling user agent</a>) to
+                <var>presentationUrls</var>.
                 </li>
-                <li>If the resolve a URL algorithm failed, then <a>throw</a> a
-                <a>SyntaxError</a> exception and abort all remaining steps.
+                <li>If the <a>parse a URL</a> algorithm failed, then
+                <a>throw</a> a <a>SyntaxError</a> exception and abort all
+                remaining steps.
                 </li>
               </ol>
+            </li>
+            <li>If <var>presentationUrls</var> is an empty list, then throw a
+            <a>NotSupportedError</a> and abort all remaining steps.
             </li>
             <li>If any member of <var>presentationUrls</var> is not an <a>a
             priori authenticated URL</a>, then throw a <a>SecurityError</a> and

--- a/index.html
+++ b/index.html
@@ -1185,15 +1185,16 @@
             </li>
             <li>For each URL <var>U</var> in <var>urls</var>:
               <ol>
-                <li>Resolve <var>U</var> relative to the API base URL specified
-                by the <a>current settings object</a>, and add the resulting
-                absolute URL (if any, and if the resulting scheme is supported
-                by the <a>controlling user agent</a>) to
-                <var>presentationUrls</var>.
+                <li>let <var>A</var> be an absolute URL that is the result of
+                parsing <var>U</var> relative to the API base URL specified by
+                the <a>current settings object</a>.
                 </li>
                 <li>If the <a>parse a URL</a> algorithm failed, then
                 <a>throw</a> a <a>SyntaxError</a> exception and abort all
                 remaining steps.
+                </li>
+                <li>If <var>A</var>'s scheme is supported by the <a>controlling
+                user agent</a>, add <var>A</var> to <var>presentationUrls</var>.
                 </li>
               </ol>
             </li>


### PR DESCRIPTION
This PR addresses #446.

- A URL with an unsupported scheme is ignored in constructing a PresentationRequest.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/tomoyukilabs/presentation-api/pull/447.html" title="Last updated on Mar 23, 2018, 10:17 AM GMT (cca5eb2)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/presentation-api/447/0919461...tomoyukilabs:cca5eb2.html" title="Last updated on Mar 23, 2018, 10:17 AM GMT (cca5eb2)">Diff</a>