### PR TITLE
typo remove method

### DIFF
--- a/index.html
+++ b/index.html
@@ -592,7 +592,7 @@
   function setConnection(newConnection) {
     // Disconnect from existing presentation, if not attempting to reconnect
     if (connection &amp;&amp; connection != newConnection &amp;&amp; connection.state != 'closed') {
-      connection.onclosed = undefined;
+      connection.onclose = undefined;
       connection.close();
     }
 


### PR DESCRIPTION
This logic is remove method when reconnect.

Target method name is `onclose` .

```js
    connection.onclose = _ => {
      connection = null;
      showDisconnectedUI();
    };
```

But, this logic remove `onclosed` method.
```js
    // Disconnect from existing presentation, if not attempting to reconnect
    if (connection && connection != newConnection && connection.state != 'closed') {
      connection.onclosed = undefined;
      connection.close();
    }
```


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/youkinjoh/presentation-api/pull/508.html" title="Last updated on Dec 14, 2022, 2:37 AM UTC (96ae513)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/presentation-api/508/e142aef...youkinjoh:96ae513.html" title="Last updated on Dec 14, 2022, 2:37 AM UTC (96ae513)">Diff</a>