### PR TITLE
Add PresentationConnection#receiverName for controlling UA

### DIFF
--- a/index.html
+++ b/index.html
@@ -1129,7 +1129,7 @@
           [SecureContext, Exposed=Window]
           interface Presentation {
           };
-        
+
 </pre>
         <p>
           The <a data-link-for="Navigator"><code>presentation</code></a>
@@ -1149,7 +1149,7 @@
             partial interface Presentation {
               attribute PresentationRequest? defaultRequest;
             };
-          
+
 </pre>
           <p>
             The <dfn data-dfn-for=
@@ -1193,7 +1193,7 @@
             partial interface Presentation {
               readonly attribute PresentationReceiver? receiver;
             };
-          
+
 </pre>
           <p>
             The <dfn data-dfn-for="Presentation"><code>receiver</code></dfn>
@@ -2872,6 +2872,26 @@
               </ol>
             </li>
           </ol>
+        </section>
+        <section>
+          <h4>
+            Controlling user agent
+          </h4>
+          <p>
+            <a data-lt="controlling user agent">Controlling user agents</a>
+            MUST implement the following partial interface:
+          </p>
+          <pre class="idl idl-controlling-ua">
+            partial interface PresentationConnection {
+              readonly attribute USVString receiverName;
+            };
+
+</pre>
+          <p>
+            The <dfn><code>receiverName</code></dfn> attribute represents the
+            user friendly name for the <a>presentation display</a> associated
+            with the <a>presentation connection</a>.
+          </p>
         </section>
         <section>
           <h4>


### PR DESCRIPTION
This is a proposal to add a receiver name attribute to `PresentationConnection` on the controlling UA side.

`receiverName` is the friendly name of the presentation display associated with the presentation connection, e.g. "Living room TV".