### PR TITLE
Updates changelog to prepare for CRD publication.

### DIFF
--- a/index.html
+++ b/index.html
@@ -3333,8 +3333,9 @@
           Changes since 01 June 2017
         </h3>
         <ul>
-          
-          <li>Added a note about receiving browsing contexts starting presentations (<a href="https://github.com/w3c/presentation-api/issues/473">#487</a>)
+          <li>Added a note about receiving browsing contexts starting
+          presentations (<a href=
+          "https://github.com/w3c/presentation-api/issues/473">#487</a>)
           </li>
           <li>Removed the definition of the BinaryType enum (<a href=
           "https://github.com/w3c/presentation-api/issues/473">#473</a>)

--- a/index.html
+++ b/index.html
@@ -5,8 +5,8 @@
     <title>
       Presentation API
     </title>
-    <script src="https://www.w3.org/Tools/respec/respec-w3c" async=
-    "async" class="remove"></script>
+    <script src="https://www.w3.org/Tools/respec/respec-w3c" async="async"
+    class="remove"></script>
     <script class="remove">
     var respecConfig = {
         specStatus: 'ED',
@@ -3559,6 +3559,34 @@
           Changes since 14 July 2016
         </h3>
         <ul>
+          <li>Removed the definition of the BinaryType enum (<a href=
+          "https://github.com/w3c/presentation-api/issues/473">#473</a>)
+          </li>
+          <li>Updated WebIDL to use constructor operations (<a href=
+          "https://github.com/w3c/presentation-api/issues/469">#469</a>)
+          </li>
+          <li>Clarified how receiving browsing contexts are allowed to navigate
+          (<a href=
+          "https://github.com/w3c/presentation-api/issues/461">#461</a>)
+          </li>
+          <li>Added explanatory text to the sample code (<a href=
+          "https://github.com/w3c/presentation-api/issues/460">#460</a>)
+          </li>
+          <li>Added sample code that starts a second presentation from the same
+          controller (<a href=
+          "https://github.com/w3c/presentation-api/issues/453">#453</a>)
+          </li>
+          <li>Updated the steps to construct a PresentationRequest to ignore a
+          URL with an unsupported scheme (<a href=
+          "https://github.com/w3c/presentation-api/issues/447">#447</a>)
+          </li>
+          <li>Clarified restrictions on navigation in receiving browsing
+          contexts (<a href=
+          "https://github.com/w3c/presentation-api/issues/434">#434</a>)
+          </li>
+          <li>Updated WebIDL to use [Exposed=Window] (<a href=
+          "https://github.com/w3c/presentation-api/issues/438">#438</a>)
+          </li>
           <li>Fixed document license (<a href=
           "https://github.com/w3c/presentation-api/pull/428">#428</a>)
           </li>
@@ -3697,7 +3725,29 @@
           <a href=
           "https://github.com/w3c/presentation-api/issues/366">#366</a>,
           <a href=
-          "https://github.com/w3c/presentation-api/issues/397">#397</a>)
+          "https://github.com/w3c/presentation-api/issues/397">#397</a>,
+          <a href=
+          "https://github.com/w3c/presentation-api/issues/429">#429</a>,
+          <a href=
+          "https://github.com/w3c/presentation-api/issues/431">#431</a>,
+          <a href=
+          "https://github.com/w3c/presentation-api/issues/432">#432</a>,
+          <a href=
+          "https://github.com/w3c/presentation-api/issues/433">#433</a>,
+          <a href=
+          "https://github.com/w3c/presentation-api/issues/441">#441</a>,
+          <a href=
+          "https://github.com/w3c/presentation-api/issues/442">#442</a>,
+          <a href=
+          "https://github.com/w3c/presentation-api/issues/443">#443</a>,
+          <a href=
+          "https://github.com/w3c/presentation-api/issues/454">#454</a>,
+          <a href=
+          "https://github.com/w3c/presentation-api/issues/465">#465</a>,
+          <a href=
+          "https://github.com/w3c/presentation-api/issues/482">#482</a>,
+          <a href=
+          "https://github.com/w3c/presentation-api/issues/483">#483</a>)
           </li>
         </ul>
       </section>

--- a/index.html
+++ b/index.html
@@ -3366,8 +3366,6 @@
           "https://github.com/w3c/presentation-api/issues/438">#438</a>)
           </li>
           <li>Various editorial updates (<a href=
-          "https://github.com/w3c/presentation-api/issues/397">#397</a>,
-          <a href=
           "https://github.com/w3c/presentation-api/issues/429">#429</a>,
           <a href=
           "https://github.com/w3c/presentation-api/issues/431">#431</a>,
@@ -3535,7 +3533,9 @@
           <a href=
           "https://github.com/w3c/presentation-api/issues/363">#363</a>,
           <a href=
-          "https://github.com/w3c/presentation-api/issues/366">#366</a>)
+          "https://github.com/w3c/presentation-api/issues/366">#366</a>,
+          <a href=
+          "https://github.com/w3c/presentation-api/issues/397">#397</a>)
           </li>
         </ul>
       </section>

--- a/index.html
+++ b/index.html
@@ -3556,9 +3556,12 @@
       </p>
       <section>
         <h3>
-          Changes since 14 July 2016
+          Changes since 01 June 2017
         </h3>
         <ul>
+          
+          <li>Added a note about receiving browsing contexts starting presentations (<a href="https://github.com/w3c/presentation-api/issues/473">#487</a>)
+          </li>
           <li>Removed the definition of the BinaryType enum (<a href=
           "https://github.com/w3c/presentation-api/issues/473">#473</a>)
           </li>
@@ -3587,6 +3590,40 @@
           <li>Updated WebIDL to use [Exposed=Window] (<a href=
           "https://github.com/w3c/presentation-api/issues/438">#438</a>)
           </li>
+          <li>Various editorial updates (<a href=
+          "https://github.com/w3c/presentation-api/issues/397">#397</a>,
+          <a href=
+          "https://github.com/w3c/presentation-api/issues/429">#429</a>,
+          <a href=
+          "https://github.com/w3c/presentation-api/issues/431">#431</a>,
+          <a href=
+          "https://github.com/w3c/presentation-api/issues/432">#432</a>,
+          <a href=
+          "https://github.com/w3c/presentation-api/issues/433">#433</a>,
+          <a href=
+          "https://github.com/w3c/presentation-api/issues/441">#441</a>,
+          <a href=
+          "https://github.com/w3c/presentation-api/issues/442">#442</a>,
+          <a href=
+          "https://github.com/w3c/presentation-api/issues/443">#443</a>,
+          <a href=
+          "https://github.com/w3c/presentation-api/issues/454">#454</a>,
+          <a href=
+          "https://github.com/w3c/presentation-api/issues/465">#465</a>,
+          <a href=
+          "https://github.com/w3c/presentation-api/issues/482">#482</a>,
+          <a href=
+          "https://github.com/w3c/presentation-api/issues/483">#483</a>,
+          <a href=
+          "https://github.com/w3c/presentation-api/issues/486">#486</a>)
+          </li>
+        </ul>
+      </section>
+      <section>
+        <h3>
+          Changes since 14 July 2016
+        </h3>
+        <ul>
           <li>Fixed document license (<a href=
           "https://github.com/w3c/presentation-api/pull/428">#428</a>)
           </li>
@@ -3723,31 +3760,7 @@
           <a href=
           "https://github.com/w3c/presentation-api/issues/363">#363</a>,
           <a href=
-          "https://github.com/w3c/presentation-api/issues/366">#366</a>,
-          <a href=
-          "https://github.com/w3c/presentation-api/issues/397">#397</a>,
-          <a href=
-          "https://github.com/w3c/presentation-api/issues/429">#429</a>,
-          <a href=
-          "https://github.com/w3c/presentation-api/issues/431">#431</a>,
-          <a href=
-          "https://github.com/w3c/presentation-api/issues/432">#432</a>,
-          <a href=
-          "https://github.com/w3c/presentation-api/issues/433">#433</a>,
-          <a href=
-          "https://github.com/w3c/presentation-api/issues/441">#441</a>,
-          <a href=
-          "https://github.com/w3c/presentation-api/issues/442">#442</a>,
-          <a href=
-          "https://github.com/w3c/presentation-api/issues/443">#443</a>,
-          <a href=
-          "https://github.com/w3c/presentation-api/issues/454">#454</a>,
-          <a href=
-          "https://github.com/w3c/presentation-api/issues/465">#465</a>,
-          <a href=
-          "https://github.com/w3c/presentation-api/issues/482">#482</a>,
-          <a href=
-          "https://github.com/w3c/presentation-api/issues/483">#483</a>)
+          "https://github.com/w3c/presentation-api/issues/366">#366</a>)
           </li>
         </ul>
       </section>


### PR DESCRIPTION
This updates the Presentation API changelog from PR #429 - PR #473.  I'll also add PR #487 once it is merged.

This is to facilitate the publication of a Candidate Recommendation Draft (Issue #488).

I skipped a few PRs that were about reformatting, or fixing ReSpec links.  If there are any relevant PRs I missed, let me know!


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/presentation-api/pull/489.html" title="Last updated on Oct 30, 2020, 7:11 PM UTC (36a5e6e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/presentation-api/489/fd33764...36a5e6e.html" title="Last updated on Oct 30, 2020, 7:11 PM UTC (36a5e6e)">Diff</a>