### PR TITLE
Update [HTML51] and [HTML52] references to [HTML]

### DIFF
--- a/index.html
+++ b/index.html
@@ -319,187 +319,171 @@
         Terminology
       </h2>
       <p>
-        The following terms are defined in [[!HTML51]]:
+        The following terms are defined in [[!HTML]]:
       </p>
       <ul>
         <li>
           <dfn><a href=
-          "https://www.w3.org/TR/html51/browsers.html#active-sandboxing-flag-set">
+          "https://html.spec.whatwg.org/multipage/origin.html#active-sandboxing-flag-set">
           active sandboxing flag set</a></dfn>
         </li>
         <li>
           <dfn><a href=
-          "https://www.w3.org/TR/html51/browsers.html#allowed-to-navigate">allowed
+          "https://html.spec.whatwg.org/multipage/browsers.html#allowed-to-navigate">allowed
           to navigate</a></dfn>
         </li>
         <li>
           <dfn><a href=
-          "https://www.w3.org/TR/html51/browsers.html#allowed-to-show-a-popup">allowed
+          "https://html.spec.whatwg.org/multipage/interaction.html#allowed-to-show-a-popup">allowed
           to show a popup</a></dfn>
         </li>
         <li>
           <dfn><a href=
-          "https://www.w3.org/TR/html51/obsolete.html#application-cache-manifest">
+          "https://html.spec.whatwg.org/multipage/offline.html#application-cache">
           application cache</a></dfn>
         </li>
         <li>
           <dfn data-lt="browsing context|browsing contexts"><a href=
-          "https://www.w3.org/TR/html51/browsers.html#browsing-context">browsing
+          "https://html.spec.whatwg.org/multipage/browsers.html#browsing-context">browsing
           context</a></dfn>
         </li>
         <li>
           <dfn><a href=
-          "https://www.w3.org/TR/html51/browsers.html#creating-a-new-browsing-context">
+          "https://html.spec.whatwg.org/multipage/browsers.html#creating-a-new-browsing-context">
           creating a new browsing context</a></dfn>
         </li>
         <li>
           <dfn><a href=
-          "https://www.w3.org/TR/html51/webappapis.html#current">current
+          "https://html.spec.whatwg.org/multipage/webappapis.html#current">current
           realm</a></dfn>
         </li>
         <li>
           <dfn><a href=
-          "https://www.w3.org/TR/html51/webappapis.html#current-settings-object">
+          "https://html.spec.whatwg.org/multipage/webappapis.html#current-settings-object">
           current settings object</a></dfn>
         </li>
         <li>
           <dfn data-lt="discard"><a href=
-          "https://www.w3.org/TR/html51/browsers.html#a-browsing-context-is-discarded">
+          "https://html.spec.whatwg.org/multipage/window-object.html#a-browsing-context-is-discarded">
           discard a browsing context</a></dfn>
         </li>
         <li>
           <a href=
-          "https://www.w3.org/TR/html51/webappapis.html#events-event-handlers"><dfn>
+          "https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-attributes"><dfn>
           <code>EventHandler</code></dfn></a>
         </li>
         <li>
           <dfn><a href=
-          "https://www.w3.org/TR/html51/webappapis.html#event-handler">event
+          "https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers">event
           handler</a></dfn>
         </li>
         <li>
           <dfn><a href=
-          "https://www.w3.org/TR/html51/webappapis.html#event-handler-event-type">
+          "https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-event-type">
           event handler event type</a></dfn>
         </li>
         <li>
-          <dfn data-lt="fire|fires"><a href=
-          "https://www.w3.org/TR/html51/infrastructure.html#fire">firing an
-          event</a></dfn>
-        </li>
-        <li>
-          <dfn data-lt="fire a simple event"><a href=
-          "https://www.w3.org/TR/html51/webappapis.html#firing-a-simple-event-named-e">
-          firing a simple event</a></dfn>
-        </li>
-        <li>
           <dfn><a href=
-          "https://www.w3.org/TR/html51/infrastructure.html#in-parallel">in
+          "https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in
           parallel</a></dfn>
         </li>
         <li>
           <dfn><a href=
-          "https://www.w3.org/TR/html51/browsers.html#list-of-the-descendant-browsing-contexts">
+          "https://html.spec.whatwg.org/multipage/browsers.html#list-of-the-descendant-browsing-contexts">
           list of descendant browsing contexts</a></dfn>
         </li>
         <li>
           <dfn data-lt="steps to navigate"><a href=
-          "https://www.w3.org/TR/html51/browsers.html#navigated">navigate</a></dfn>
+          "https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigate">navigate</a></dfn>
         </li>
         <li>
           <dfn><a href=
-          "https://www.w3.org/TR/html51/browsers.html#navigating-to-a-fragment-identifier">
+          "https://html.spec.whatwg.org/multipage/browsing-the-web.html#scroll-to-fragid">
           navigating to a fragment identifier</a></dfn>
         </li>
         <li>
           <a href=
-          "https://www.w3.org/TR/html51/webappapis.html#navigator-navigator"><dfn>
+          "https://html.spec.whatwg.org/multipage/system-state.html#navigator"><dfn>
           <code>Navigator</code></dfn></a>
         </li>
         <li>
           <dfn><a href=
-          "https://www.w3.org/TR/html51/browsers.html#nested-browsing-contexts">
+          "https://html.spec.whatwg.org/multipage/browsers.html#nested-browsing-contexts">
           nested browsing context</a></dfn>
         </li>
         <li>
           <dfn><a href=
-          "https://www.w3.org/TR/html51/browsers.html#parse-the-sandboxing-directive">
+          "https://html.spec.whatwg.org/multipage/origin.html#parse-a-sandboxing-directive">
           parse a sandboxing directive</a></dfn>
         </li>
         <li>
           <dfn><a href=
-          "https://www.w3.org/TR/html51/infrastructure.html#reparsed">parse a
+          "https://html.spec.whatwg.org/multipage/urls-and-fetching.html#parse-a-url">parse a
           URL</a></dfn>
         </li>
         <li>
           <dfn><a href=
-          "https://www.w3.org/TR/html51/webappapis.html#queuing">queue a
+          "https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queue a
           task</a></dfn>
         </li>
         <li>
           <dfn><a href=
-          "https://www.w3.org/TR/html51/webappapis.html#relevant-settings-object">
+          "https://html.spec.whatwg.org/multipage/webappapis.html#relevant-settings-object">
           relevant settings object</a></dfn>
         </li>
         <li>
           <dfn><a href=
-          "https://www.w3.org/TR/html51/webappapis.html#responsible-browsing-context">
+          "https://html.spec.whatwg.org/multipage/webappapis.html#responsible-browsing-context">
           responsible browsing context</a></dfn>
         </li>
         <li>
           <dfn><a href=
-          "https://www.w3.org/TR/html51/browsers.html#dom-location-reload">reload
+          "https://html.spec.whatwg.org/multipage/history.html#dom-location-reload">reload
           a document</a></dfn>
         </li>
         <li>
           <dfn><a href=
-          "https://www.w3.org/TR/html51/browsers.html#sandboxed-auxiliary-navigation-browsing-context-flag">
+          "https://html.spec.whatwg.org/multipage/origin.html#sandboxed-auxiliary-navigation-browsing-context-flag">
           sandboxed auxiliary navigation browsing context flag</a></dfn>
         </li>
         <li>
           <dfn><a href=
-          "https://www.w3.org/TR/html51/browsers.html#sandboxed-top-level-navigation-browsing-context-flag">
-          sandboxed top-level navigation browsing context flag</a></dfn>
+          "https://html.spec.whatwg.org/multipage/origin.html#sandboxed-top-level-navigation-without-user-activation-browsing-context-flag">
+          sandboxed top-level navigation without user activation browsing context flag</a></dfn>
         </li>
         <li>
           <dfn><a href=
-          "https://www.w3.org/TR/html51/browsers.html#sandboxed-modals-flag">sandboxed
+          "https://html.spec.whatwg.org/multipage/origin.html#sandboxed-modals-flag">sandboxed
           modals flag</a></dfn>
         </li>
         <li>
           <dfn><a href=
-          "https://www.w3.org/TR/html52/browsers.html#sandboxed-presentation-browsing-context-flag">
-          sandboxed presentation browsing context flag</a></dfn> (defined in
-          [[!HTML52]])
+          "https://html.spec.whatwg.org/multipage/origin.html#sandboxed-presentation-browsing-context-flag">
+          sandboxed presentation browsing context flag</a></dfn>
         </li>
         <li>
           <dfn><a href=
-          "https://www.w3.org/TR/html51/browsers.html#sandboxing-flag-set">sandboxing
+          "https://html.spec.whatwg.org/multipage/origin.html#sandboxing-flag-set">sandboxing
           flag set</a></dfn>
         </li>
         <li>
           <dfn><a href=
-          "https://www.w3.org/TR/html51/browsers.html#session-history">session
+          "https://html.spec.whatwg.org/multipage/history.html#session-history">session
           history</a></dfn>
         </li>
         <li>
           <dfn><a href=
-          "https://www.w3.org/TR/html51/webappapis.html#task-source">task
+          "https://html.spec.whatwg.org/multipage/webappapis.html#task-source">task
           source</a></dfn>
         </li>
         <li>
           <dfn><a href=
-          "https://www.w3.org/TR/html51/browsers.html#top-level-browsing-context">
+          "https://html.spec.whatwg.org/multipage/browsers.html#top-level-browsing-context">
           top-level browsing context</a></dfn>
         </li>
         <li>
           <dfn><a href=
-          "https://www.w3.org/TR/html51/infrastructure.html#trusted">trusted
-          event</a></dfn>
-        </li>
-        <li>
-          <dfn><a href=
-          "https://www.w3.org/TR/html51/browsers.html#unloaded">unload a
+          "https://html.spec.whatwg.org/#unload-a-document">unload a
           document</a></dfn>
         </li>
       </ul>
@@ -509,12 +493,17 @@
         realm</a></dfn> is defined in [[!ECMASCRIPT]].
       </p>
       <p>
-        The terms <a href=
+        The terms and concepts <a href=
         "https://dom.spec.whatwg.org/#eventtarget"><dfn><code>EventTarget</code></dfn></a>,
         <a href=
         "https://dom.spec.whatwg.org/#event"><dfn><code>Event</code></dfn></a>,
         <a href=
-        "https://dom.spec.whatwg.org/#dictdef-eventinit"><dfn><code>EventInit</code></dfn></a>
+        "https://dom.spec.whatwg.org/#dictdef-eventinit"><dfn><code>EventInit</code></dfn></a>,
+        <dfn data-lt="fire|fires an event|fire an event"><a href=
+        "https://dom.spec.whatwg.org/#concept-event-fire">firing an event</a></dfn>,
+        and
+        <dfn data-lt="isTrusted|trusted event"><a href=
+        "https://dom.spec.whatwg.org/#dom-event-istrusted">trusted event</a></dfn>
         are defined in [[!DOM]].
       </p>
       <p>
@@ -2040,8 +2029,8 @@
                     <var>newAvailability</var>.
                     </li>
                     <li>
-                      <a>Fire a simple event</a> named <a>change</a> at
-                      <var>A</var>.
+                      <a>Fire an event</a> named <a>change</a> whose
+                      <a>isTrusted</a> attribute is true at <var>A</var>.
                     </li>
                   </ol>
                 </li>
@@ -2336,9 +2325,9 @@
                 "PresentationConnectionState">connected</a>.
                 </li>
                 <li>
-                  <a>Fire a simple event</a> named <a class=
-                  "PresentationConnectionEvent">connect</a> at
-                  <var>presentationConnection</var>.
+                  <a>Fire an event</a> named <a class=
+                  "PresentationConnectionEvent">connect</a> whose <a>isTrusted</a>
+                  attribute is true at <var>presentationConnection</var>.
                 </li>
               </ol>
             </li>
@@ -2763,8 +2752,9 @@
                     "PresentationConnectionState">terminated</a>.
                     </li>
                     <li>
-                      <a>Fire a simple event</a> named <code>terminate</code>
-                      at <var>known connection</var>.
+                      <a>Fires an event</a> named <code>terminate</code>
+                      whose <a>isTrusted</a> attribute is true at <var>known
+                      connection</var>.
                     </li>
                   </ol>
                 </li>
@@ -2876,8 +2866,8 @@
                 "PresentationConnectionState">terminated</a>.
                 </li>
                 <li>
-                  <a>Fire a simple event</a> named <code>terminate</code> at
-                  <var>connection</var>.
+                  <a>Fire an event</a> named <code>terminate</code> whose
+                  <a>isTrusted</a> attribute is true at <var>connection</var>.
                 </li>
               </ol>
             </li>
@@ -3056,7 +3046,7 @@
             document, i.e. that have the <a>receiving browsing context</a> as
             their <a data-lt="top-level browsing context">top-level browsing
             context</a>, MUST also have restrictions 2-4 above. In addition,
-            they MUST have the <a>sandboxed top-level navigation browsing
+            they MUST have the <a>sandboxed top-level navigation without user activation browsing
             context flag</a> set. All of these <a>browsing contexts</a> MUST
             also share the same browsing state (storage) for features 5-10
             listed above.
@@ -3375,7 +3365,7 @@
               click to trigger a request to start an unwanted presentation.
             </p>
             <p>
-              The <a>sandboxed top-level navigation browsing context flag</a>
+              The <a>sandboxed top-level navigation without user activation browsing context flag</a>
               is set on the <a>receiving browsing context</a> to enforce that
               the top-level origin of the presentation remains the same during
               the lifetime of the presentation.


### PR DESCRIPTION
Apart from direct mapping:

- "firing an event" concept moved to [DOM]
- "firing a simple event named e" concept replaced with "fire an event" in https://github.com/whatwg/html/issues/1887
- "sandboxed top-level navigation browsing context flag" is now forked into "with user gesture" and "without user gesture",
  "without user gesture" seems appropriate here. Historical context: https://github.com/w3c/presentation-api/issues/414

Fix #464


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/presentation-api/pull/465.html" title="Last updated on Jun 27, 2019, 7:22 PM UTC (f552cca)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/presentation-api/465/b9dd345...f552cca.html" title="Last updated on Jun 27, 2019, 7:22 PM UTC (f552cca)">Diff</a>