### PR TITLE
Add support for allowing same-screen display

### DIFF
--- a/index.html
+++ b/index.html
@@ -1224,11 +1224,15 @@
           Interface <dfn>PresentationRequest</dfn>
         </h3>
         <pre class="idl">
+          dictionary PresentationRequestStartOptions {
+            boolean allowSameScreen = false;
+          };
+
           [SecureContext, Exposed=Window]
           interface PresentationRequest : EventTarget {
             constructor(USVString url);
             constructor(sequence&lt;USVString&gt; urls);
-            Promise&lt;PresentationConnection&gt; start();
+            Promise&lt;PresentationConnection&gt; start(optional PresentationRequestStartOptions options = {} );
             Promise&lt;PresentationConnection&gt; reconnect(USVString presentationId);
             Promise&lt;PresentationAvailability&gt; getAvailability();
 
@@ -1334,6 +1338,11 @@
               object that received the call to <a data-link-for=
               "PresentationRequest">start</a>
             </dd>
+            <dd>
+              <var>options</var>, the <a>PresentationRequestStartOptions</a>
+              dictionary passed to <a data-link-for=
+              "PresentationRequest">start</a>
+            </dd>
             <dt>
               Output
             </dt>
@@ -1367,11 +1376,20 @@
             <a>monitor the list of available presentation displays</a> <a>in
             parallel</a>.
             </li>
+            <li>Let <var>allowSameScreen</var> be false.
+            </li>
+            <li>If <var>options</var> is a dictionary, then set
+            <var>allowSameScreen</var> to <var>option</var>'s
+            <a data-link-for="PresentationRequestStartOptions">
+            allowSameScreen</a>.
+            </li>
             <li>Let <var>presentationUrls</var> be the <a>presentation request
             URLs</a> of <var>presentationRequest</var>.
             </li>
             <li>Request user permission for the use of a <a>presentation
-            display</a> and selection of one presentation display.
+            display</a> and selection of one presentation display. If 
+            <var>allowSameScreen</var> is true, the current display must be
+            listed as an available <a>presentation display</a>.
             </li>
             <li>If either of the following is true:
               <ol>


### PR DESCRIPTION
Addresses #476.
Add an options dictionary to PresentationRequest.start() that indicates the list of available displays that the user can choose from must include the current display.

I thought about plumbing this through to "monitor the list of available presentation displays", but this won't ever be used for getAvailability() and it wasn't clear to me how to mechanically do this in the spec (all ears if there are suggestions though!).

Once there's some consensus that this is the right approach, I'll work on adding a WPT and reference it in this PR description.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/dlibby-/presentation-api/pull/479.html" title="Last updated on May 8, 2020, 7:22 PM UTC (54013d8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/presentation-api/479/1d9fcf3...dlibby-:54013d8.html" title="Last updated on May 8, 2020, 7:22 PM UTC (54013d8)">Diff</a>