### PR TITLE
Fix respec errors.

### DIFF
--- a/index.html
+++ b/index.html
@@ -2131,8 +2131,7 @@
               <dfn>closed</dfn> means that the <a>presentation connection</a>
               has been closed, or could not be opened. It may be re-opened
               through a call to <a data-link-for=
-              "PresentationRequest">reconnect</a>. No communication is
-              possible.
+              "PresentationRequest">reconnect</a>. No communication is possible.
             </li>
             <li>
               <dfn>terminated</dfn> means that the <a>receiving browsing
@@ -3411,11 +3410,11 @@
         requirement that all features be implemented by a single product.
         Additionally, implementations of the <a>controlling user agent</a>
         conformance class must include at least one implementation of the
-        <a href="#1-ua">1-UA mode</a>, and one implementation of the <a href=
-        "#2-ua">2-UA mode</a>. <a href="#2-ua">2-UA mode</a> implementations
-        may only support non http/https presentation URLs. Implementations of
-        the <a>receiving user agent</a> conformance class may not include
-        implementations of the <a href="#2-ua">2-UA mode</a>.
+        <a>1-UA mode</a>, and one implementation of the <a>2-UA
+        mode</a>. <a>2-UA mode</a> implementations may only support non
+        http/https presentation URLs. Implementations of the <a>receiving user
+        agent</a> conformance class may not include implementations of
+        the <a>2-UA mode</a>.
       </p>
       <p>
         The API was recently restricted to secure contexts. Deprecation of the


### PR DESCRIPTION
Fix ReSpec errors reported for references to "1-UA mode" and "2-UA mode"; these are defined terms and don't need to be manually linked.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/presentation-api/pull/458.html" title="Last updated on Aug 30, 2018, 11:59 PM GMT (5bfe300)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/presentation-api/458/c0cea69...5bfe300.html" title="Last updated on Aug 30, 2018, 11:59 PM GMT (5bfe300)">Diff</a>