### PR TITLE
Editorial: fix link to Navigator and update Respec URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <title>
       Presentation API
     </title>
-    <script src="https://www.w3.org/Tools/respec/respec-w3c-common" async=
+    <script src="https://www.w3.org/Tools/respec/respec-w3c" async=
     "async" class="remove"></script>
     <script class="remove">
     var respecConfig = {
@@ -75,10 +75,8 @@
           }
         ],
         sotdAfterWGinfo: true,
-        wg: 'Second Screen Working Group',
-        wgURI: 'https://www.w3.org/2014/secondscreen/',
-        wgPublicList: 'public-secondscreen',
-        wgPatentURI: 'https://www.w3.org/2004/01/pp-impl/74168/status',
+        group: 'secondscreen',
+        xref: ['html', 'webidl'],
         localBiblio: {
           PROMGUIDE: {
             title: 'Writing Promise-Using Specifications',


### PR DESCRIPTION
The update tells ReSpec to look for Navigator in the HTML spec. It also updates the URL of the ReSpec script. Coupled with #482, this should fix ReSpec errors.

Unrelated, the update also reduces the information provided for the boilerplate text to a minimum by asking Respec to fetch the group info itself.

Note the `xref` list will need to be completed once the Presentation API starts using automatic cross-ref linking features instead of maintaining definitions in a separate "Terminology" section as currently done. Relying on the automatic cross-ref linking feature is recommended to detect cross-references to concepts that groups actually did not plan to export to other specs, as well as terms that may no longer exist in other specs. I'll prepare another PR for that.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/tidoust/presentation-api/pull/483.html" title="Last updated on Sep 22, 2020, 12:45 PM UTC (507fdbe)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/presentation-api/483/57ef841...tidoust:507fdbe.html" title="Last updated on Sep 22, 2020, 12:45 PM UTC (507fdbe)">Diff</a>