### PR TITLE
Fix xref link to permission descriptor types

### DIFF
--- a/index.html
+++ b/index.html
@@ -2751,8 +2751,8 @@
             auxiliary navigation browsing context flag</a> on <var>C</var>.
             </li>
             <li>If the <a>receiving user agent</a> implements [[!PERMISSIONS]],
-            set the <a>permission state</a> of all <a>permission descriptor
-            types</a> for <var>C</var> to <code>"denied"</code>.
+            set the <a>permission state</a> of all [=powerful feature/permission
+            descriptor types=] for <var>C</var> to <code>"denied"</code>.
             </li>
             <li>Create a new empty <a>cookie store</a> for <var>C</var>.
             </li>


### PR DESCRIPTION
The definition in the Permissions spec now comes with a scope that must be specified for ReSpec to pick it up.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/presentation-api/pull/499.html" title="Last updated on Oct 6, 2021, 12:24 PM UTC (dcb1bb6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/presentation-api/499/7b90d61...dcb1bb6.html" title="Last updated on Oct 6, 2021, 12:24 PM UTC (dcb1bb6)">Diff</a>