### PR TITLE
Update 301 links and test suite URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,8 +47,8 @@
                 href: 'https://github.com/web-platform-tests/wpt/tree/master/presentation-api'
               },
               {
-                value: 'w3c-test.org/presentation-api/',
-                href: 'https://w3c-test.org/presentation-api/'
+                value: 'wpt.live/presentation-api/',
+                href: 'https://wpt.live/presentation-api/'
               }
             ]
           },
@@ -309,13 +309,13 @@
       </h2>
       <p>
         The term <dfn>JavaScript realm</dfn> is used as <a href=
-        "https://tc39.github.io/ecma262/#sec-code-realms" title=
+        "https://tc39.es/ecma262/#sec-code-realms" title=
         "Definition of JavaScript realm in ECMAScript">defined in
         ECMAScript</a> [[!ECMASCRIPT]].
       </p>
       <p>
         The term <dfn>current realm</dfn> is used as <a href=
-        "https://tc39.github.io/ecma262/#current-realm" title=
+        "https://tc39.es/ecma262/#current-realm" title=
         "Definition of current realm in ECMAScript">defined in ECMAScript</a>
         [[!ECMASCRIPT]].
       </p>
@@ -338,7 +338,7 @@
       </p>
       <p>
         The term <dfn>cookie store</dfn> is used as <a href=
-        "http://tools.ietf.org/html/rfc6265#section-4.2" title=
+        "https://tools.ietf.org/html/rfc6265#section-4.2" title=
         "Definition of cookie store in RFC 6265">defined in RFC 6265</a>
         [[!COOKIES]].
       </p>
@@ -1243,7 +1243,7 @@
             request presentation and choose the intended <a>presentation
             display</a> with the same user gesture. For example, the browser
             chrome could allow the user to pick a display from a menu, or allow
-            the user to tap on an <a href="http://nfc-forum.org/">Near Field
+            the user to tap on an <a href="https://nfc-forum.org/">Near Field
             Communications (NFC)</a> enabled display.
           </div>
         </section>
@@ -1726,7 +1726,7 @@
             available presentation displays</dfn> by running the following
             steps:
           </p>
-          <ol link-for="PresentationAvailability">
+          <ol>
             <li>Let <var>availabilitySet</var> be a shallow copy of the <a>set
             of presentation availability objects</a>.
             </li>


### PR DESCRIPTION
301 links need to be updated per publication rules.

The `wpt.live` domain should be more stable than `w3c-test.org`.

This update also fixes an HTML markup error: `link-for` should have been `data-link-for` (otherwise it remains as `link-for` in the generated page, which is invalid HTML). In practice, the attribute was not needed in the section where it appeared. This update removes it.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/tidoust/presentation-api/pull/492.html" title="Last updated on Nov 4, 2020, 11:24 AM UTC (a1c52a5)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/presentation-api/492/736e459...tidoust:a1c52a5.html" title="Last updated on Nov 4, 2020, 11:24 AM UTC (a1c52a5)">Diff</a>