### PR TITLE
debug `EXAMPLE 7`

### DIFF
--- a/index.html
+++ b/index.html
@@ -681,10 +681,10 @@
         <pre class="example">
 &lt;!-- controller.html --&gt;
 &lt;script&gt;
-  connection.send("{string: '你好，世界!', lang: 'zh-CN'}");
-  connection.send("{string: 'こんにちは、世界!', lang: 'ja'}");
-  connection.send("{string: '안녕하세요, 세계!', lang: 'ko'}");
-  connection.send("{string: 'Hello, world!', lang: 'en-US'}");
+  connection.send('{"string": "你好，世界!", "lang": "zh-CN"}');
+  connection.send('{"string": "こんにちは、世界!", "lang": "ja"}');
+  connection.send('{"string": "안녕하세요, 세계!", "lang": "ko"}');
+  connection.send('{"string": "Hello, world!", "lang": "en-US"}');
 &lt;/script&gt;
 
 &lt;!-- presentation.html --&gt;
@@ -694,7 +694,7 @@
     var spanElt = document.createElement("SPAN");
     spanElt.lang = messageObj.lang;
     spanElt.textContent = messageObj.string;
-    document.appendChild(spanElt);
+    document.body.appendChild(spanElt);
   };
 &lt;/script&gt;
 </pre>


### PR DESCRIPTION
`{string: '你好，世界!', lang: 'zh-CN'}` is not parsable to JSON.

```js
// controller.html
connection.send("{string: '你好，世界!', lang: 'zh-CN'}");

// presentation.html
var messageObj = JSON.parse(message.data);
```

And, drop `body` property.

```js
document.appendChild(spanElt);
```


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/youkinjoh/presentation-api/pull/511.html" title="Last updated on Dec 26, 2022, 7:22 AM UTC (837c343)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/presentation-api/511/cb625d4...youkinjoh:837c343.html" title="Last updated on Dec 26, 2022, 7:22 AM UTC (837c343)">Diff</a>