### PR TITLE
Add the websockets spec to the list of xref sources

### DIFF
--- a/index.html
+++ b/index.html
@@ -76,7 +76,7 @@
         ],
         sotdAfterWGinfo: true,
         group: 'secondscreen',
-        xref: ['dom', 'fileapi', 'secure-contexts', 'html', 'url', 'webidl', 'webrtc'],
+        xref: ['dom', 'fileapi', 'secure-contexts', 'html', 'url', 'webidl', 'webrtc', 'websockets'],
         localBiblio: {
           DIAL: {
             title: 'DIscovery And Launch Protocol Specification',


### PR DESCRIPTION
The `BinaryType` type is defined in WebSockets and WebSockets is no longer part of the HTML spec.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/tidoust/presentation-api/pull/501.html" title="Last updated on Apr 14, 2022, 4:04 PM UTC (afeb098)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/presentation-api/501/395194c...tidoust:afeb098.html" title="Last updated on Apr 14, 2022, 4:04 PM UTC (afeb098)">Diff</a>