### PR TITLE
Add a note about keep-alive mechanism at the app level

### DIFF
--- a/index.html
+++ b/index.html
@@ -1975,6 +1975,13 @@
               terminated and cannot be re-opened. No communication is possible.
             </li>
           </ul>
+          <div class="note">
+            A <a data-link-for="PresentationConnectionState">connected</a> state
+            does not mean that sending/receiving messages will always succeed as
+            the communication channel may be abruptly closed at any time.
+            Applications that wish to detect such situations as soon as possible
+            should implement their own keep-alive mechanism.
+          </div>
           <p>
             When the <dfn>close</dfn> method is called on a
             <a>PresentationConnection</a> <var>S</var>, the <a>user agent</a>


### PR DESCRIPTION
This adds a note next to the definitions of the different presentation connection states to alert developers that `connected` is not a live reading and that applications should implement their own keep-alive mechanism is they need more guarantees on the actual connection state.

Fixes #485.