### PR TITLE
Adds sample code for starting a 2nd presentation.

### DIFF
--- a/index.html
+++ b/index.html
@@ -887,6 +887,32 @@
 &lt;/script&gt;
 </pre>
       </section>
+      <section>
+        <h3>
+          Creating a second presentation from the same controlling page
+        </h3>
+        <pre class="example">
+&lt;!-- controller.html --&gt;
+&lt;!-- The same controlling page can create and manage multiple presentations,
+  by calling start() multiple times. --&gt;
+&lt;button id="secondPresentBtn" style="display: none;"&gt;Present Again&lt;/button&gt;
+&lt;script&gt;
+  var secondPresentBtn = document.getElementById("secondPresentBtn");
+  var secondPresUrl = "https://example.com/second-presentation.html";
+  var secondRequest = new PresentationRequest(secondPresUrl);
+  // For simplicity, the logic to handle screen availability for secondRequest
+  // and update the status of secondPresentBtn is omitted.
+  secondPresentBtn.onclick = function () {
+  // Start new presentation, likely on a different screen than the original
+  // request.
+    secondRequest.start().then(setSecondConnection);
+  };
+  function setSecondConnection(newConnection) {
+    // Logic to handle messages to/from second-presentation.html.
+  };
+&lt;/script&gt;
+</pre>
+      </section>
     </section>
     <section>
       <h2>


### PR DESCRIPTION
Addresses Issue #451: Add sample code for single controller to multiple presentations.

Adds a code sample showing how the developer can create a second presentation, from the same controlling page.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/presentation-api/pull/453.html" title="Last updated on Jun 14, 2018, 8:48 PM GMT (18f1e28)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/presentation-api/453/b439c16...18f1e28.html" title="Last updated on Jun 14, 2018, 8:48 PM GMT (18f1e28)">Diff</a>