### PR TITLE
Add note about controlling browsing contexts.

### DIFF
--- a/index.html
+++ b/index.html
@@ -3110,6 +3110,13 @@
             <a>receiving browsing context</a> to prevent most of these
             operations.
           </p>
+          <p class="note">
+            As noted in <a href="#conformance>Conformance</a>, a user agent that
+            is both a <a>controlling user agent</a> and <a>receiving user
+            agent</a> may allow a <a>receiving browsing context</a> to create
+            additional presentations (thus becoming a <a>controlling browsing
+            context</a> as well).
+          </p>
         </section>
       </section>
       <section>

--- a/index.html
+++ b/index.html
@@ -3111,11 +3111,13 @@
             operations.
           </p>
           <p class="note">
-            As noted in <a href="#conformance>Conformance</a>, a user agent that
+            As noted in <a href="#conformance">Conformance</a>, a user agent that
             is both a <a>controlling user agent</a> and <a>receiving user
             agent</a> may allow a <a>receiving browsing context</a> to create
             additional presentations (thus becoming a <a>controlling browsing
-            context</a> as well).
+            context</a> as well).  Web developers can use <a data-lt=
+            "Presentation.receiver">navigator.presentation.receiver</a> to
+            detect when a document is loaded as a receiving browsing context.
           </p>
         </section>
       </section>


### PR DESCRIPTION
This addresses Issue #338: Can the same browsing context act as a controller and receiver?

This adds a note just clarifying that the spec allows a receiving browsing context (created by starting one presentation) to start a second presentation, and thus become a controlling browsing context as well.

Not sure if this belongs in the main body of the specification, as this is a clarification and not a new requirement, but would be fine with putting it there as well.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/presentation-api/pull/487.html" title="Last updated on Oct 26, 2020, 6:33 PM UTC (b651cbd)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/presentation-api/487/7cc74aa...b651cbd.html" title="Last updated on Oct 26, 2020, 6:33 PM UTC (b651cbd)">Diff</a>