### PR TITLE
Remove BinaryType enum (already in HTML)

### DIFF
--- a/index.html
+++ b/index.html
@@ -2078,7 +2078,6 @@
         </p>
         <pre class="idl">
           enum PresentationConnectionState { "connecting", "connected", "closed", "terminated" };
-          enum BinaryType { "blob", "arraybuffer" };
 
           [SecureContext, Exposed=Window]
           interface PresentationConnection : EventTarget {


### PR DESCRIPTION
See https://html.spec.whatwg.org/multipage/web-sockets.html#binarytype.

Fixes https://github.com/w3c/presentation-api/issues/456.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/foolip/presentation-api/pull/457.html" title="Last updated on Aug 8, 2018, 1:05 PM GMT (3470b52)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/presentation-api/457/2a686db...foolip:3470b52.html" title="Last updated on Aug 8, 2018, 1:05 PM GMT (3470b52)">Diff</a>