### PR TITLE
Add note on how presentations without connections should be handled.

### DIFF
--- a/index.html
+++ b/index.html
@@ -2343,6 +2343,19 @@
             and in-order fashion as described in the <a>Send a Message</a> and
             <a>Receive a Message</a> steps below.
           </div>
+          <p class="note">
+            In some cases, the <a>receiving user agent</a> may not support
+            communication with the <a>controlling user agent</a> through the
+            Presentation API. For example, the <a>controlling browsing
+            context</a> and <a>receiving browsing context</a> could use WebRTC
+            or a cloud service to communicate independently of
+            a <a>PresentationConnection</a>. In these cases, after step 3 above,
+            user agents can immediately close the connection with
+            a <a data-link-for= "PresentationConnectionCloseEvent">reason</a>
+            of <a data-link-for="PresentationConnectionCloseReason">error</a>
+            and a <dfn data-link-for="PresentationConnectionCloseEvent">message
+            </dfn> indicating that connections are not supported.
+          </p>
         </section>
         <section>
           <h4>


### PR DESCRIPTION
Addresses Issue #202: Presentations without communication channel

This advises user agents on how to handle presentations where the controlling page cannot communicate with the presentation through the Presentation API. 

Presumably, the presentation request URL contains sufficient information for the two pages to rendezvous through some other mechanism (if they wish to communicate).


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/presentation-api/pull/484.html" title="Last updated on Oct 15, 2020, 12:06 AM UTC (2ec5092)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/presentation-api/484/7cc74aa...2ec5092.html" title="Last updated on Oct 15, 2020, 12:06 AM UTC (2ec5092)">Diff</a>