### PR TITLE
Always return a new Promise from getAvailability().

### DIFF
--- a/index.html
+++ b/index.html
@@ -995,7 +995,7 @@
               Output
             </dt>
             <dd>
-              A <a>PresentationRequest</a> object
+              A new <a>PresentationRequest</a> object
             </dd>
           </dl>
           <ol>
@@ -1064,7 +1064,7 @@
               Output
             </dt>
             <dd>
-              A {{Promise}}
+              A new {{Promise}}
             </dd>
           </dl>
           <ol>
@@ -1320,7 +1320,7 @@
               Output
             </dt>
             <dd>
-              <var>P</var>, a {{Promise}}
+              <var>P</var>, a new {{Promise}}
             </dd>
           </dl>
           <ol>
@@ -1618,8 +1618,8 @@
             </dd>
           </dl>
           <ol>
-            <li>Otherwise, let <var>P</var> be a new {{Promise}} constructed in
-            the <a>JavaScript realm</a> of <var>presentationRequest</var>.
+            <li>Let <var>P</var> be a new {{Promise}} constructed in the
+            <a>JavaScript realm</a> of <var>presentationRequest</var>.
             </li>
             <li>Return <var>P</var>, but continue running these steps <a>in
             parallel</a>.

--- a/index.html
+++ b/index.html
@@ -291,8 +291,9 @@
         context of {{Promise}} objects are used as defined in [[!ECMASCRIPT]].
       </p>
       <p>
-        The terms <dfn data-cite="rfc9110#field.accept-language">Accept-Language</dfn>
-        and <dfn data-cite="rfc9110#authentication">HTTP authentication</dfn> are
+        The terms <dfn data-cite=
+        "rfc9110#field.accept-language">Accept-Language</dfn> and
+        <dfn data-cite="rfc9110#authentication">HTTP authentication</dfn> are
         used as defined in [[!RFC9110]].
       </p>
       <p>
@@ -1599,15 +1600,10 @@
               Output
             </dt>
             <dd>
-              A {{Promise}}
+              A new {{Promise}}
             </dd>
           </dl>
           <ol>
-            <li>If there is an unsettled {{Promise}} from a previous call to
-            <a data-link-for="PresentationRequest">getAvailability</a> on <var>
-              presentationRequest</var>, return that {{Promise}} and abort
-              these steps.
-            </li>
             <li>Otherwise, let <var>P</var> be a new {{Promise}} constructed in
             the <a>JavaScript realm</a> of <var>presentationRequest</var>.
             </li>


### PR DESCRIPTION
Closes Issue #507 by always returning a new Promise from `PresentationRequest.getAvailability()`.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/presentation-api/pull/525.html" title="Last updated on Oct 7, 2024, 5:33 PM UTC (4e6d7e3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/presentation-api/525/214830c...4e6d7e3.html" title="Last updated on Oct 7, 2024, 5:33 PM UTC (4e6d7e3)">Diff</a>