### PR TITLE
Update SOTD to mention main normative changes since last CR

### DIFF
--- a/index.html
+++ b/index.html
@@ -133,15 +133,15 @@
     <section id="sotd">
       <p>
         Since publication as Candidate Recommendation on <a href=
-        "http://www.w3.org/TR/2016/CR-presentation-api-20160714/">14 July
-        2016</a>, the Working Group updated most algorithms in the spec to fix
-        issues identified through testing and implementation feedback.
-        Interfaces defined in this document did not change, except
-        <code>PresentationConnectionClosedReason</code> and
-        <code>PresentationConnectionClosedEvent</code>, which were renamed to
-        improve consistency with the rest of the Web platform. The API was also
-        restricted to secure contexts. See the <a href=
-        "#changes-since-14-july-2016">list of changes</a> for details.
+        "https://www.w3.org/TR/2017/CR-presentation-api-20170601/">01 June
+        2017</a>, the Working Group updated the steps to construct a
+        <code>PresentationRequest</code> to ignore a URL with an unsupported
+        scheme, and dropped the definition of the <code>BinaryType</code> enum
+        in favor of the one defined in the HTML specification. Other interfaces
+        defined in this document did not change other than to adjust to WebIDL
+        updates. Various clarifications and editorial updates were also made.
+        See the <a href="#changes-since-01-june-2017">list of changes</a> for
+        details.
       </p>
       <p>
         No feature has been identified as being <strong>at risk</strong>.

--- a/index.html
+++ b/index.html
@@ -136,12 +136,13 @@
         "https://www.w3.org/TR/2017/CR-presentation-api-20170601/">01 June
         2017</a>, the Working Group updated the steps to construct a
         <code>PresentationRequest</code> to ignore a URL with an unsupported
-        scheme, and dropped the definition of the <code>BinaryType</code> enum
-        in favor of the one defined in the HTML specification. Other interfaces
-        defined in this document did not change other than to adjust to WebIDL
-        updates. Various clarifications and editorial updates were also made.
-        See the <a href="#changes-since-01-june-2017">list of changes</a> for
-        details.
+        scheme, placed further restrictions on how receiving browsing contexts
+        are allowed to navigate themselves, and dropped the definition of the
+        <code>BinaryType</code> enum in favor of the one defined in the HTML
+        specification. Other interfaces defined in this document did not change
+        other than to adjust to WebIDL updates. Various clarifications and
+        editorial updates were also made. See the <a href=
+        "#changes-since-01-june-2017">list of changes</a> for details.
       </p>
       <p>
         No feature has been identified as being <strong>at risk</strong>.


### PR DESCRIPTION
The Status of This Document section was still talking about changes since the Candidate Recommendation published in 2016. This update adjusts the text to mention main normative changes since the 2017 version, and to point at the right list of changes.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/tidoust/presentation-api/pull/491.html" title="Last updated on Nov 4, 2020, 6:28 PM UTC (dfee939)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/presentation-api/491/736e459...tidoust:dfee939.html" title="Last updated on Nov 4, 2020, 6:28 PM UTC (dfee939)">Diff</a>