### PR TITLE
Fix some HTML tidy formatting

### DIFF
--- a/build/tidyconfig.txt
+++ b/build/tidyconfig.txt
@@ -1,6 +1,7 @@
 char-encoding: utf8
 doctype: html5
 drop-proprietary-attributes: no
+warn-proprietary-attributes: no
 indent: yes
 indent-spaces: 2
 preserve-entities: yes

--- a/index.html
+++ b/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <meta charset="UTF-8" />
+    <meta charset="UTF-8">
     <title>
       Presentation API
     </title>
@@ -329,13 +329,13 @@
         </li>
         <li>
           <dfn><a href=
-          "https://html.spec.whatwg.org/multipage/browsers.html#allowed-to-navigate">allowed
-          to navigate</a></dfn>
+          "https://html.spec.whatwg.org/multipage/browsers.html#allowed-to-navigate">
+          allowed to navigate</a></dfn>
         </li>
         <li>
           <dfn><a href=
-          "https://html.spec.whatwg.org/multipage/interaction.html#allowed-to-show-a-popup">allowed
-          to show a popup</a></dfn>
+          "https://html.spec.whatwg.org/multipage/interaction.html#allowed-to-show-a-popup">
+          allowed to show a popup</a></dfn>
         </li>
         <li>
           <dfn><a href=
@@ -344,13 +344,13 @@
         </li>
         <li>
           <a href=
-          "https://html.spec.whatwg.org/multipage/web-sockets.html#binarytype">
-          <dfn><code>BinaryType</code></dfn></a>
+          "https://html.spec.whatwg.org/multipage/web-sockets.html#binarytype"><dfn>
+          <code>BinaryType</code></dfn></a>
         </li>
         <li>
           <dfn data-lt="browsing context|browsing contexts"><a href=
-          "https://html.spec.whatwg.org/multipage/browsers.html#browsing-context">browsing
-          context</a></dfn>
+          "https://html.spec.whatwg.org/multipage/browsers.html#browsing-context">
+          browsing context</a></dfn>
         </li>
         <li>
           <dfn><a href=
@@ -374,13 +374,13 @@
         </li>
         <li>
           <a href=
-          "https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-attributes"><dfn>
-          <code>EventHandler</code></dfn></a>
+          "https://html.spec.whatwg.org/multipage/webappapis.html#event-handler-attributes">
+          <dfn><code>EventHandler</code></dfn></a>
         </li>
         <li>
           <dfn><a href=
-          "https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers">event
-          handler</a></dfn>
+          "https://html.spec.whatwg.org/multipage/webappapis.html#event-handlers">
+          event handler</a></dfn>
         </li>
         <li>
           <dfn><a href=
@@ -389,8 +389,8 @@
         </li>
         <li>
           <dfn><a href=
-          "https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">in
-          parallel</a></dfn>
+          "https://html.spec.whatwg.org/multipage/infrastructure.html#in-parallel">
+          in parallel</a></dfn>
         </li>
         <li>
           <dfn><a href=
@@ -399,7 +399,8 @@
         </li>
         <li>
           <dfn data-lt="steps to navigate"><a href=
-          "https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigate">navigate</a></dfn>
+          "https://html.spec.whatwg.org/multipage/browsing-the-web.html#navigate">
+          navigate</a></dfn>
         </li>
         <li>
           <dfn><a href=
@@ -408,8 +409,8 @@
         </li>
         <li>
           <a href=
-          "https://html.spec.whatwg.org/multipage/system-state.html#navigator">
-          <dfn><code>Navigator</code></dfn></a>
+          "https://html.spec.whatwg.org/multipage/system-state.html#navigator"><dfn>
+          <code>Navigator</code></dfn></a>
         </li>
         <li>
           <dfn><a href=
@@ -423,13 +424,13 @@
         </li>
         <li>
           <dfn><a href=
-          "https://html.spec.whatwg.org/multipage/urls-and-fetching.html#parse-a-url">parse a
-          URL</a></dfn>
+          "https://html.spec.whatwg.org/multipage/urls-and-fetching.html#parse-a-url">
+          parse a URL</a></dfn>
         </li>
         <li>
           <dfn><a href=
-          "https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">queue a
-          task</a></dfn>
+          "https://html.spec.whatwg.org/multipage/webappapis.html#queue-a-task">
+          queue a task</a></dfn>
         </li>
         <li>
           <dfn><a href=
@@ -443,8 +444,8 @@
         </li>
         <li>
           <dfn><a href=
-          "https://html.spec.whatwg.org/multipage/history.html#dom-location-reload">reload
-          a document</a></dfn>
+          "https://html.spec.whatwg.org/multipage/history.html#dom-location-reload">
+          reload a document</a></dfn>
         </li>
         <li>
           <dfn><a href=
@@ -454,12 +455,13 @@
         <li>
           <dfn><a href=
           "https://html.spec.whatwg.org/multipage/origin.html#sandboxed-top-level-navigation-without-user-activation-browsing-context-flag">
-          sandboxed top-level navigation without user activation browsing context flag</a></dfn>
+          sandboxed top-level navigation without user activation browsing
+          context flag</a></dfn>
         </li>
         <li>
           <dfn><a href=
-          "https://html.spec.whatwg.org/multipage/origin.html#sandboxed-modals-flag">sandboxed
-          modals flag</a></dfn>
+          "https://html.spec.whatwg.org/multipage/origin.html#sandboxed-modals-flag">
+          sandboxed modals flag</a></dfn>
         </li>
         <li>
           <dfn><a href=
@@ -468,13 +470,13 @@
         </li>
         <li>
           <dfn><a href=
-          "https://html.spec.whatwg.org/multipage/origin.html#sandboxing-flag-set">sandboxing
-          flag set</a></dfn>
+          "https://html.spec.whatwg.org/multipage/origin.html#sandboxing-flag-set">
+          sandboxing flag set</a></dfn>
         </li>
         <li>
           <dfn><a href=
-          "https://html.spec.whatwg.org/multipage/history.html#session-history">session
-          history</a></dfn>
+          "https://html.spec.whatwg.org/multipage/history.html#session-history">
+          session history</a></dfn>
         </li>
         <li>
           <dfn><a href=
@@ -487,9 +489,8 @@
           top-level browsing context</a></dfn>
         </li>
         <li>
-          <dfn><a href=
-          "https://html.spec.whatwg.org/#unload-a-document">unload a
-          document</a></dfn>
+          <dfn><a href="https://html.spec.whatwg.org/#unload-a-document">unload
+          a document</a></dfn>
         </li>
       </ul>
       <p>
@@ -505,11 +506,10 @@
         <a href=
         "https://dom.spec.whatwg.org/#dictdef-eventinit"><dfn><code>EventInit</code></dfn></a>,
         <dfn data-lt="fire|fires an event|fire an event"><a href=
-        "https://dom.spec.whatwg.org/#concept-event-fire">firing an event</a></dfn>,
-        and
-        <dfn data-lt="isTrusted|trusted event"><a href=
-        "https://dom.spec.whatwg.org/#dom-event-istrusted">trusted event</a></dfn>
-        are defined in [[!DOM]].
+        "https://dom.spec.whatwg.org/#concept-event-fire">firing an
+        event</a></dfn>, and <dfn data-lt="isTrusted|trusted event"><a href=
+        "https://dom.spec.whatwg.org/#dom-event-istrusted">trusted
+        event</a></dfn> are defined in [[!DOM]].
       </p>
       <p>
         The term <a href=
@@ -2242,11 +2242,11 @@
           <p>
             The <dfn>binaryType</dfn> attribute can take one of the values of
             <a>BinaryType</a>. When a <a>PresentationConnection</a> object is
-            created, its
-            <a data-link-for="PresentationConnection">binaryType</a> attribute
-            MUST be set to the string "<code>arraybuffer</code>". On getting,
-            it MUST return the last value it was set to. On setting, the user
-            agent MUST set the attribute to the new value.
+            created, its <a data-link-for=
+            "PresentationConnection">binaryType</a> attribute MUST be set to
+            the string "<code>arraybuffer</code>". On getting, it MUST return
+            the last value it was set to. On setting, the user agent MUST set
+            the attribute to the new value.
           </p>
           <div class="note">
             The <a data-link-for="PresentationConnection">binaryType</a>
@@ -2324,8 +2324,9 @@
                 </li>
                 <li>
                   <a>Fire an event</a> named <a class=
-                  "PresentationConnectionEvent">connect</a> whose <a>isTrusted</a>
-                  attribute is true at <var>presentationConnection</var>.
+                  "PresentationConnectionEvent">connect</a> whose
+                  <a>isTrusted</a> attribute is true at
+                  <var>presentationConnection</var>.
                 </li>
               </ol>
             </li>
@@ -2747,8 +2748,8 @@
                     "PresentationConnectionState">terminated</a>.
                     </li>
                     <li>
-                      <a>Fires an event</a> named <code>terminate</code>
-                      whose <a>isTrusted</a> attribute is true at <var>known
+                      <a>Fires an event</a> named <code>terminate</code> whose
+                      <a>isTrusted</a> attribute is true at <var>known
                       connection</var>.
                     </li>
                   </ol>
@@ -3041,10 +3042,10 @@
             document, i.e. that have the <a>receiving browsing context</a> as
             their <a data-lt="top-level browsing context">top-level browsing
             context</a>, MUST also have restrictions 2-4 above. In addition,
-            they MUST have the <a>sandboxed top-level navigation without user activation browsing
-            context flag</a> set. All of these <a>browsing contexts</a> MUST
-            also share the same browsing state (storage) for features 5-10
-            listed above.
+            they MUST have the <a>sandboxed top-level navigation without user
+            activation browsing context flag</a> set. All of these <a>browsing
+            contexts</a> MUST also share the same browsing state (storage) for
+            features 5-10 listed above.
           </p>
           <p>
             When the <a>top-level browsing context</a> attempts to navigate to
@@ -3360,10 +3361,11 @@
               click to trigger a request to start an unwanted presentation.
             </p>
             <p>
-              The <a>sandboxed top-level navigation without user activation browsing context flag</a>
-              is set on the <a>receiving browsing context</a> to enforce that
-              the top-level origin of the presentation remains the same during
-              the lifetime of the presentation.
+              The <a>sandboxed top-level navigation without user activation
+              browsing context flag</a> is set on the <a>receiving browsing
+              context</a> to enforce that the top-level origin of the
+              presentation remains the same during the lifetime of the
+              presentation.
             </p>
           </dd>
           <dt>


### PR DESCRIPTION
- Adds warn-proprietary-attributes:  no to the tidy spec (otherwise it refuses to process the spec)
- Re-run tidy resulting in some line wrapping fixes.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/presentation-api/pull/481.html" title="Last updated on Jul 7, 2020, 5:54 PM UTC (609d319)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/presentation-api/481/1d9fcf3...609d319.html" title="Last updated on Jul 7, 2020, 5:54 PM UTC (609d319)">Diff</a>