### PR TITLE
Fix task queueing.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1113,9 +1113,8 @@
               </ol>Then run the following steps:
               <ol>
                 <li>
-                  <a data-cite="!HTML#queue-a-global-task">Queue a global
-                  task</a> to <a>reject</a> <var>P</var> with a
-                  {{NotFoundError}} exception.
+                  <a>Queue a global task</a> to <a>reject</a> <var>P</var> with
+                  a {{NotFoundError}} exception.
                 </li>
                 <li>Abort all remaining steps.
                 </li>
@@ -1754,8 +1753,8 @@
                 <var>newAvailability</var> and skip the following step.
                 </li>
                 <li>If <var>previousAvailability</var> is not equal to
-                <var>newAvailability</var>, then <a>queue a task</a> to run the
-                following steps:
+                <var>newAvailability</var>, then <a>queue a global task</a> to
+                run the following steps:
                   <ol>
                     <li>Set <var>A</var>'s <a>value</a> property to
                     <var>newAvailability</var>.
@@ -2048,8 +2047,8 @@
             identifier</a> of <var>presentationConnection</var> MUST be sent
             with this request.
             </li>
-            <li>If connection completes successfully, <a>queue a task</a> to
-            run the following steps:
+            <li>If connection completes successfully, <a>queue a global
+            task</a> to run the following steps:
               <ol>
                 <li>Set the <a>presentation connection state</a> of
                 <var>presentationConnection</var> to <a data-link-for=
@@ -2466,7 +2465,7 @@
                 connection</var> is <a data-link-for=
                 "PresentationConnectionState">connected</a> or
                   <a data-link-for="PresentationConnectionState">connecting</a>,
-                  then <a>queue a task</a> to run the following steps:
+                  then <a>queue a global task</a> to run the following steps:
                   <ol>
                     <li>Set the <a>presentation connection state</a> of
                     <var>known connection</var> to <a data-link-for=
@@ -2548,8 +2547,8 @@
             the user interface and discard it.
             </li>
             <li>For each <var>connection</var> in
-            <var>connectedControllers</var>, <a>queue a task</a> to send a
-            termination confirmation for <var>P</var> using an implementation
+            <var>connectedControllers</var>, <a>queue a global task</a> to send
+            a termination confirmation for <var>P</var> using an implementation
             specific mechanism to the <a>controlling user agent</a> that owns
             the <a>destination browsing context</a> for <var>connection</var>.
               <p class="note">
@@ -2572,7 +2571,7 @@
           <ol>
             <li>For each <var>connection</var> in the <a>set of controlled
             presentations</a> that was connected to <var>P</var>, <a>queue a
-            task</a> to run the following steps:
+            global task</a> to run the following steps:
               <ol>
                 <li>If the <a>presentation connection state</a> of
                 <var>connection</var> is not <a data-link-for=

--- a/index.html
+++ b/index.html
@@ -2587,7 +2587,9 @@
           <ol>
             <li>For each <var>connection</var> in the <a>set of controlled
             presentations</a> that was connected to <var>P</var>, <a>queue a
-            Presentation API task</a> to run the following steps:
+            global task</a> on the <a>presentation task source</a> given <var>
+              connection</var>'s <a>relevant global object</a> to run the
+              following steps:
               <ol>
                 <li>If the <a>presentation connection state</a> of
                 <var>connection</var> is not <a data-link-for=

--- a/index.html
+++ b/index.html
@@ -49,7 +49,7 @@
         sotdAfterWGinfo: true,
         group: 'secondscreen',
         github: 'https://github.com/w3c/presentation-api',
-        xref: ['dom', 'fileapi', 'secure-contexts', 'html', 'url', 'webidl', 'webrtc', 'websockets'],
+        xref: ['dom', 'fileapi', 'secure-contexts', 'html', 'url', 'webidl', 'webrtc', 'websockets', 'infra'],
         localBiblio: {
           DIAL: {
             title: 'DIscovery And Launch Protocol Specification',
@@ -842,8 +842,8 @@
           When an algorithm <dfn data-lt="queue a Presentation API task">queues
           a Presentation API task</dfn> <var>T</var>, the <a>user agent</a>
           MUST <a>queue a global task</a> <var>T</var> on the <a>presentation
-          task source</a> using the <a data-cite="!HTML#global-object">global
-          object</a> of the <a>current realm</a>.
+          task source</a> using the <a>global object</a> of the <a>current
+          realm</a>.
         </p>
         <p>
           Unless otherwise specified, the <a>JavaScript realm</a> for script
@@ -1183,6 +1183,8 @@
             </dd>
           </dl>
           <ol>
+            <li>Run the following steps <a>in parallel</a>
+            </li>.
             <li>Let <var>presentationUrls</var> be the <a>presentation request
             URLs</a> of <var>presentationRequest</var>.
             </li>
@@ -1230,8 +1232,7 @@
           </dl>
           <ol>
             <li>
-              <a data-cite="!INFRA#assert">Assert</a>: this is running <a>in
-              parallel</a>.
+              <a>Assert</a>: this is running <a>in parallel</a>.
             </li>
             <li>Let <var>I</var> be a new <a>valid presentation identifier</a>
             unique among all <a>presentation identifiers</a> for known
@@ -1691,8 +1692,7 @@
           </p>
           <ol>
             <li>
-              <a data-cite="!INFRA#assert">Assert</a>: this is running <a>in
-              parallel</a>.
+              <a>Assert</a>: this is running <a>in parallel</a>.
             </li>
             <li>Let <var>availabilitySet</var> be a shallow copy of the <a>set
             of presentation availability objects</a>.
@@ -2046,8 +2046,7 @@
           </dl>
           <ol>
             <li>
-              <a data-cite="!INFRA#assert">Assert</a>: this is running <a>in
-              parallel</a>.
+              <a>Assert</a>: this is running <a>in parallel</a>.
             </li>
             <li>If the <a>presentation connection state</a> of
             <var>presentationConnection</var> is not <a data-link-for=
@@ -2059,8 +2058,8 @@
             identifier</a> of <var>presentationConnection</var> MUST be sent
             with this request.
             </li>
-            <li>If connection completes successfully, <a>queue a global
-            task</a> to run the following steps:
+            <li>If connection completes successfully, <a>queue a Presentation
+            API task</a> to run the following steps:
               <ol>
                 <li>Set the <a>presentation connection state</a> of
                 <var>presentationConnection</var> to <a data-link-for=
@@ -2216,8 +2215,7 @@
           </dl>
           <ol data-link-for="PresentationConnection">
             <li>
-              <a data-cite="!INFRA#assert">Assert</a>: this is running <a>in
-              parallel</a>.
+              <a>Assert</a>: this is running <a>in parallel</a>.
             </li>
             <li>If the <a>state</a> property of
             <var>presentationConnection</var> is not <a data-link-for=
@@ -2466,8 +2464,7 @@
           </p>
           <ol>
             <li>
-              <a data-cite="!INFRA#assert">Assert</a>: this is running <a>in
-              parallel</a>.
+              <a>Assert</a>: this is running <a>in parallel</a>.
             </li>
             <li>If the <a>presentation connection state</a> of
             <var>connection</var> is not <a data-link-for=
@@ -2500,9 +2497,9 @@
               </ol>
             </li>
             <li>
-              <dfn>Send a termination request</dfn> for the presentation to its
-              <a>receiving user agent</a> using an implementation specific
-              mechanism.
+              <a>In parallel</a>, <dfn>send a termination request</dfn> for the
+              presentation to its <a>receiving user agent</a> using an
+              implementation specific mechanism.
             </li>
           </ol>
         </section>
@@ -2917,8 +2914,7 @@
           </dl>
           <ol>
             <li>
-              <a data-cite="!INFRA#assert">Assert</a>: this is running <a>in
-              parallel</a>.
+              <a>Assert</a>: this is running <a>in parallel</a>.
             </li>
             <li>If <var>presentationId</var> and <var>I</var> are not equal,
             refuse the connection and abort all remaining steps.
@@ -2971,7 +2967,7 @@
                 the <a>set of presentation controllers</a>.
                 </li>
                 <li>
-                  <a>queue a Presentation API task</a> to [=fire an event=]
+                  <a>Queue a Presentation API task</a> to [=fire an event=]
                   named <a data-link-for=
                   "PresentationConnectionList">connectionavailable</a>, that
                   uses the <a>PresentationConnectionAvailableEvent</a>

--- a/index.html
+++ b/index.html
@@ -291,8 +291,9 @@
         context of {{Promise}} objects are used as defined in [[!ECMASCRIPT]].
       </p>
       <p>
-        The terms <dfn data-cite="rfc9110#field.accept-language">Accept-Language</dfn>
-        and <dfn data-cite="rfc9110#authentication">HTTP authentication</dfn> are
+        The terms <dfn data-cite=
+        "rfc9110#field.accept-language">Accept-Language</dfn> and
+        <dfn data-cite="rfc9110#authentication">HTTP authentication</dfn> are
         used as defined in [[!RFC9110]].
       </p>
       <p>
@@ -840,6 +841,10 @@
         <p>
           Unless otherwise specified, the <a>JavaScript realm</a> for script
           objects constructed by algorithm steps is the <a>current realm</a>.
+          Unless otherwise specified, all global tasks use the <a data-cite=
+          "!HTML#networking-task-source">networking task source</a> associated
+          with the <a data-cite="!HTML#global-object">global object</a> of the
+          <a>current realm</a>.
         </p>
       </section>
       <section>
@@ -1038,6 +1043,10 @@
             Selecting a presentation display
           </h4>
           <p>
+            The global tasks queued in these steps use the <a data-cite=
+            "!HTML#-interaction-task-source">user interaction task source</a>.
+          </p>
+          <p>
             When the <code><dfn data-dfn-for=
             "PresentationRequest">start</dfn></code> method is called, the
             <a>user agent</a> MUST run the following steps to <dfn>select a
@@ -1104,16 +1113,17 @@
               </ol>Then run the following steps:
               <ol>
                 <li>
-                  <a>Reject</a> <var>P</var> with a {{NotFoundError}}
-                  exception.
+                  <a data-cite="!HTML#queue-a-global-task">Queue a global
+                  task</a> to <a>reject</a> <var>P</var> with a
+                  {{NotFoundError}} exception.
                 </li>
                 <li>Abort all remaining steps.
                 </li>
               </ol>
             </li>
-            <li>If the user <em>denies permission</em> to use a display, reject
-            <var>P</var> with an {{NotAllowedError}} exception, and abort all
-            remaining steps.
+            <li>If the user <em>denies permission</em> to use a display,
+            <a>queue a global task</a> to reject <var>P</var> with an
+            {{NotAllowedError}} exception, and abort all remaining steps.
             </li>
             <li>Otherwise, the user <em>grants permission</em> to use a
             display; let <var>D</var> be that display.
@@ -1250,10 +1260,10 @@
             <var>S</var>.
             </li>
             <li>
-              <a>Queue a task</a> to [=fire an event=] named <a data-link-for=
-              "PresentationRequest">connectionavailable</a>, that uses the
-              <a>PresentationConnectionAvailableEvent</a> interface, with the
-              <a data-link-for=
+              <a>Queue a global task</a> to [=fire an event=] named
+              <a data-link-for="PresentationRequest">connectionavailable</a>,
+              that uses the <a>PresentationConnectionAvailableEvent</a>
+              interface, with the <a data-link-for=
               "PresentationConnectionAvailableEvent">connection</a> attribute
               initialized to <var>S</var>, at <var>presentationRequest</var>.
               The event must not bubble and must not be cancelable.
@@ -1341,8 +1351,8 @@
                 <a>PresentationConnection</a>.
                 </li>
                 <li>
-                  <a>Resolve</a> <var>P</var> with
-                  <var>existingConnection</var>.
+                  <a>Queue a global task</a> to <a>resolve</a> <var>P</var>
+                  with <var>existingConnection</var>.
                 </li>
                 <li>If the <a>presentation connection state</a> of
                 <var>existingConnection</var> is <a data-link-for=
@@ -1404,10 +1414,11 @@
                 presentations</a>.
                 </li>
                 <li>
-                  <a>Resolve</a> <var>P</var> with <var>newConnection</var>.
+                  <a>Queue a global task</a> to <a>resolve</a> <var>P</var>
+                  with <var>newConnection</var>.
                 </li>
                 <li>
-                  <a>Queue a task</a> to [=fire an event=] named
+                  <a>Queue a global task</a> to [=fire an event=] named
                   <a data-link-for=
                   "PresentationRequest">connectionavailable</a>, that uses the
                   <a>PresentationConnectionAvailableEvent</a> interface, with
@@ -1426,7 +1437,8 @@
               </ol>
             </li>
             <li>
-              <a>Reject</a> <var>P</var> with a {{NotFoundError}} exception.
+              <a>Queue a global task</a> to <a>reject</a> <var>P</var> with a
+              {{NotFoundError}} exception.
             </li>
           </ol>
         </section>
@@ -1620,8 +1632,8 @@
             then:
               <ol>
                 <li>
-                  <a>Reject</a> <var>P</var> with a {{NotSupportedError}}
-                  exception.
+                  <a>Queue a global task</a> to <a>reject</a> <var>P</var> with
+                  a {{NotSupportedError}} exception.
                 </li>
                 <li>Abort all the remaining steps.
                 </li>
@@ -1631,8 +1643,8 @@
             <var>presentationRequest</var> is not <code>null</code>, then:
               <ol>
                 <li>
-                  <a>Resolve</a> <var>P</var> with the request's
-                  <a>presentation display availability</a>.
+                  <a>Queue a global task</a> to <a>resolve</a> <var>P</var>
+                  with the request's <a>presentation display availability</a>.
                 </li>
                 <li>Abort all the remaining steps.
                 </li>
@@ -1657,7 +1669,8 @@
               </div>
             </li>
             <li>
-              <a>Resolve</a> <var>P</var> with <var>A</var>.
+              <a>Queue a global task</a> to <a>resolve</a> <var>P</var> with
+              <var>A</var>.
             </li>
           </ol>
         </section>
@@ -2220,8 +2233,8 @@
               </ol>
             </li>
             <li>
-              <a>Queue a task</a> to [=fire an event|fire=] <var>event</var> at
-              <var>presentationConnection</var>.
+              <a>Queue a global task</a> to [=fire an event|fire=]
+              <var>event</var> at <var>presentationConnection</var>.
             </li>
           </ol>
           <p>
@@ -2386,7 +2399,7 @@
             <var>presentationConnection</var>, then abort the remaining steps.
             </li>
             <li>
-              <a>Queue a task</a> to run the following steps:
+              <a>Queue a global task</a> to run the following steps:
               <ol>
                 <li>If the <a>presentation connection state</a> of
                 <var>presentationConnection</var> is not <a data-link-for=
@@ -2920,9 +2933,9 @@
                 the <a>set of presentation controllers</a>.
                 </li>
                 <li>If the <a>presentation controllers promise</a> is not
-                <code>null</code>, <a>resolve</a> the <a>presentation
-                controllers promise</a> with the <a>presentation controllers
-                monitor</a>.
+                <code>null</code>, <a>queue a global task</a> to <a>resolve</a>
+                the <a>presentation controllers promise</a> with the
+                <a>presentation controllers monitor</a>.
                 </li>
                 <li>Abort all remaining steps.
                 </li>
@@ -2934,7 +2947,7 @@
                 the <a>set of presentation controllers</a>.
                 </li>
                 <li>
-                  <a>Queue a task</a> to [=fire an event=] named
+                  <a>Queue a global task</a> to [=fire an event=] named
                   <a data-link-for=
                   "PresentationConnectionList">connectionavailable</a>, that
                   uses the <a>PresentationConnectionAvailableEvent</a>

--- a/index.html
+++ b/index.html
@@ -1183,8 +1183,8 @@
             </dd>
           </dl>
           <ol>
-            <li>Run the following steps <a>in parallel</a>
-            </li>.
+            <li>Run the following steps <a>in parallel</a>.
+            </li>
             <li>Let <var>presentationUrls</var> be the <a>presentation request
             URLs</a> of <var>presentationRequest</var>.
             </li>

--- a/index.html
+++ b/index.html
@@ -2463,9 +2463,6 @@
             MUST run the following steps:
           </p>
           <ol>
-            <li>
-              <a>Assert</a>: this is running <a>in parallel</a>.
-            </li>
             <li>If the <a>presentation connection state</a> of
             <var>connection</var> is not <a data-link-for=
             "PresentationConnectionState">connected</a> or <a data-link-for=
@@ -2482,8 +2479,9 @@
                 connection</var> is <a data-link-for=
                 "PresentationConnectionState">connected</a> or
                   <a data-link-for="PresentationConnectionState">connecting</a>,
-                  then <a>queue a Presentation API task</a> to run the
-                  following steps:
+                  then <a>queue a global task</a> on the <a>presentation task
+                  source</a> given <var>known connection</var>'s <a>relevant
+                  global object</a> to run the following steps:
                   <ol>
                     <li>Set the <a>presentation connection state</a> of
                     <var>known connection</var> to <a data-link-for=

--- a/index.html
+++ b/index.html
@@ -836,15 +836,18 @@
         </p>
         <p>
           The <a>task source</a> for the tasks mentioned in this specification
-          is the <var>presentation task source</var>.
+          is the <dfn>presentation task source</dfn>.
+        </p>
+        <p>
+          When an algorithm <dfn data-lt="queue a Presentation API task">queues
+          a Presentation API task</dfn> <var>T</var>, the <a>user agent</a>
+          MUST <a>queue a global task</a> <var>T</var> on the <a>presentation
+          task source</a> using the <a data-cite="!HTML#global-object">global
+          object</a> of the <a>current realm</a>.
         </p>
         <p>
           Unless otherwise specified, the <a>JavaScript realm</a> for script
           objects constructed by algorithm steps is the <a>current realm</a>.
-          Unless otherwise specified, all global tasks use the <a data-cite=
-          "!HTML#networking-task-source">networking task source</a> associated
-          with the <a data-cite="!HTML#global-object">global object</a> of the
-          <a>current realm</a>.
         </p>
       </section>
       <section>
@@ -1043,10 +1046,6 @@
             Selecting a presentation display
           </h4>
           <p>
-            The global tasks queued in these steps use the <a data-cite=
-            "!HTML#-interaction-task-source">user interaction task source</a>.
-          </p>
-          <p>
             When the <code><dfn data-dfn-for=
             "PresentationRequest">start</dfn></code> method is called, the
             <a>user agent</a> MUST run the following steps to <dfn>select a
@@ -1113,15 +1112,15 @@
               </ol>Then run the following steps:
               <ol>
                 <li>
-                  <a>Queue a global task</a> to <a>reject</a> <var>P</var> with
-                  a {{NotFoundError}} exception.
+                  <a>Queue a Presentation API task</a> to <a>reject</a>
+                  <var>P</var> with a {{NotFoundError}} exception.
                 </li>
                 <li>Abort all remaining steps.
                 </li>
               </ol>
             </li>
             <li>If the user <em>denies permission</em> to use a display,
-            <a>queue a global task</a> to reject <var>P</var> with an
+            <a>queue a Presentation API task</a> to reject <var>P</var> with an
             {{NotAllowedError}} exception, and abort all remaining steps.
             </li>
             <li>Otherwise, the user <em>grants permission</em> to use a
@@ -1230,6 +1229,10 @@
             </dd>
           </dl>
           <ol>
+            <li>
+              <a data-cite="!INFRA#assert">Assert</a>: this is running <a>in
+              parallel</a>.
+            </li>
             <li>Let <var>I</var> be a new <a>valid presentation identifier</a>
             unique among all <a>presentation identifiers</a> for known
             <a>presentation connections</a> in the <a>set of controlled
@@ -1255,11 +1258,11 @@
             </li>
             <li>Add <var>S</var> to the <a>set of controlled presentations</a>.
             </li>
-            <li>If <var>P</var> is provided, <a>resolve</a> <var>P</var> with
-            <var>S</var>.
+            <li>If <var>P</var> is provided, <a>queue a Presentation API
+            task</a> to <a>resolve</a> <var>P</var> with <var>S</var>.
             </li>
             <li>
-              <a>Queue a global task</a> to [=fire an event=] named
+              <a>Queue a Presentation API task</a> to [=fire an event=] named
               <a data-link-for="PresentationRequest">connectionavailable</a>,
               that uses the <a>PresentationConnectionAvailableEvent</a>
               interface, with the <a data-link-for=
@@ -1322,8 +1325,8 @@
           <ol>
             <li>Let <var>P</var> be a new {{Promise}}.
             </li>
-            <li>Return <var>P</var>, but continue running these steps in
-            parallel.
+            <li>Return <var>P</var>, but continue running these steps <a>in
+            parallel</a>.
             </li>
             <li>Search the <a>set of controlled presentations</a> for a
             <a>PresentationConnection</a> that meets the following criteria:
@@ -1350,8 +1353,8 @@
                 <a>PresentationConnection</a>.
                 </li>
                 <li>
-                  <a>Queue a global task</a> to <a>resolve</a> <var>P</var>
-                  with <var>existingConnection</var>.
+                  <a>Queue a Presentation API task</a> to <a>resolve</a>
+                  <var>P</var> with <var>existingConnection</var>.
                 </li>
                 <li>If the <a>presentation connection state</a> of
                 <var>existingConnection</var> is <a data-link-for=
@@ -1413,12 +1416,12 @@
                 presentations</a>.
                 </li>
                 <li>
-                  <a>Queue a global task</a> to <a>resolve</a> <var>P</var>
-                  with <var>newConnection</var>.
+                  <a>Queue a Presentation API task</a> to <a>resolve</a>
+                  <var>P</var> with <var>newConnection</var>.
                 </li>
                 <li>
-                  <a>Queue a global task</a> to [=fire an event=] named
-                  <a data-link-for=
+                  <a>Queue a Presentation API task</a> to [=fire an event=]
+                  named <a data-link-for=
                   "PresentationRequest">connectionavailable</a>, that uses the
                   <a>PresentationConnectionAvailableEvent</a> interface, with
                   the <a data-link-for=
@@ -1436,8 +1439,8 @@
               </ol>
             </li>
             <li>
-              <a>Queue a global task</a> to <a>reject</a> <var>P</var> with a
-              {{NotFoundError}} exception.
+              <a>Queue a Presentation API task</a> to <a>reject</a>
+              <var>P</var> with a {{NotFoundError}} exception.
             </li>
           </ol>
         </section>
@@ -1631,8 +1634,8 @@
             then:
               <ol>
                 <li>
-                  <a>Queue a global task</a> to <a>reject</a> <var>P</var> with
-                  a {{NotSupportedError}} exception.
+                  <a>Queue a Presentation API task</a> to <a>reject</a>
+                  <var>P</var> with a {{NotSupportedError}} exception.
                 </li>
                 <li>Abort all the remaining steps.
                 </li>
@@ -1642,8 +1645,9 @@
             <var>presentationRequest</var> is not <code>null</code>, then:
               <ol>
                 <li>
-                  <a>Queue a global task</a> to <a>resolve</a> <var>P</var>
-                  with the request's <a>presentation display availability</a>.
+                  <a>Queue a Presentation API task</a> to <a>resolve</a>
+                  <var>P</var> with the request's <a>presentation display
+                  availability</a>.
                 </li>
                 <li>Abort all the remaining steps.
                 </li>
@@ -1668,8 +1672,8 @@
               </div>
             </li>
             <li>
-              <a>Queue a global task</a> to <a>resolve</a> <var>P</var> with
-              <var>A</var>.
+              <a>Queue a Presentation API task</a> to <a>resolve</a>
+              <var>P</var> with <var>A</var>.
             </li>
           </ol>
         </section>
@@ -1686,6 +1690,10 @@
             steps:
           </p>
           <ol>
+            <li>
+              <a data-cite="!INFRA#assert">Assert</a>: this is running <a>in
+              parallel</a>.
+            </li>
             <li>Let <var>availabilitySet</var> be a shallow copy of the <a>set
             of presentation availability objects</a>.
             </li>
@@ -1753,8 +1761,8 @@
                 <var>newAvailability</var> and skip the following step.
                 </li>
                 <li>If <var>previousAvailability</var> is not equal to
-                <var>newAvailability</var>, then <a>queue a global task</a> to
-                run the following steps:
+                <var>newAvailability</var>, then <a>queue a Presentation API
+                task</a> to run the following steps:
                   <ol>
                     <li>Set <var>A</var>'s <a>value</a> property to
                     <var>newAvailability</var>.
@@ -2037,6 +2045,10 @@
             </dd>
           </dl>
           <ol>
+            <li>
+              <a data-cite="!INFRA#assert">Assert</a>: this is running <a>in
+              parallel</a>.
+            </li>
             <li>If the <a>presentation connection state</a> of
             <var>presentationConnection</var> is not <a data-link-for=
             "PresentationConnectionState">connecting</a>, then abort all
@@ -2203,6 +2215,10 @@
             </dd>
           </dl>
           <ol data-link-for="PresentationConnection">
+            <li>
+              <a data-cite="!INFRA#assert">Assert</a>: this is running <a>in
+              parallel</a>.
+            </li>
             <li>If the <a>state</a> property of
             <var>presentationConnection</var> is not <a data-link-for=
             "PresentationConnectionState">connected</a>, abort these steps.
@@ -2232,7 +2248,7 @@
               </ol>
             </li>
             <li>
-              <a>Queue a global task</a> to [=fire an event|fire=]
+              <a>Queue a Presentation API task</a> to [=fire an event|fire=]
               <var>event</var> at <var>presentationConnection</var>.
             </li>
           </ol>
@@ -2398,7 +2414,7 @@
             <var>presentationConnection</var>, then abort the remaining steps.
             </li>
             <li>
-              <a>Queue a global task</a> to run the following steps:
+              <a>Queue a Presentation API task</a> to run the following steps:
               <ol>
                 <li>If the <a>presentation connection state</a> of
                 <var>presentationConnection</var> is not <a data-link-for=
@@ -2449,6 +2465,10 @@
             MUST run the following steps:
           </p>
           <ol>
+            <li>
+              <a data-cite="!INFRA#assert">Assert</a>: this is running <a>in
+              parallel</a>.
+            </li>
             <li>If the <a>presentation connection state</a> of
             <var>connection</var> is not <a data-link-for=
             "PresentationConnectionState">connected</a> or <a data-link-for=
@@ -2465,7 +2485,8 @@
                 connection</var> is <a data-link-for=
                 "PresentationConnectionState">connected</a> or
                   <a data-link-for="PresentationConnectionState">connecting</a>,
-                  then <a>queue a global task</a> to run the following steps:
+                  then <a>queue a Presentation API task</a> to run the
+                  following steps:
                   <ol>
                     <li>Set the <a>presentation connection state</a> of
                     <var>known connection</var> to <a data-link-for=
@@ -2547,10 +2568,10 @@
             the user interface and discard it.
             </li>
             <li>For each <var>connection</var> in
-            <var>connectedControllers</var>, <a>queue a global task</a> to send
-            a termination confirmation for <var>P</var> using an implementation
-            specific mechanism to the <a>controlling user agent</a> that owns
-            the <a>destination browsing context</a> for <var>connection</var>.
+            <var>connectedControllers</var>, send a termination confirmation
+            for <var>P</var> using an implementation specific mechanism to the
+            <a>controlling user agent</a> that owns the <a>destination browsing
+            context</a> for <var>connection</var>.
               <p class="note">
                 Only one termination confirmation needs to be sent per
                 <a>controlling user agent</a>.
@@ -2571,7 +2592,7 @@
           <ol>
             <li>For each <var>connection</var> in the <a>set of controlled
             presentations</a> that was connected to <var>P</var>, <a>queue a
-            global task</a> to run the following steps:
+            Presentation API task</a> to run the following steps:
               <ol>
                 <li>If the <a>presentation connection state</a> of
                 <var>connection</var> is not <a data-link-for=
@@ -2895,6 +2916,10 @@
             </dd>
           </dl>
           <ol>
+            <li>
+              <a data-cite="!INFRA#assert">Assert</a>: this is running <a>in
+              parallel</a>.
+            </li>
             <li>If <var>presentationId</var> and <var>I</var> are not equal,
             refuse the connection and abort all remaining steps.
             </li>
@@ -2932,9 +2957,9 @@
                 the <a>set of presentation controllers</a>.
                 </li>
                 <li>If the <a>presentation controllers promise</a> is not
-                <code>null</code>, <a>queue a global task</a> to <a>resolve</a>
-                the <a>presentation controllers promise</a> with the
-                <a>presentation controllers monitor</a>.
+                <code>null</code>, <a>queue a Presentation API task</a> to <a>
+                  resolve</a> the <a>presentation controllers promise</a> with
+                  the <a>presentation controllers monitor</a>.
                 </li>
                 <li>Abort all remaining steps.
                 </li>
@@ -2946,8 +2971,8 @@
                 the <a>set of presentation controllers</a>.
                 </li>
                 <li>
-                  <a>Queue a global task</a> to [=fire an event=] named
-                  <a data-link-for=
+                  <a>queue a Presentation API task</a> to [=fire an event=]
+                  named <a data-link-for=
                   "PresentationConnectionList">connectionavailable</a>, that
                   uses the <a>PresentationConnectionAvailableEvent</a>
                   interface, with the <a data-link-for=


### PR DESCRIPTION
Addresses Issue #523 by specifically queuing a global task when promises are resolved or events are fired from parallel steps.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/presentation-api/pull/524.html" title="Last updated on Sep 19, 2024, 6:31 PM UTC (0fb1088)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/presentation-api/524/74d1a41...0fb1088.html" title="Last updated on Sep 19, 2024, 6:31 PM UTC (0fb1088)">Diff</a>