### PR TITLE
Fix refs to "a priori authenticated URL" and "application cache"

### DIFF
--- a/index.html
+++ b/index.html
@@ -76,7 +76,7 @@
         ],
         sotdAfterWGinfo: true,
         group: 'secondscreen',
-        xref: ['dom', 'fileapi', 'mixed-content', 'html', 'url', 'webidl', 'webrtc'],
+        xref: ['dom', 'fileapi', 'secure-contexts', 'html', 'url', 'webidl', 'webrtc'],
         localBiblio: {
           DIAL: {
             title: 'DIscovery And Launch Protocol Specification',
@@ -1075,9 +1075,9 @@
             <li>If <var>presentationUrls</var> is an empty list, then throw a
             {{NotSupportedError}} and abort all remaining steps.
             </li>
-            <li>If any member of <var>presentationUrls</var> is not an <a>a
-            priori authenticated URL</a>, then throw a {{SecurityError}} and
-            abort these steps.
+            <li>If any member of <var>presentationUrls</var> is not a
+            <a>potentially trustworthy URL</a>, then throw a {{SecurityError}}
+            and abort these steps.
             </li>
             <li>Construct a new <a>PresentationRequest</a> object with
             <var>presentationUrls</var> as its <a>presentation request URLs</a>
@@ -2772,9 +2772,6 @@
             <li>Create a new empty store for <var>C</var> to hold <a>HTTP
             authentication</a> states.
             </li>
-            <li>Create a new empty <a>application cache</a> storage for
-            <var>C</var>.
-            </li>
             <li>Create a new empty storage for <a>session storage areas</a> and
             <a>local storage areas</a> for <var>C</var>.
             </li>
@@ -2842,11 +2839,11 @@
             with the <a>receiving browsing context</a> and the <a>browsing
             contexts</a> in its <a>list of descendant browsing contexts</a>,
             including <a>session history</a>, the <a>cookie store</a>, any
-            <a>HTTP authentication</a> state, the <a>application cache</a>, any
-            <a>databases</a>, the <a>session storage areas</a>, the <a>local
-            storage areas</a>, the list of registered <a>service worker
-            registrations</a> and the {{Cache}} objects MUST be discarded and
-            not used for any other <a>browsing context</a>.
+            <a>HTTP authentication</a> state, any <a>databases</a>, the
+            <a>session storage areas</a>, the <a>local storage areas</a>, the
+            list of registered <a>service worker registrations</a> and the
+            {{Cache}} objects MUST be discarded and not used for any other
+            <a>browsing context</a>.
           </p>
           <p class="note">
             This algorithm is intended to create a well defined environment to


### PR DESCRIPTION
The concept of "application cache" was completed removed from HTML 6 days ago:
https://github.com/whatwg/html/commit/e4330d510a1d05e1f5f84707c9d6dcec97db94b8

The notion of "a priori authenticated URL" was dropped in mixed content, and is to be replaced by "potentially trustworthy URL" in Secure Contexts.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/tidoust/presentation-api/pull/495.html" title="Last updated on Dec 7, 2020, 3:11 PM UTC (76afce7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/presentation-api/495/ffea4da...tidoust:76afce7.html" title="Last updated on Dec 7, 2020, 3:11 PM UTC (76afce7)">Diff</a>