### PR TITLE
Drop BinaryType enum definition

### DIFF
--- a/index.html
+++ b/index.html
@@ -343,6 +343,11 @@
           application cache</a></dfn>
         </li>
         <li>
+          <a href=
+          "https://html.spec.whatwg.org/multipage/web-sockets.html#binarytype">
+          <dfn><code>BinaryType</code></dfn></a>
+        </li>
+        <li>
           <dfn data-lt="browsing context|browsing contexts"><a href=
           "https://html.spec.whatwg.org/multipage/browsers.html#browsing-context">browsing
           context</a></dfn>
@@ -2148,7 +2153,6 @@
         </p>
         <pre class="idl">
           enum PresentationConnectionState { "connecting", "connected", "closed", "terminated" };
-          enum BinaryType { "blob", "arraybuffer" };
 
           [SecureContext, Exposed=Window]
           interface PresentationConnection : EventTarget {
@@ -2171,7 +2175,7 @@
           };
 
 </pre>
-        <div data-dfn-for="PresentationConnection" link-for=
+        <div data-dfn-for="PresentationConnection" data-link-for=
         "PresentationConnection">
           <p>
             The <dfn><code>id</code></dfn> attribute specifies the
@@ -2238,19 +2242,18 @@
           </p>
           <p>
             The <dfn>binaryType</dfn> attribute can take one of the values of
-            <dfn data-dfn-for="">BinaryType</dfn>. When a
+            <a data-link-for="">BinaryType</a>. When a
             <a>PresentationConnection</a> object is created, its
-            <a>binaryType</a> attribute MUST be set to the string "<a link-for=
-            "BinaryType">arraybuffer</a>". On getting, it MUST return the last
+            <a>binaryType</a> attribute MUST be set to the string
+            "<code>arraybuffer</code>". On getting, it MUST return the last
             value it was set to. On setting, the user agent MUST set the
             attribute to the new value.
           </p>
           <div class="note">
             The <a>binaryType</a> attribute allows authors to control how
             binary data is exposed to scripts. By setting the attribute to
-            "<dfn data-dfn-for="BinaryType">blob</dfn>", binary data is
-            returned in <a>Blob</a> form; by setting it to "<dfn data-dfn-for=
-            "BinaryType">arraybuffer</dfn>", it is returned in
+            "<code>blob</code>", binary data is returned in <a>Blob</a> form;
+            by setting it to "<code>arraybuffer</code>", it is returned in
             <a>ArrayBuffer</a> form. The attribute defaults to
             "<code>arraybuffer</code>". This attribute has no effect on data
             sent in a string form.
@@ -2487,17 +2490,16 @@
                 <var>messageData</var> with type <code>DOMString</code>.
                 </li>
                 <li>If <var>messageType</var> is <code>binary</code>, and
-                <a>binaryType</a> attribute is set to "<a link-for=
-                "BinaryType">blob</a>", then initialize <var>event</var>'s
-                <code>data</code> attribute to a new <a>Blob</a> object with
-                <var>messageData</var> as its raw data.
+                <a>binaryType</a> attribute is set to "<code>blob</code>", then
+                initialize <var>event</var>'s <code>data</code> attribute to a
+                new <a>Blob</a> object with <var>messageData</var> as its raw
+                data.
                 </li>
                 <li>If <var>messageType</var> is <code>binary</code>, and
-                <a>binaryType</a> attribute is set to "<a link-for=
-                "BinaryType">arraybuffer</a>", then initialize
-                <var>event</var>'s <code>data</code> attribute to a new
-                <a>ArrayBuffer</a> object whose contents are
-                <var>messageData</var>.
+                <a>binaryType</a> attribute is set to
+                "<code>arraybuffer</code>", then initialize <var>event</var>'s
+                <code>data</code> attribute to a new <a>ArrayBuffer</a> object
+                whose contents are <var>messageData</var>.
                 </li>
               </ol>
             </li>

--- a/index.html
+++ b/index.html
@@ -2175,8 +2175,7 @@
           };
 
 </pre>
-        <div data-dfn-for="PresentationConnection" data-link-for=
-        "PresentationConnection">
+        <div data-dfn-for="PresentationConnection">
           <p>
             The <dfn><code>id</code></dfn> attribute specifies the
             <a>presentation connection</a>'s <a>presentation identifier</a>.
@@ -2242,21 +2241,21 @@
           </p>
           <p>
             The <dfn>binaryType</dfn> attribute can take one of the values of
-            <a data-link-for="">BinaryType</a>. When a
-            <a>PresentationConnection</a> object is created, its
-            <a>binaryType</a> attribute MUST be set to the string
-            "<code>arraybuffer</code>". On getting, it MUST return the last
-            value it was set to. On setting, the user agent MUST set the
-            attribute to the new value.
+            <a>BinaryType</a>. When a <a>PresentationConnection</a> object is
+            created, its
+            <a data-link-for="PresentationConnection">binaryType</a> attribute
+            MUST be set to the string "<code>arraybuffer</code>". On getting,
+            it MUST return the last value it was set to. On setting, the user
+            agent MUST set the attribute to the new value.
           </p>
           <div class="note">
-            The <a>binaryType</a> attribute allows authors to control how
-            binary data is exposed to scripts. By setting the attribute to
-            "<code>blob</code>", binary data is returned in <a>Blob</a> form;
-            by setting it to "<code>arraybuffer</code>", it is returned in
-            <a>ArrayBuffer</a> form. The attribute defaults to
-            "<code>arraybuffer</code>". This attribute has no effect on data
-            sent in a string form.
+            The <a data-link-for="PresentationConnection">binaryType</a>
+            attribute allows authors to control how binary data is exposed to
+            scripts. By setting the attribute to "<code>blob</code>", binary
+            data is returned in <a>Blob</a> form; by setting it to
+            "<code>arraybuffer</code>", it is returned in <a>ArrayBuffer</a>
+            form. The attribute defaults to "<code>arraybuffer</code>". This
+            attribute has no effect on data sent in a string form.
           </div>
           <p>
             When the <dfn data-lt=


### PR DESCRIPTION
The Presentation API defined the `BinaryType` enumeration because it was referencing HTML5. That's no longer needed because the spec now references HTML LS, which defines the enumeration.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/tidoust/presentation-api/pull/473.html" title="Last updated on Sep 28, 2019, 9:11 AM UTC (d7bfc1f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/presentation-api/473/a76a31e...tidoust:d7bfc1f.html" title="Last updated on Sep 28, 2019, 9:11 AM UTC (d7bfc1f)">Diff</a>