### PR TITLE
Revert "Remove BinaryType enum (already in HTML) (#457)"

### DIFF
--- a/index.html
+++ b/index.html
@@ -2078,6 +2078,7 @@
         </p>
         <pre class="idl">
           enum PresentationConnectionState { "connecting", "connected", "closed", "terminated" };
+          enum BinaryType { "blob", "arraybuffer" };
 
           [SecureContext, Exposed=Window]
           interface PresentationConnection : EventTarget {


### PR DESCRIPTION
This reverts commit c0cea69ed17a5584c4486a3551f8e6bb801203fe, landed to address Issue #456.

That commit introduced ReSpec errors:

```
Duplicate definitions of 'arraybuffer' at: 1.
Duplicate definitions of 'blob' at: 1.
```

FYI @foolip


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/presentation-api/pull/459.html" title="Last updated on Aug 31, 2018, 12:04 AM GMT (aa3860c)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/presentation-api/459/c0cea69...aa3860c.html" title="Last updated on Aug 31, 2018, 12:04 AM GMT (aa3860c)">Diff</a>