### PR TITLE
Switch to neutral "they" for user

### DIFF
--- a/index.html
+++ b/index.html
@@ -3195,7 +3195,7 @@
         <p>
           The content displayed on the presentation is different from the
           controller. In particular, if the user is logged in in both contexts,
-          then logs out of the <a>controlling browsing context</a>, she will
+          then logs out of the <a>controlling browsing context</a>, they will
           not be automatically logged out from the <a>receiving browsing
           context</a>. Applications that use authentication should pay extra
           care when communicating between devices.


### PR DESCRIPTION
Use of inclusive terminology is strongly encouraged, see:
https://w3c.github.io/manual-of-style/#inclusive


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/tidoust/presentation-api/pull/493.html" title="Last updated on Nov 4, 2020, 11:33 AM UTC (5bac02f)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/presentation-api/493/736e459...tidoust:5bac02f.html" title="Last updated on Nov 4, 2020, 11:33 AM UTC (5bac02f)">Diff</a>