### PR TITLE
Update now broken RFC links

### DIFF
--- a/index.html
+++ b/index.html
@@ -289,12 +289,12 @@
         context of {{Promise}} objects are used as defined in [[!ECMASCRIPT]].
       </p>
       <p>
-        The terms <dfn data-cite="rfc9110#section-12.5.4">Accept-Language</dfn>
-        and <dfn data-cite="rfc9110#section-11">HTTP authentication</dfn> are
+        The terms <dfn data-cite="rfc9110#field.accept-language">Accept-Language</dfn>
+        and <dfn data-cite="rfc9110#authentication">HTTP authentication</dfn> are
         used as defined in [[!RFC9110]].
       </p>
       <p>
-        The term <dfn data-cite="rfc6265#section-5.3">cookie store</dfn> is
+        The term <dfn data-cite="rfc6265#storage-model">cookie store</dfn> is
         used as defined in [[!RFC6265]].
       </p>
       <p>


### PR DESCRIPTION
ReSpec now references the `httpwg.org` versions of RFCs when they exist. Unfortunately, these versions use different fragment identifiers.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/presentation-api/pull/520.html" title="Last updated on Nov 24, 2023, 2:55 PM UTC (53e7ae6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/presentation-api/520/a128d1e...53e7ae6.html" title="Last updated on Nov 24, 2023, 2:55 PM UTC (53e7ae6)">Diff</a>